### PR TITLE
deprecate tot_nitro slot

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -14360,29 +14360,6 @@ slots:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
-  tot_nitro:
-    annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter, milligram per liter
-    description: 'Total nitrogen concentration of water samples, calculated by: total
-      nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured
-      without filtering, reported as nitrogen'
-    title: total nitrogen concentration
-    examples:
-      - value: 50 micromole per liter
-    keywords:
-      - concentration
-      - nitrogen
-      - total
-    slot_uri: MIXS:0000102
-    range: string
-    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
-    structured_pattern:
-      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
-      interpolated: true
-      partial_match: true
   tot_nitro_cont_meth:
     description: Reference or method used in determining the total nitrogen
     title: total nitrogen content method

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -19101,7 +19101,8 @@ classes:
       - nitrate
       - nitrite
       - ammonium
-      - tot_nitro
+      - tot_nitro_content
+      - tot_nitro_cont_meth
       - diss_iron
       - sodium
       - chloride
@@ -19229,7 +19230,8 @@ classes:
       - nitrate
       - nitrite
       - ammonium
-      - tot_nitro
+      - tot_nitro_content
+      - tot_nitro_cont_meth
       - diss_iron
       - sodium
       - chloride

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -19364,6 +19364,7 @@ classes:
       - temp
       - tot_carb
       - tot_nitro_content
+      - tot_nitro_cont_meth
       - tot_org_carb
       - turbidity
       - water_content
@@ -19721,6 +19722,7 @@ classes:
       - tot_carb
       - tot_depth_water_col
       - tot_nitro_content
+      - tot_nitro_cont_meth
       - tot_org_carb
       - turbidity
       - water_content
@@ -20055,7 +20057,8 @@ classes:
       - suspend_solids
       - temp
       - tertiary_treatment
-      - tot_nitro
+      - tot_nitro_content
+      - tot_nitro_cont_meth
       - tot_phosphate
       - wastewater_type
     slot_usage:
@@ -20162,7 +20165,8 @@ classes:
       - tot_depth_water_col
       - tot_diss_nitro
       - tot_inorg_nitro
-      - tot_nitro
+      - tot_nitro_content
+      - tot_nitro_cont_meth
       - tot_part_carb
       - tot_phosp
       - turbidity


### PR DESCRIPTION
Fixes #680

`tot_nitro` = 
Total nitrogen concentration of water samples, calculated by: total nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured without filtering, reported as nitrogen
domain_of:
- HydrocarbonResourcesCores
- HydrocarbonResourcesFluidsSwabs
- WastewaterSludge
- Water

`tot_nitro_content` = 
Total nitrogen content of the sample
domain_of:
- Agriculture
- FoodFarmEnvironment
- MicrobialMatBiofilm
- Sediment
- Soil

`tot_nitro` & `tot_nitro_content` are the same, with the exception that `tot_nitro` is [water](https://genomicsstandardsconsortium.github.io/mixs/0000102/) specific in its description

In this PR,
- [ ] marked `tot_nitro` for deprecation
- [ ] changed anywhere `tot_nitro` it used to now use `tot_nitro_content`
  - HydrocarbonResourcesFluidsSwabs
  - Water
  - WastewaterSludge
  - HydrocarbonResourcesCores