### PR TITLE
GitHub Action for autopublishing documentation

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,31 @@
+name: Auto-deployment of MIxS Documentation
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@main
+      with:
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+    
+    - name: Set up Python 3.
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+
+    - name: Install Poetry.
+      uses: snok/install-poetry@v1.3
+
+    - name: Install dependencies.
+      run: poetry install -E docs
+    
+    - name: Build documentation.
+      run: |
+        mkdir -p docs
+        touch docs/.nojekyll
+        make generated/docs/introduction/background.md
+        make gh_docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ mkdocs-material = "^8.3.5"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.extras]
+docs = ["linkml", "mkdocs-material"]


### PR DESCRIPTION
This action has been added to the repo as a workaround for a long standing issue on the LinkML repo: https://github.com/linkml/linkml/issues/632

Every time a branch is merged into main, this Action runs which automatically builds and publishes new documentation t GitHub pages.

CC: @hrshdhgd