### PR TITLE
Make links in schema text/content clickable

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ plugins:
   - mermaid2
 markdown_extensions:
   - tables
+  - pymdownx.magiclink
 extra_javascript:
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
   - javascripts/tablesort.js


### PR DESCRIPTION
The links that appear in schema element descriptions, etc. will now be clickable.

Fixes #682 