### PR TITLE
Enable `prebuild_index` option using mkdocs

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -39,4 +39,5 @@ jobs:
           touch docs/.nojekyll
           make gendoc
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
+          mkdocs build --clean
           make mkd-gh-deploy

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -24,6 +24,15 @@ jobs:
       - name: Install dependencies.
         run: poetry install -E docs
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14' # Choose the desired Node.js version
+
+      - name: Add Node.js to the system path
+        run: |
+          echo 'export PATH=$HOME/.npm-global/bin:$PATH' >> $GITHUB_ENV
+
       - name: Build documentation.
         run: |
           mkdir -p docs
@@ -31,5 +40,3 @@ jobs:
           make gendoc
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
           make mkd-gh-deploy
-
-...

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -39,5 +39,5 @@ jobs:
           touch docs/.nojekyll
           make gendoc
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
-          mkdocs build --clean
+          poetry run mkdocs build --clean
           make mkd-gh-deploy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
 plugins:
   - search:
       separator: '[\s\-\:\(\)]+'
+      prebuild_index: true
   - mermaid2
 markdown_extensions:
   - tables


### PR DESCRIPTION
This PR seeks to enable the `prebuild_index` option in mkdocs by setting up `node.js` using GitHub Actions which is necessary for mkdocs to generate a pre-built index of all files.

Fixes #695 