### PR TITLE
remove empty additional properties section in docs

### DIFF
--- a/doc_templates/slot.md.jinja2
+++ b/doc_templates/slot.md.jinja2
@@ -42,8 +42,6 @@ URI: {{ gen.uri_link(element) }}
 
 ## Properties
 
-## Properties
-
 * Range: {{gen.link(element.range)}}
 {%- if element.multivalued %}
 * Multivalued: {{ element.multivalued }}


### PR DESCRIPTION
Remove additional empty `Properties` section link coming up on term pages.