### PR TITLE
scripted fix; manual dense forms

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -1,17 +1,17 @@
 name: mixs
 comments:
-  - 'slot titles that are associated with more than one slot name/SCN: host sex'
+- 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
 version: v6.2.0
+imports:
+- linkml:types
 prefixes:
   linkml: https://w3id.org/linkml/
   MIXS: https://w3id.org/mixs/
   xsd: http://www.w3.org/2001/XMLSchema#
   shex: http://www.w3.org/ns/shex#
   schema: http://schema.org/
-imports:
-  - linkml:types
 default_prefix: MIXS
 default_range: string
 subsets:
@@ -1135,7 +1135,7 @@ slots:
     description: Data that comply with Extension Air
     title: Air data
     keywords:
-      - air
+    - air
     domain: MixsCompliantData
     slot_uri: MIXS:air_data
     multivalued: true
@@ -1443,7 +1443,7 @@ slots:
     description: Data that comply with Extension Sediment
     title: Sediment data
     keywords:
-      - sediment
+    - sediment
     domain: MixsCompliantData
     slot_uri: MIXS:sediment_data
     multivalued: true
@@ -1463,7 +1463,7 @@ slots:
     description: Data that comply with Extension Soil
     title: Soil data
     keywords:
-      - soil
+    - soil
     domain: MixsCompliantData
     slot_uri: MIXS:soil_data
     multivalued: true
@@ -1519,7 +1519,7 @@ slots:
     description: Data that comply with Extension Water
     title: Water data
     keywords:
-      - water
+    - water
     domain: MixsCompliantData
     slot_uri: MIXS:water_data
     multivalued: true
@@ -3700,10 +3700,10 @@ slots:
       This field accepts terms listed under HACCP guide food safety term (http://purl.obolibrary.org/obo/FOODON_03530221)
     title: Hazard Analysis Critical Control Points (HACCP) guide food safety term
     examples:
-      - value: tetrodotoxic poisoning [FOODON:03530249]
+    - value: tetrodotoxic poisoning [FOODON:03530249]
     keywords:
-      - food
-      - term
+    - food
+    - term
     slot_uri: MIXS:0001215
     multivalued: true
     range: string
@@ -3714,9 +3714,7 @@ slots:
       partial_match: true
   IFSAC_category:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: IFSAC term
+      Expected_value: IFSAC term
     description: 'The IFSAC food categorization scheme has five distinct levels to
       which foods can be assigned, depending upon the type of food. First, foods are
       assigned to one of four food groups (aquatic animals, land animals, plants,
@@ -3731,27 +3729,25 @@ slots:
       PMID: 28926300'
     title: Interagency Food Safety Analytics Collaboration (IFSAC) category
     examples:
-      - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
+    - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
     keywords:
-      - food
+    - food
     string_serialization: '{text}'
     slot_uri: MIXS:0001179
     multivalued: true
     required: true
   abs_air_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per gram, kilogram per kilogram, kilogram, pound
+      Preferred_unit: gram per gram, kilogram per kilogram, kilogram, pound
     description: Actual mass of water vapor - mh20 - present in the air water vapor
       mixture
     title: absolute air humidity
     examples:
-      - value: 9 gram per gram
+    - value: 9 gram per gram
     keywords:
-      - absolute
-      - air
-      - humidity
+    - absolute
+    - air
+    - humidity
     slot_uri: MIXS:0000122
     range: string
     required: true
@@ -3763,37 +3759,33 @@ slots:
       partial_match: true
   adapters:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: adapter A and B sequence
+      Expected_value: adapter A and B sequence
     description: Adapters provide priming sequences for both amplification and sequencing
       of the sample-library fragments. Both adapters should be reported; in uppercase
       letters
     title: adapters
     examples:
-      - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
+    - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
     in_subset:
-      - sequencing
+    - sequencing
     string_serialization: '{dna};{dna}'
     slot_uri: MIXS:0000048
   add_recov_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;timestamp
+      Expected_value: enumeration;timestamp
     description: Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed
       for increase of hydrocarbon recovery from resource and start date for each one
       of them. If "other" is specified, please propose entry in "additional info"
       field
     title: secondary and tertiary recovery methods and start date
     examples:
-      - value: Polymer Addition;2018-06-21T14:30Z
+    - value: Polymer Addition;2018-06-21T14:30Z
     keywords:
-      - date
-      - method
-      - recover
-      - secondary
-      - start
+    - date
+    - method
+    - recover
+    - secondary
+    - start
     string_serialization: '[Water Injection|Dump Flood|Gas Injection|Wag Immiscible
       Injection|Polymer Addition|Surfactant Addition|Not Applicable|other];{timestamp}'
     slot_uri: MIXS:0001009
@@ -3803,14 +3795,12 @@ slots:
       new entries for fields with controlled vocabulary
     title: additional info
     keywords:
-      - information
+    - information
     slot_uri: MIXS:0000300
     range: string
   address:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: value
+      Expected_value: value
     description: The street name and building number where the sampling occurred
     title: address
     string_serialization: '{integer}{text}'
@@ -3820,8 +3810,8 @@ slots:
       sampling room
     title: adjacent rooms
     keywords:
-      - adjacent
-      - room
+    - adjacent
+    - room
     slot_uri: MIXS:0000219
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -3831,20 +3821,18 @@ slots:
       partial_match: true
   adjacent_environment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO_01001110 or ENVO_00000070
+      Expected_value: ENVO_01001110 or ENVO_00000070
     description: Description of the environmental system or features that are adjacent
       to the sampling site. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110)
       and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple
       terms can be separated by pipes
     title: environment adjacent to site
     examples:
-      - value: estuarine biome [ENVO:01000020]
+    - value: estuarine biome [ENVO:01000020]
     keywords:
-      - adjacent
-      - environment
-      - site
+    - adjacent
+    - environment
+    - site
     string_serialization: '{termLabel}{[termID]}'
     slot_uri: MIXS:0001121
     multivalued: true
@@ -3854,70 +3842,60 @@ slots:
       such as welds, rivets, screws and bolts to hold the components together
     title: aerospace structure
     examples:
-      - value: plane
+    - value: plane
     slot_uri: MIXS:0000773
     range: AeroStrucEnum
   agrochem_addition:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: agrochemical name;agrochemical amount;timestamp
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Expected_value: agrochemical name;agrochemical amount;timestamp
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Addition of fertilizers, pesticides, etc. - amount and time of applications
     title: history/agrochemical additions
     examples:
-      - value: roundup;5 milligram per liter;2018-06-21
+    - value: roundup;5 milligram per liter;2018-06-21
     keywords:
-      - history
+    - history
     string_serialization: '{text};{float} {unit};{timestamp}'
     slot_uri: MIXS:0000639
     multivalued: true
   air_PM_concen:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: particulate matter name;measurement value
+      Expected_value: particulate matter name;measurement value
     description: Concentration of substances that remain suspended in the air, and
       comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can
       report multiple PM's by entering numeric values preceded by name of PM
     title: air particulate matter concentration
     examples:
-      - value: PM2.5;10 microgram per cubic meter
+    - value: PM2.5;10 microgram per cubic meter
     keywords:
-      - air
-      - concentration
-      - particle
-      - particulate
+    - air
+    - concentration
+    - particle
+    - particulate
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000108
     multivalued: true
   air_flow_impede:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;obstruction type; distance from sampling device
+      Expected_value: enumeration;obstruction type; distance from sampling device
     description: Presence of objects in the area that would influence or impede air
       flow through the air filter
     title: local air flow impediments
     examples:
-      - value: obstructed;hay bales; 2 m
+    - value: obstructed;hay bales; 2 m
     keywords:
-      - air
+    - air
     string_serialization: '[obstructed|unobstructed]; {text}; {measurement value}'
     slot_uri: MIXS:0001146
     multivalued: true
   air_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of the air at the time of sampling
     title: air temperature
     keywords:
-      - air
-      - temperature
+    - air
+    - temperature
     slot_uri: MIXS:0000124
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -3928,38 +3906,32 @@ slots:
       partial_match: true
   air_temp_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: temperature value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: temperature value;treatment interval and duration
+      Preferred_unit: meter
     description: Information about treatment involving an exposure to varying temperatures;
       should include the temperature, treatment regimen including how many times the
       treatment was repeated, how long each treatment lasted, and the start and end
       time of the entire treatment; can include different temperature regimens
     title: air temperature regimen
     examples:
-      - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - air
-      - regimen
-      - temperature
+    - air
+    - regimen
+    - temperature
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000551
     multivalued: true
   al_sat:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Aluminum saturation (esp. For tropical soils)
     title: extreme_unusual_properties/Al saturation
     keywords:
-      - extreme
-      - properties
-      - saturation
-      - unusual
+    - extreme
+    - properties
+    - saturation
+    - unusual
     slot_uri: MIXS:0000607
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -3972,11 +3944,11 @@ slots:
     description: Reference or method used in determining Al saturation
     title: extreme_unusual_properties/Al saturation method
     keywords:
-      - extreme
-      - method
-      - properties
-      - saturation
-      - unusual
+    - extreme
+    - method
+    - properties
+    - saturation
+    - unusual
     slot_uri: MIXS:0000324
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -3986,16 +3958,14 @@ slots:
       partial_match: true
   alkalinity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliequivalent per liter, milligram per liter
+      Preferred_unit: milliequivalent per liter, milligram per liter
     description: Alkalinity, the ability of a solution to neutralize acids to the
       equivalence point of carbonate or bicarbonate
     title: alkalinity
     examples:
-      - value: 50 milligram per liter
+    - value: 50 milligram per liter
     keywords:
-      - alkalinity
+    - alkalinity
     slot_uri: MIXS:0000421
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4008,17 +3978,17 @@ slots:
     description: Method used for alkalinity measurement
     title: alkalinity method
     examples:
-      - value: titration
+    - value: titration
     keywords:
-      - alkalinity
-      - method
+    - alkalinity
+    - method
     slot_uri: MIXS:0000298
     range: string
   alkyl_diethers:
     description: Concentration of alkyl diethers
     title: alkyl diethers
     examples:
-      - value: 0.005 mole per liter
+    - value: 0.005 mole per liter
     slot_uri: MIXS:0000490
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4029,9 +3999,7 @@ slots:
       partial_match: true
   alt:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Heights of objects such as airplanes, space shuttles, rockets, atmospheric
       balloons and heights of places such as atmospheric layers and clouds. It is
       used to measure the height of an object which is above the earth's surface.
@@ -4039,9 +4007,9 @@ slots:
       earth's surface above sea level and the sampled position in the air
     title: altitude
     examples:
-      - value: 100 meter
+    - value: 100 meter
     in_subset:
-      - environment
+    - environment
     slot_uri: MIXS:0000094
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4052,13 +4020,11 @@ slots:
       partial_match: true
   aminopept_act:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mole per liter per hour
+      Preferred_unit: mole per liter per hour
     description: Measurement of aminopeptidase activity
     title: aminopeptidase activity
     examples:
-      - value: 0.269 mole per liter per hour
+    - value: 0.269 mole per liter per hour
     slot_uri: MIXS:0000172
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4069,13 +4035,11 @@ slots:
       partial_match: true
   ammonium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of ammonium in the sample
     title: ammonium
     examples:
-      - value: 1.5 milligram per liter
+    - value: 1.5 milligram per liter
     slot_uri: MIXS:0000427
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4091,14 +4055,12 @@ slots:
     range: string
   amount_light:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: lux, lumens per square meter
+      Preferred_unit: lux, lumens per square meter
     description: The unit of illuminance and luminous emittance, measuring luminous
       flux per unit area
     title: amount of light
     keywords:
-      - light
+    - light
     slot_uri: MIXS:0000140
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4113,7 +4075,7 @@ slots:
       (meaning [(A x B) x B] x B)
     title: ancestral data
     examples:
-      - value: A/3*B
+    - value: A/3*B
     slot_uri: MIXS:0000247
     range: string
   anim_water_method:
@@ -4122,12 +4084,12 @@ slots:
       Multiple terms can be separated by pipes
     title: animal water delivery method
     examples:
-      - value: water trough [EOL:0001618]
+    - value: water trough [EOL:0001618]
     keywords:
-      - animal
-      - delivery
-      - method
-      - water
+    - animal
+    - delivery
+    - method
+    - water
     slot_uri: MIXS:0001115
     multivalued: true
     range: string
@@ -4141,29 +4103,27 @@ slots:
       food animal within the last 30 days
     title: food animal antimicrobial
     examples:
-      - value: tetracycline
+    - value: tetracycline
     keywords:
-      - animal
-      - antimicrobial
-      - food
+    - animal
+    - antimicrobial
+    - food
     slot_uri: MIXS:0001243
     range: string
   animal_am_dur:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: value
+      Expected_value: value
     description: The duration of time (days) that the antimicrobial was administered
       to the food animal
     title: food animal antimicrobial duration
     examples:
-      - value: 3 days
+    - value: 3 days
     keywords:
-      - animal
-      - antimicrobial
-      - duration
-      - food
-      - period
+    - animal
+    - antimicrobial
+    - duration
+    - food
+    - period
     string_serialization: '{float} {day}'
     slot_uri: MIXS:0001244
   animal_am_freq:
@@ -4171,12 +4131,12 @@ slots:
       food animal
     title: food animal antimicrobial frequency
     examples:
-      - value: '1.5'
+    - value: '1.5'
     keywords:
-      - animal
-      - antimicrobial
-      - food
-      - frequency
+    - animal
+    - antimicrobial
+    - food
+    - frequency
     slot_uri: MIXS:0001245
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4190,13 +4150,13 @@ slots:
       of the food animal
     title: food animal antimicrobial route of administration
     examples:
-      - value: oral-feed
+    - value: oral-feed
     keywords:
-      - administration
-      - animal
-      - antimicrobial
-      - food
-      - route
+    - administration
+    - animal
+    - antimicrobial
+    - food
+    - route
     slot_uri: MIXS:0001246
     range: string
   animal_am_use:
@@ -4204,12 +4164,12 @@ slots:
       given to the food animal by any route of administration
     title: food animal antimicrobial intended use
     examples:
-      - value: shipping fever
+    - value: shipping fever
     keywords:
-      - animal
-      - antimicrobial
-      - food
-      - use
+    - animal
+    - antimicrobial
+    - food
+    - use
     slot_uri: MIXS:0001247
     range: string
   animal_body_cond:
@@ -4218,19 +4178,17 @@ slots:
       scoring systems, this field is restricted to three categories
     title: food animal body condition
     examples:
-      - value: under conditioned
+    - value: under conditioned
     keywords:
-      - animal
-      - body
-      - condition
-      - food
+    - animal
+    - body
+    - condition
+    - food
     slot_uri: MIXS:0001248
     range: AnimalBodyCondEnum
   animal_diet:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or FOODON_03309997
+      Expected_value: text or FOODON_03309997
     description: If the isolate is from a food animal, the type of diet eaten by the
       food animal.  Please list the main food staple and the setting, if appropriate.  For
       a list of acceptable animal feed terms or categories, please see http://www.feedipedia.org.  Multiple
@@ -4241,29 +4199,27 @@ slots:
       is not listed please use text to describe the food product type
     title: food animal source diet
     examples:
-      - value: Hay [FOODON:03301763]
+    - value: Hay [FOODON:03301763]
     keywords:
-      - animal
-      - diet
-      - food
-      - source
+    - animal
+    - diet
+    - food
+    - source
     string_serialization: '{text}'
     slot_uri: MIXS:0001130
     multivalued: true
   animal_feed_equip:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: EOL:0001757
+      Expected_value: EOL:0001757
     description: Description of the feeding equipment used for livestock. This field
       accepts terms listed under feed delivery (http://opendata.inra.fr/EOL/EOL_0001757).
       Multiple terms can be separated by pipes
     title: animal feeding equipment
     examples:
-      - value: self feeding [EOL:0001645]| straight feed trough [EOL:0001661]
+    - value: self feeding [EOL:0001645]| straight feed trough [EOL:0001661]
     keywords:
-      - animal
-      - equipment
+    - animal
+    - equipment
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001113
     multivalued: true
@@ -4272,11 +4228,11 @@ slots:
       together as a unit, i.e. a herd or flock
     title: food animal group size
     examples:
-      - value: '80'
+    - value: '80'
     keywords:
-      - animal
-      - food
-      - size
+    - animal
+    - food
+    - size
     slot_uri: MIXS:0001129
     range: integer
   animal_housing:
@@ -4284,9 +4240,9 @@ slots:
       terms listed under terrestrial management housing system (http://opendata.inra.fr/EOL/EOL_0001605)
     title: animal housing system
     examples:
-      - value: pen rearing system [EOL:0001636]
+    - value: pen rearing system [EOL:0001636]
     keywords:
-      - animal
+    - animal
     slot_uri: MIXS:0001180
     multivalued: true
     range: string
@@ -4304,11 +4260,11 @@ slots:
       can be separated by pipes
     title: animal intrusion near sample source
     examples:
-      - value: Thripidae [NCBITaxon:45053]
+    - value: Thripidae [NCBITaxon:45053]
     keywords:
-      - animal
-      - sample
-      - source
+    - animal
+    - sample
+    - source
     slot_uri: MIXS:0001114
     multivalued: true
     range: string
@@ -4321,38 +4277,34 @@ slots:
     description: The sex and reproductive status of the food animal
     title: food animal source sex category
     examples:
-      - value: castrated male
+    - value: castrated male
     keywords:
-      - animal
-      - food
-      - source
+    - animal
+    - food
+    - source
     slot_uri: MIXS:0001249
     range: AnimalSexEnum
   annot:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name of tool or pipeline used, or annotation source description
+      Expected_value: name of tool or pipeline used, or annotation source description
     description: Tool used for annotation, or for cases where annotation was provided
       by a community jamboree or model organism database rather than by a specific
       submitter
     title: annotation
     examples:
-      - value: prokka
+    - value: prokka
     in_subset:
-      - sequencing
+    - sequencing
     string_serialization: '{text}'
     slot_uri: MIXS:0000059
   annual_precpt:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter
+      Preferred_unit: millimeter
     description: The average of all annual precipitation values known, or an estimated
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean annual precipitation
     keywords:
-      - mean
+    - mean
     slot_uri: MIXS:0000644
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4363,16 +4315,14 @@ slots:
       partial_match: true
   annual_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Mean annual temperature
     title: mean annual temperature
     examples:
-      - value: 12.5 degree Celsius
+    - value: 12.5 degree Celsius
     keywords:
-      - mean
-      - temperature
+    - mean
+    - temperature
     slot_uri: MIXS:0000642
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4383,12 +4333,8 @@ slots:
       partial_match: true
   antibiotic_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: antibiotic name;antibiotic amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram
+      Expected_value: antibiotic name;antibiotic amount;treatment interval and duration
+      Preferred_unit: milligram
     description: Information about treatment involving antibiotic administration;
       should include the name of antibiotic, amount administered, treatment regimen
       including how many times the treatment was repeated, how long each treatment
@@ -4396,23 +4342,21 @@ slots:
       antibiotic regimens
     title: antibiotic regimen
     examples:
-      - value: penicillin;5 milligram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: penicillin;5 milligram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
+    - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000553
     multivalued: true
   api:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degrees API
+      Preferred_unit: degrees API
     description: 'API gravity is a measure of how heavy or light a petroleum liquid
       is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g.
       31.1   API)'
     title: API gravity
     examples:
-      - value: 31.1 API
+    - value: 31.1 API
     slot_uri: MIXS:0000157
     range: string
     required: true
@@ -4427,33 +4371,27 @@ slots:
       outdoor construction
     title: architectural structure
     examples:
-      - value: shed
+    - value: shed
     slot_uri: MIXS:0000774
     range: ArchStrucEnum
   area_samp_size:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter
+      Expected_value: measurement value
+      Preferred_unit: centimeter
     description: The total amount or size (volume (ml), mass (g) or area (m2) ) of
       sample collected
     title: area sampled size
     examples:
-      - value: 12 centimeter x 12 centimeter
+    - value: 12 centimeter x 12 centimeter
     keywords:
-      - area
-      - sample
-      - size
+    - area
+    - sample
+    - size
     string_serialization: '{integer} {unit} x {integer} {unit}'
     slot_uri: MIXS:0001255
   aromatics_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
@@ -4470,9 +4408,7 @@ slots:
       partial_match: true
   asphaltenes_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
@@ -4489,23 +4425,19 @@ slots:
       partial_match: true
   assembly_name:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name and version of assembly
+      Expected_value: name and version of assembly
     description: Name/version of the assembly provided by the submitter that is used
       in the genome browsers and in the community
     title: assembly name
     examples:
-      - value: HuRef, JCVI_ISG_i3_1.0
+    - value: HuRef, JCVI_ISG_i3_1.0
     in_subset:
-      - sequencing
+    - sequencing
     string_serialization: '{text} {text}'
     slot_uri: MIXS:0000057
   assembly_qual:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: 'The assembly quality category is based on sets of criteria outlined
       for each assembly quality category. For MISAG/MIMAG; Finished: Single, validated,
       contiguous sequence per replicon without gaps or ambiguities with a consensus
@@ -4525,11 +4457,11 @@ slots:
       which no genome size could be estimated'
     title: assembly quality
     examples:
-      - value: High-quality draft genome
+    - value: High-quality draft genome
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - quality
+    - quality
     string_serialization: '[Finished genome|High-quality draft genome|Medium-quality
       draft genome|Low-quality draft genome|Genome fragment(s)]'
     slot_uri: MIXS:0000056
@@ -4537,11 +4469,11 @@ slots:
     description: Tool(s) used for assembly, including version number and parameters
     title: assembly software
     examples:
-      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
+    - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     slot_uri: MIXS:0000058
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -4551,35 +4483,31 @@ slots:
       partial_match: true
   associated_resource:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: reference to resource
+      Expected_value: reference to resource
     description: A related resource that is referenced, cited, or otherwise associated
       to the sequence
     title: relevant electronic resources
     examples:
-      - value: http://www.earthmicrobiome.org/
+    - value: http://www.earthmicrobiome.org/
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - resource
+    - resource
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000091
     multivalued: true
     recommended: true
   association_duration:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: year, day, hour
+      Preferred_unit: year, day, hour
     description: Time spent in host of the symbiotic organism at the time of sampling;
       relevant scale depends on symbiotic organism and study
     title: duration of association with the host
     keywords:
-      - duration
-      - host
-      - host.
-      - period
+    - duration
+    - host
+    - host.
+    - period
     slot_uri: MIXS:0001299
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4590,28 +4518,24 @@ slots:
       partial_match: true
   atmospheric_data:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: atmospheric data name;measurement value
+      Expected_value: atmospheric data name;measurement value
     description: Measurement of atmospheric data; can include multiple data
     title: atmospheric data
     examples:
-      - value: wind speed;9 knots
+    - value: wind speed;9 knots
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0001097
     multivalued: true
   avg_dew_point:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The average of dew point measures taken at the beginning of every
       hour over a 24 hour period on the sampling day
     title: average dew point
     examples:
-      - value: 25.5 degree Celsius
+    - value: 25.5 degree Celsius
     keywords:
-      - average
+    - average
     slot_uri: MIXS:0000141
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4625,22 +4549,20 @@ slots:
       daily occupying the sampling room
     title: average daily occupancy
     keywords:
-      - average
+    - average
     slot_uri: MIXS:0000775
     range: float
   avg_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The average of temperatures taken at the beginning of every hour
       over a 24 hour period on the sampling day
     title: average temperature
     examples:
-      - value: 12.5 degree Celsius
+    - value: 12.5 degree Celsius
     keywords:
-      - average
-      - temperature
+    - average
+    - temperature
     slot_uri: MIXS:0000142
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4651,15 +4573,13 @@ slots:
       partial_match: true
   bac_prod:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter per day
+      Preferred_unit: milligram per cubic meter per day
     description: Bacterial production in the water column measured by isotope uptake
     title: bacterial production
     examples:
-      - value: 5 milligram per cubic meter per day
+    - value: 5 milligram per cubic meter per day
     keywords:
-      - production
+    - production
     slot_uri: MIXS:0000683
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4670,13 +4590,11 @@ slots:
       partial_match: true
   bac_resp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter per day, micromole oxygen per liter per hour
+      Preferred_unit: milligram per cubic meter per day, micromole oxygen per liter per hour
     description: Measurement of bacterial respiration in the water column
     title: bacterial respiration
     examples:
-      - value: 300 micromole oxygen per liter per hour
+    - value: 300 micromole oxygen per liter per hour
     slot_uri: MIXS:0000684
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4689,10 +4607,10 @@ slots:
     description: Measurement of bacterial carbon production
     title: bacterial carbon production
     examples:
-      - value: 2.53 microgram per liter per hour
+    - value: 2.53 microgram per liter per hour
     keywords:
-      - carbon
-      - production
+    - carbon
+    - production
     slot_uri: MIXS:0000173
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4703,16 +4621,14 @@ slots:
       partial_match: true
   bacterial_density:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: colony forming units per milliliter; colony forming units per gram
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram
           of dry weight
     description: Number of bacteria in sample, as defined by bacteria density (http://purl.obolibrary.org/obo/GENEPIO_0000043)
     title: bacteria density
     examples:
-      - value: 10 colony forming units per gram dry weight
+    - value: 10 colony forming units per gram dry weight
     keywords:
-      - density
+    - density
     slot_uri: MIXS:0001194
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4723,16 +4639,14 @@ slots:
       partial_match: true
   barometric_press:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millibar
+      Preferred_unit: millibar
     description: Force per unit area exerted against a surface by the weight of air
       above that surface
     title: barometric pressure
     examples:
-      - value: 5 millibar
+    - value: 5 millibar
     keywords:
-      - pressure
+    - pressure
     slot_uri: MIXS:0000096
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4745,7 +4659,7 @@ slots:
     description: Name of the basin (e.g. Campos)
     title: basin name
     examples:
-      - value: Campos
+    - value: Campos
     slot_uri: MIXS:0000290
     range: string
     required: true
@@ -4753,25 +4667,23 @@ slots:
     description: The number of bathrooms in the building
     title: bathroom count
     examples:
-      - value: '1'
+    - value: '1'
     keywords:
-      - count
+    - count
     slot_uri: MIXS:0000776
     range: integer
   bedroom_count:
     description: The number of bedrooms in the building
     title: bedroom count
     examples:
-      - value: '2'
+    - value: '2'
     keywords:
-      - count
+    - count
     slot_uri: MIXS:0000777
     range: integer
   benzene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of benzene in the sample
     title: benzene
     slot_uri: MIXS:0000153
@@ -4788,43 +4700,39 @@ slots:
       from metagenomic datasets
     title: binning parameters
     examples:
-      - value: coverage
-        description: was 'coverage and kmer'
-      - value: kmer
-        description: was coverage and kmer
+    - value: coverage
+      description: was 'coverage and kmer'
+    - value: kmer
+      description: was coverage and kmer
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - parameter
+    - parameter
     slot_uri: MIXS:0000077
     range: BinParamEnum
   bin_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names and versions of software(s) used
+      Expected_value: names and versions of software(s) used
     description: Tool(s) used for the extraction of genomes from metagenomic datasets,
       where possible include a product ID (PID) of the tool(s) used
     title: binning software
     examples:
-      - value: MetaCluster-TA (RRID:SCR_004599), MaxBin (biotools:maxbin)
+    - value: MetaCluster-TA (RRID:SCR_004599), MaxBin (biotools:maxbin)
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     string_serialization: '{software};{version}{PID}'
     slot_uri: MIXS:0000078
   biochem_oxygen_dem:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Amount of dissolved oxygen needed by aerobic biological organisms
       in a body of water to break down organic material present in a given water sample
       at certain temperature over a specific time period
     title: biochemical oxygen demand
     keywords:
-      - oxygen
+    - oxygen
     slot_uri: MIXS:0000653
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4835,42 +4743,34 @@ slots:
       partial_match: true
   biocide:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name;name;timestamp
+      Expected_value: name;name;timestamp
     description: List of biocides (commercial name of product and supplier) and date
       of administration
     title: biocide administration
     examples:
-      - value: ALPHA 1427;Baker Hughes;2008-01-23
+    - value: ALPHA 1427;Baker Hughes;2008-01-23
     keywords:
-      - administration
+    - administration
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001011
     recommended: true
   biocide_admin_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;frequency;duration;duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: measurement value;frequency;duration;duration
+      Preferred_unit: milligram per liter
     description: Method of biocide administration (dose, frequency, duration, time
       elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr; 3
       days)
     title: biocide administration method
     keywords:
-      - administration
-      - method
+    - administration
+    - method
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration}'
     slot_uri: MIXS:0000456
     recommended: true
   biocide_used:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: commercial name of biocide, active ingredient in biocide or class of
+      Expected_value: commercial name of biocide, active ingredient in biocide or class of
           biocide
     description: Substance intended for preventing, neutralizing, destroying, repelling,
       or mitigating the effects of any pest or microorganism; that inhibits the growth,
@@ -4880,39 +4780,33 @@ slots:
       where the sample was taken. Multiple terms can be separated by pipes
     title: biocide
     examples:
-      - value: Quaternary ammonium compound|SterBac
+    - value: Quaternary ammonium compound|SterBac
     string_serialization: '{text}'
     slot_uri: MIXS:0001258
     multivalued: true
   biol_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The level of genome modification
     title: biological status
     examples:
-      - value: natural
+    - value: natural
     keywords:
-      - status
+    - status
     string_serialization: '[wild|natural|semi-natural|inbred line|breeder''s line|hybrid|clonal
       selection|mutant]'
     slot_uri: MIXS:0000858
   biomass:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: biomass type;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ton, kilogram, gram
+      Expected_value: biomass type;measurement value
+      Preferred_unit: ton, kilogram, gram
     description: Amount of biomass; should include the name for the part of biomass
       measured, e.g. Microbial, total. Can include multiple measurements
     title: biomass
     examples:
-      - value: total;20 gram
+    - value: total;20 gram
     keywords:
-      - biomass
+    - biomass
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000174
     multivalued: true
@@ -4921,9 +4815,9 @@ slots:
       as bacteria, viruses or fungi
     title: biotic regimen
     examples:
-      - value: sample inoculated with Rhizobium spp. Culture
+    - value: sample inoculated with Rhizobium spp. Culture
     keywords:
-      - regimen
+    - regimen
     slot_uri: MIXS:0001038
     multivalued: true
     range: string
@@ -4934,32 +4828,28 @@ slots:
       organism(s) is the object
     title: observed biotic relationship
     examples:
-      - value: free living
+    - value: free living
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - observed
-      - relationship
+    - observed
+    - relationship
     slot_uri: MIXS:0000028
     range: BioticRelationshipEnum
   birth_control:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: medication name
+      Expected_value: medication name
     description: Specification of birth control medication used
     title: birth control
     string_serialization: '{text}'
     slot_uri: MIXS:0000286
   bishomohopanol:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, microgram per gram
+      Preferred_unit: microgram per liter, microgram per gram
     description: Concentration of bishomohopanol
     title: bishomohopanol
     examples:
-      - value: 14 microgram per liter
+    - value: 14 microgram per liter
     slot_uri: MIXS:0000175
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4974,21 +4864,19 @@ slots:
       hematopoietic system disease (https://disease-ontology.org/?id=DOID:74)
     title: blood/blood disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000271
     multivalued: true
     range: string
   blood_press_diast:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter mercury
+      Preferred_unit: millimeter mercury
     description: Resting diastolic blood pressure, measured as mm mercury
     title: host blood pressure diastolic
     keywords:
-      - host
-      - host.
-      - pressure
+    - host
+    - host.
+    - pressure
     slot_uri: MIXS:0000258
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4999,15 +4887,13 @@ slots:
       partial_match: true
   blood_press_syst:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter mercury
+      Preferred_unit: millimeter mercury
     description: Resting systolic blood pressure, measured as mm mercury
     title: host blood pressure systolic
     keywords:
-      - host
-      - host.
-      - pressure
+    - host
+    - host.
+    - pressure
     slot_uri: MIXS:0000259
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5018,13 +4904,11 @@ slots:
       partial_match: true
   bromide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: parts per million
+      Preferred_unit: parts per million
     description: Concentration of bromide
     title: bromide
     examples:
-      - value: 0.05 parts per million
+    - value: 0.05 parts per million
     slot_uri: MIXS:0000176
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5037,9 +4921,9 @@ slots:
     description: The building design, construction and operation documents
     title: design, construction, and operation documents
     examples:
-      - value: maintenance plans
+    - value: maintenance plans
     keywords:
-      - documents
+    - documents
     slot_uri: MIXS:0000787
     range: BuildDocsEnum
   build_occup_type:
@@ -5047,9 +4931,9 @@ slots:
       is intended to be used
     title: building occupancy type
     examples:
-      - value: market
+    - value: market
     keywords:
-      - type
+    - type
     slot_uri: MIXS:0000761
     multivalued: true
     range: BuildOccupTypeEnum
@@ -5058,21 +4942,19 @@ slots:
     description: A location (geography) where a building is set
     title: building setting
     examples:
-      - value: rural
+    - value: rural
     slot_uri: MIXS:0000768
     range: BuildingSettingEnum
     required: true
   built_struc_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: year
+      Preferred_unit: year
     description: The age of the built structure since construction
     title: built structure age
     examples:
-      - value: 15 years
+    - value: 15 years
     keywords:
-      - age
+    - age
     slot_uri: MIXS:0000145
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5086,7 +4968,7 @@ slots:
       or low human density
     title: built structure setting
     examples:
-      - value: rural
+    - value: rural
     slot_uri: MIXS:0000778
     range: BuiltStrucSetEnum
   built_struc_type:
@@ -5094,18 +4976,16 @@ slots:
       to form a system capable of supporting loads
     title: built structure type
     keywords:
-      - type
+    - type
     slot_uri: MIXS:0000721
     range: string
   calcium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, micromole per liter, parts per million
+      Preferred_unit: milligram per liter, micromole per liter, parts per million
     description: Concentration of calcium in the sample
     title: calcium
     examples:
-      - value: 0.2 micromole per liter
+    - value: 0.2 micromole per liter
     slot_uri: MIXS:0000432
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5116,15 +4996,13 @@ slots:
       partial_match: true
   carb_dioxide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, parts per million
+      Preferred_unit: micromole per liter, parts per million
     description: Carbon dioxide (gas) amount or concentration at the time of sampling
     title: carbon dioxide
     examples:
-      - value: 410 parts per million
+    - value: 410 parts per million
     keywords:
-      - carbon
+    - carbon
     slot_uri: MIXS:0000097
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5135,15 +5013,13 @@ slots:
       partial_match: true
   carb_monoxide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, parts per million
+      Preferred_unit: micromole per liter, parts per million
     description: Carbon monoxide (gas) amount or concentration at the time of sampling
     title: carbon monoxide
     examples:
-      - value: 0.1 parts per million
+    - value: 0.1 parts per million
     keywords:
-      - carbon
+    - carbon
     slot_uri: MIXS:0000098
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5154,32 +5030,28 @@ slots:
       partial_match: true
   carb_nitro_ratio:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
+      Expected_value: measurement value
     description: Ratio of amount or concentrations of carbon to nitrogen
     title: carbon/nitrogen ratio
     examples:
-      - value: '0.417361111'
+    - value: '0.417361111'
     keywords:
-      - carbon
-      - nitrogen
-      - ratio
+    - carbon
+    - nitrogen
+    - ratio
     string_serialization: '{float}:{float}'
     slot_uri: MIXS:0000310
     range: float
   ceil_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The area of the ceiling space within the room
     title: ceiling area
     examples:
-      - value: 25 square meter
+    - value: 25 square meter
     keywords:
-      - area
-      - ceiling
+    - area
+    - ceiling
     slot_uri: MIXS:0000148
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5193,54 +5065,52 @@ slots:
       or video preferred; use drawings to indicate location of damaged areas
     title: ceiling condition
     examples:
-      - value: damaged
+    - value: damaged
     keywords:
-      - ceiling
-      - condition
+    - ceiling
+    - condition
     slot_uri: MIXS:0000779
     range: DamagedEnum
   ceil_finish_mat:
     description: The type of material used to finish a ceiling
     title: ceiling finish material
     examples:
-      - value: stucco
+    - value: stucco
     keywords:
-      - ceiling
-      - material
+    - ceiling
+    - material
     slot_uri: MIXS:0000780
     range: CeilFinishMatEnum
   ceil_struc:
     description: The construction format of the ceiling
     title: ceiling structure
     examples:
-      - value: concrete
+    - value: concrete
     keywords:
-      - ceiling
+    - ceiling
     slot_uri: MIXS:0000782
     range: CeilStrucEnum
   ceil_texture:
     description: The feel, appearance, or consistency of a ceiling surface
     title: ceiling texture
     examples:
-      - value: popcorn
+    - value: popcorn
     keywords:
-      - ceiling
-      - texture
+    - ceiling
+    - texture
     slot_uri: MIXS:0000783
     range: CeilingWallTextureEnum
   ceil_thermal_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: joule per degree Celsius
+      Preferred_unit: joule per degree Celsius
     description: The ability of the ceiling to provide inertia against temperature
       fluctuations. Generally this means concrete that is exposed. A metal deck that
       supports a concrete slab will act thermally as long as it is exposed to room
       air flow
     title: ceiling thermal mass
     keywords:
-      - ceiling
-      - mass
+    - ceiling
+    - mass
     slot_uri: MIXS:0000143
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5253,67 +5123,59 @@ slots:
     description: The type of ceiling according to the ceiling's appearance or construction
     title: ceiling type
     examples:
-      - value: coffered
+    - value: coffered
     keywords:
-      - ceiling
-      - type
+    - ceiling
+    - type
     slot_uri: MIXS:0000784
     range: CeilTypeEnum
   ceil_water_mold:
     description: Signs of the presence of mold or mildew on the ceiling
     title: ceiling signs of water/mold
     examples:
-      - value: presence of mold visible
+    - value: presence of mold visible
     keywords:
-      - ceiling
+    - ceiling
     slot_uri: MIXS:0000781
     range: MoldVisibilityEnum
   chem_administration:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: CHEBI;timestamp
+      Expected_value: CHEBI;timestamp
     description: List of chemical compounds administered to the host or site where
       sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can
       include multiple compounds. For chemical entities of biological interest ontology
       (chebi) (v 163), http://purl.bioontology.org/ontology/chebi
     title: chemical administration
     examples:
-      - value: agar [CHEBI:2509];2018-05-11T20:00Z
+    - value: agar [CHEBI:2509];2018-05-11T20:00Z
     keywords:
-      - administration
+    - administration
     string_serialization: '{termLabel} [{termID}];{timestamp}'
     slot_uri: MIXS:0000751
     multivalued: true
   chem_mutagen:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: mutagen name;mutagen amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: mutagen name;mutagen amount;treatment interval and duration
+      Preferred_unit: milligram per liter
     description: Treatment involving use of mutagens; should include the name of mutagen,
       amount administered, treatment regimen including how many times the treatment
       was repeated, how long each treatment lasted, and the start and end time of
       the entire treatment; can include multiple mutagen regimens
     title: chemical mutagen
     examples:
-      - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000555
     multivalued: true
   chem_oxygen_dem:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: A measure of the capacity of water to consume oxygen during the decomposition
       of organic matter and the oxidation of inorganic chemicals such as ammonia and
       nitrite
     title: chemical oxygen demand
     keywords:
-      - oxygen
+    - oxygen
     slot_uri: MIXS:0000656
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5324,26 +5186,20 @@ slots:
       partial_match: true
   chem_treat_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;frequency;duration;duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: measurement value;frequency;duration;duration
+      Preferred_unit: milligram per liter
     description: Method of chemical administration(dose, frequency, duration, time
       elapsed between administration and sampling) (e.g. 50 mg/l; twice a week; 1
       hr; 0 days)
     title: chemical treatment method
     keywords:
-      - method
-      - treatment
+    - method
+    - treatment
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration};{duration}'
     slot_uri: MIXS:0000457
   chem_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name;name;timestamp
+      Expected_value: name;name;timestamp
     description: List of chemical compounds administered upstream the sampling location
       where sampling occurred (e.g. Glycols, H2S scavenger, corrosion and scale inhibitors,
       demulsifiers, and other production chemicals etc.). The commercial name of the
@@ -5351,9 +5207,9 @@ slots:
       should also be included
     title: chemical treatment
     examples:
-      - value: ACCENT 1125;DOW;2010-11-17
+    - value: ACCENT 1125;DOW;2010-11-17
     keywords:
-      - treatment
+    - treatment
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001012
   chimera_check:
@@ -5362,11 +5218,11 @@ slots:
       of two or more phylogenetically distinct parent sequences
     title: chimera check software
     examples:
-      - value: uchime;v4.1;default parameters
+    - value: uchime;v4.1;default parameters
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     slot_uri: MIXS:0000052
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -5376,13 +5232,11 @@ slots:
       partial_match: true
   chloride:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of chloride in the sample
     title: chloride
     examples:
-      - value: 5000 milligram per liter
+    - value: 5000 milligram per liter
     slot_uri: MIXS:0000429
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5393,13 +5247,11 @@ slots:
       partial_match: true
   chlorophyll:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter, microgram per liter
+      Preferred_unit: milligram per cubic meter, microgram per liter
     description: Concentration of chlorophyll
     title: chlorophyll
     examples:
-      - value: 5 milligram per cubic meter
+    - value: 5 milligram per cubic meter
     slot_uri: MIXS:0000177
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5415,17 +5267,15 @@ slots:
       climates
     title: climate environment
     examples:
-      - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - environment
+    - environment
     slot_uri: MIXS:0001040
     multivalued: true
     range: string
   coll_site_geo_feat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:00000002 or ENVO:00000070
+      Expected_value: ENVO:00000002 or ENVO:00000070
     description: 'Text or terms that describe the geographic feature where the food
       sample was obtained by the researcher. This field accepts selected terms listed
       under the following ontologies: anthropogenic geographic feature (http://purl.obolibrary.org/obo/ENVO_00000002),
@@ -5434,11 +5284,11 @@ slots:
       or human construction (http://purl.obolibrary.org/obo/ENVO_00000070)'
     title: collection site geographic feature
     examples:
-      - value: farm [ENVO:00000078]
+    - value: farm [ENVO:00000078]
     keywords:
-      - feature
-      - geographic
-      - site
+    - feature
+    - geographic
+    - site
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001183
     required: true
@@ -5449,37 +5299,33 @@ slots:
       2008-01-23; 2008-01; 2008; Except: 2008-01; 2008 all are ISO8601 compliant'
     title: collection date
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     in_subset:
-      - environment
+    - environment
     keywords:
-      - date
+    - date
     slot_uri: MIXS:0000011
     range: datetime
     required: true
   compl_appr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text
+      Expected_value: text
     description: The approach used to determine the completeness of a given genomic
       assembly, which would typically make use of a set of conserved marker genes
       or a closely related reference genome. For UViG completeness, include reference
       genome or group used, and contig feature suggesting a complete genome
     title: completeness approach
     examples:
-      - value: other
-        description: was other <colon> UViG length compared to the average length of
-          reference genomes from the P22virus genus (NCBI RefSeq v83)
+    - value: other
+      description: was other <colon> UViG length compared to the average length of
+        reference genomes from the P22virus genus (NCBI RefSeq v83)
     in_subset:
-      - sequencing
+    - sequencing
     slot_uri: MIXS:0000071
     range: ComplApprEnum
   compl_score:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: quality;percent completeness
+      Expected_value: quality;percent completeness
     description: 'Completeness score is typically based on either the fraction of
       markers found as compared to a database or the percent of a genome found as
       compared to a closely related reference genome. High Quality Draft: >90%, Medium
@@ -5487,37 +5333,33 @@ slots:
       completeness scores'
     title: completeness score
     examples:
-      - value: med;60%
+    - value: med;60%
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - score
+    - score
     string_serialization: '[high|med|low];{percentage}'
     slot_uri: MIXS:0000069
   compl_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names and versions of software(s) used
+      Expected_value: names and versions of software(s) used
     description: Tools used for completion estimate, i.e. checkm, anvi'o, busco
     title: completeness software
     examples:
-      - value: checkm
+    - value: checkm
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     string_serialization: '{software};{version}'
     slot_uri: MIXS:0000070
   conduc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliSiemens per centimeter
+      Preferred_unit: milliSiemens per centimeter
     description: Electrical conductivity of water
     title: conductivity
     examples:
-      - value: 10 milliSiemens per centimeter
+    - value: 10 milliSiemens per centimeter
     slot_uri: MIXS:0000692
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5528,20 +5370,18 @@ slots:
       partial_match: true
   cons_food_stor_dur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours or days
+      Preferred_unit: hours or days
     description: The storage duration of the food commodity by the consumer, prior
       to onset of illness or sample collection.  Indicate the timepoint written in
       ISO 8601 format
     title: food stored by consumer (storage duration)
     examples:
-      - value: P5D
+    - value: P5D
     keywords:
-      - consumer
-      - duration)
-      - food
-      - storage
+    - consumer
+    - duration)
+    - food
+    - storage
     slot_uri: MIXS:0001195
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -5551,40 +5391,36 @@ slots:
       partial_match: true
   cons_food_stor_temp:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Expected_value: text or measurement value
+      Preferred_unit: degree Celsius
     description: Temperature at which food commodity was stored by the consumer, prior
       to onset of illness or sample collection
     title: food stored by consumer (storage temperature)
     examples:
-      - value: 4 degree Celsius
+    - value: 4 degree Celsius
     keywords:
-      - consumer
-      - food
-      - storage
-      - temperature
+    - consumer
+    - food
+    - storage
+    - temperature
     string_serialization: '{float} {unit}|{text}'
     slot_uri: MIXS:0001196
   cons_purch_date:
     description: The date a food product was purchased by consumer
     title: purchase date
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     keywords:
-      - date
+    - date
     slot_uri: MIXS:0001197
     range: datetime
   cons_qty_purchased:
     description: The quantity of food purchased by consumer
     title: quantity purchased
     examples:
-      - value: 5 cans
+    - value: 5 cans
     keywords:
-      - quantity
+    - quantity
     slot_uri: MIXS:0001198
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -5600,71 +5436,65 @@ slots:
       deposited into any of the public databases'
     title: contamination score
     examples:
-      - value: '0.01'
+    - value: '0.01'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - score
+    - score
     slot_uri: MIXS:0000072
     range: float
   contam_screen_input:
     description: The type of sequence data used as input
     title: contamination screening input
     examples:
-      - value: contigs
+    - value: contigs
     in_subset:
-      - sequencing
+    - sequencing
     slot_uri: MIXS:0000005
     range: ContamScreenInputEnum
   contam_screen_param:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;value or name
+      Expected_value: enumeration;value or name
     description: Specific parameters used in the decontamination sofware, such as
       reference database, coverage, and kmers. Combinations of these parameters may
       also be used, i.e. kmer and coverage, or reference database and kmer
     title: contamination screening parameters
     examples:
-      - value: kmer
+    - value: kmer
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - parameter
+    - parameter
     string_serialization: '[ref db|kmer|coverage|combination];{text|integer}'
     slot_uri: MIXS:0000073
   cool_syst_id:
     description: The cooling system identifier
     title: cooling system identifier
     examples:
-      - value: '12345'
+    - value: '12345'
     keywords:
-      - identifier
+    - identifier
     slot_uri: MIXS:0000785
     range: integer
   crop_rotation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: crop rotation status;schedule
+      Expected_value: crop rotation status;schedule
     description: Whether or not crop is rotated, and if yes, rotation schedule
     title: history/crop rotation
     examples:
-      - value: yes;R2/2017-01-01/2018-12-31/P6M
+    - value: yes;R2/2017-01-01/2018-12-31/P6M
     keywords:
-      - history
+    - history
     slot_uri: MIXS:0000318
   crop_yield:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram per metre square
+      Preferred_unit: kilogram per metre square
     description: Amount of crop produced per unit or area of land
     title: crop yield
     examples:
-      - value: 570 kilogram per metre square
+    - value: 570 kilogram per metre square
     keywords:
-      - crop
+    - crop
     slot_uri: MIXS:0001116
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5679,11 +5509,11 @@ slots:
       colony or colonies
     title: culture isolation date
     examples:
-      - value: '2018-05-11T10:00:00+01:00'
+    - value: '2018-05-11T10:00:00+01:00'
     keywords:
-      - culture
-      - date
-      - isolation
+    - culture
+    - date
+    - isolation
     slot_uri: MIXS:0001181
     range: datetime
   cult_result:
@@ -5691,19 +5521,19 @@ slots:
       assessment such as positive/negative, active/inactive
     title: culture result
     examples:
-      - value: positive
+    - value: positive
     keywords:
-      - culture
+    - culture
     slot_uri: MIXS:0001117
     range: CultResultEnum
   cult_result_org:
     description: Taxonomic information about the cultured organism(s)
     title: culture result organism
     examples:
-      - value: Listeria monocytogenes [NCIT:C86502]
+    - value: Listeria monocytogenes [NCIT:C86502]
     keywords:
-      - culture
-      - organism
+    - culture
+    - organism
     slot_uri: MIXS:0001118
     multivalued: true
     range: string
@@ -5714,50 +5544,44 @@ slots:
       partial_match: true
   cult_root_med:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name, PMID,DOI or url
+      Expected_value: name, PMID,DOI or url
     description: Name or reference for the hydroponic or in vitro culture rooting
       medium; can be the name of a commonly used medium or reference to a specific
       medium, e.g. Murashige and Skoog medium. If the medium has not been formally
       published, use the rooting medium descriptors
     title: culture rooting medium
     examples:
-      - value: http://himedialabs.com/TD/PT158.pdf
+    - value: http://himedialabs.com/TD/PT158.pdf
     keywords:
-      - culture
+    - culture
     string_serialization: '{text}|{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0001041
   cult_target:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C14250 or NCBI taxid or culture independent
+      Expected_value: NCIT:C14250 or NCBI taxid or culture independent
     description: The target microbial analyte in terms of investigation scope. This
       field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
     title: culture target microbial analyte
     examples:
-      - value: Listeria monocytogenes [NCIT:C86502]
+    - value: Listeria monocytogenes [NCIT:C86502]
     keywords:
-      - culture
-      - microbial
-      - target
+    - culture
+    - microbial
+    - target
     string_serialization: '{termLabel} [{termID}]|{integer}'
     slot_uri: MIXS:0001119
     multivalued: true
   cur_land_use:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Present state of sample site
     title: current land use
     examples:
-      - value: conifers
+    - value: conifers
     keywords:
-      - land
-      - use
+    - land
+    - use
     string_serialization: '[cities|farmstead|industrial areas|roads/railroads|rock|sand|gravel|mudflats|salt
       flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste areas|small
       grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
@@ -5774,22 +5598,20 @@ slots:
     slot_uri: MIXS:0001080
   cur_vegetation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: current vegetation type
+      Expected_value: current vegetation type
     description: Vegetation classification from one or more standard classification
       systems, or agricultural crop
     title: current vegetation
     keywords:
-      - vegetation
+    - vegetation
     string_serialization: '{text}'
     slot_uri: MIXS:0000312
   cur_vegetation_meth:
     description: Reference or method used in vegetation classification
     title: current vegetation method
     keywords:
-      - method
-      - vegetation
+    - method
+    - vegetation
     slot_uri: MIXS:0000314
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -5802,11 +5624,11 @@ slots:
       Multiple terms can be separated by pipes, listed in reverse chronological order
     title: extreme weather date
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     keywords:
-      - date
-      - extreme
-      - weather
+    - date
+    - extreme
+    - weather
     slot_uri: MIXS:0001142
     multivalued: true
     range: datetime
@@ -5814,39 +5636,35 @@ slots:
     description: The date of the last time it rained
     title: date last rain
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     keywords:
-      - date
-      - rain
+    - date
+    - rain
     slot_uri: MIXS:0000786
     range: datetime
   decontam_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Tool(s) used in contamination screening
     title: decontamination software
     examples:
-      - value: anvi'o
+    - value: anvi'o
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     string_serialization: '[checkm/refinem|anvi''o|prodege|bbtools:decontaminate.sh|acdc|combination]'
     slot_uri: MIXS:0000074
   density:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per cubic meter, gram per cubic centimeter
+      Preferred_unit: gram per cubic meter, gram per cubic centimeter
     description: Density of the sample, which is its mass per unit volume (aka volumetric
       mass density)
     title: density
     examples:
-      - value: 1000 kilogram per cubic meter
+    - value: 1000 kilogram per cubic meter
     keywords:
-      - density
+    - density
     slot_uri: MIXS:0000435
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5860,23 +5678,21 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: depositional environment
     keywords:
-      - environment
+    - environment
     slot_uri: MIXS:0000992
     range: DeposEnvEnum
     recommended: true
   depth:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: The vertical distance below local surface. For sediment or soil samples
       depth is measured from sediment or soil surface, respectively. Depth can be
       reported as an interval for subsurface samples
     title: depth
     in_subset:
-      - environment
+    - environment
     keywords:
-      - depth
+    - depth
     slot_uri: MIXS:0000018
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5891,35 +5707,31 @@ slots:
       skin disease (https://disease-ontology.org/?id=DOID:37)
     title: dermatology disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000284
     multivalued: true
     range: string
   detec_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Type of UViG detection
     title: detection type
     examples:
-      - value: independent sequence (UViG)
+    - value: independent sequence (UViG)
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - type
+    - type
     string_serialization: '[independent sequence (UViG)|provirus (UpViG)]'
     slot_uri: MIXS:0000084
   dew_point:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The temperature to which a given parcel of humid air must be cooled,
       at constant barometric pressure, for water vapor to condense into water
     title: dew point
     examples:
-      - value: 22 degree Celsius
+    - value: 22 degree Celsius
     slot_uri: MIXS:0000129
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5930,24 +5742,20 @@ slots:
       partial_match: true
   diet_last_six_month:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: diet change;current diet
+      Expected_value: diet change;current diet
     description: Specification of major diet changes in the last six months, if yes
       the change should be specified
     title: major diet change in last six months
     examples:
-      - value: yes;vegetarian diet
+    - value: yes;vegetarian diet
     keywords:
-      - diet
-      - months
+    - diet
+    - months
     string_serialization: '{boolean};{text}'
     slot_uri: MIXS:0000266
   dietary_claim_use:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03510023
+      Expected_value: FOODON:03510023
     description: These descriptors are used either for foods intended for special
       dietary use as defined in 21 CFR 105 or for foods that have special characteristics
       indicated in the name or labeling. This field accepts terms listed under dietary
@@ -5956,42 +5764,36 @@ slots:
       to the most prominent dietary claim or use
     title: dietary claim or use
     examples:
-      - value: No preservatives [FOODON:03510113]
+    - value: No preservatives [FOODON:03510113]
     keywords:
-      - diet
-      - use
+    - diet
+    - use
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001199
     multivalued: true
   diether_lipids:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: diether lipid name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: nanogram per liter
+      Expected_value: diether lipid name;measurement value
+      Preferred_unit: nanogram per liter
     description: Concentration of diether lipids; can include multiple types of diether
       lipids
     title: diether lipids
     examples:
-      - value: 0.2 nanogram per liter
+    - value: 0.2 nanogram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000178
     multivalued: true
   diss_carb_dioxide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter
+      Preferred_unit: micromole per liter, milligram per liter
     description: Concentration of dissolved carbon dioxide in the sample or liquid
       portion of the sample
     title: dissolved carbon dioxide
     examples:
-      - value: 5 milligram per liter
+    - value: 5 milligram per liter
     keywords:
-      - carbon
-      - dissolved
+    - carbon
+    - dissolved
     slot_uri: MIXS:0000436
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6002,15 +5804,13 @@ slots:
       partial_match: true
   diss_hydrogen:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of dissolved hydrogen
     title: dissolved hydrogen
     examples:
-      - value: 0.3 micromole per liter
+    - value: 0.3 micromole per liter
     keywords:
-      - dissolved
+    - dissolved
     slot_uri: MIXS:0000179
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6021,18 +5821,16 @@ slots:
       partial_match: true
   diss_inorg_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, milligram per liter, parts per million
+      Preferred_unit: microgram per liter, milligram per liter, parts per million
     description: Dissolved inorganic carbon concentration in the sample, typically
       measured after filtering the sample using a 0.45 micrometer filter
     title: dissolved inorganic carbon
     examples:
-      - value: 2059 micromole per kilogram
+    - value: 2059 micromole per kilogram
     keywords:
-      - carbon
-      - dissolved
-      - inorganic
+    - carbon
+    - dissolved
+    - inorganic
     slot_uri: MIXS:0000434
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6043,17 +5841,15 @@ slots:
       partial_match: true
   diss_inorg_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Concentration of dissolved inorganic nitrogen
     title: dissolved inorganic nitrogen
     examples:
-      - value: 761 micromole per liter
+    - value: 761 micromole per liter
     keywords:
-      - dissolved
-      - inorganic
-      - nitrogen
+    - dissolved
+    - inorganic
+    - nitrogen
     slot_uri: MIXS:0000698
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6066,11 +5862,11 @@ slots:
     description: Concentration of dissolved inorganic phosphorus in the sample
     title: dissolved inorganic phosphorus
     examples:
-      - value: 56.5 micromole per liter
+    - value: 56.5 micromole per liter
     keywords:
-      - dissolved
-      - inorganic
-      - phosphorus
+    - dissolved
+    - inorganic
+    - phosphorus
     slot_uri: MIXS:0000106
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6081,13 +5877,11 @@ slots:
       partial_match: true
   diss_iron:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Concentration of dissolved iron in the sample
     title: dissolved iron
     keywords:
-      - dissolved
+    - dissolved
     slot_uri: MIXS:0000139
     range: string
     recommended: true
@@ -6099,18 +5893,16 @@ slots:
       partial_match: true
   diss_org_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter
+      Preferred_unit: micromole per liter, milligram per liter
     description: Concentration of dissolved organic carbon in the sample, liquid portion
       of the sample, or aqueous phase of the fluid
     title: dissolved organic carbon
     examples:
-      - value: 197 micromole per liter
+    - value: 197 micromole per liter
     keywords:
-      - carbon
-      - dissolved
-      - organic
+    - carbon
+    - dissolved
+    - organic
     slot_uri: MIXS:0000433
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6124,11 +5916,11 @@ slots:
       nitrogen - NH4 - NO3 - NO2
     title: dissolved organic nitrogen
     examples:
-      - value: 0.05 micromole per liter
+    - value: 0.05 micromole per liter
     keywords:
-      - dissolved
-      - nitrogen
-      - organic
+    - dissolved
+    - nitrogen
+    - organic
     slot_uri: MIXS:0000162
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6139,16 +5931,14 @@ slots:
       partial_match: true
   diss_oxygen:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per kilogram, milligram per liter
+      Preferred_unit: micromole per kilogram, milligram per liter
     description: Concentration of dissolved oxygen
     title: dissolved oxygen
     examples:
-      - value: 175 micromole per kilogram
+    - value: 175 micromole per kilogram
     keywords:
-      - dissolved
-      - oxygen
+    - dissolved
+    - oxygen
     slot_uri: MIXS:0000119
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6159,15 +5949,13 @@ slots:
       partial_match: true
   diss_oxygen_fluid:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per kilogram, milligram per liter
+      Preferred_unit: micromole per kilogram, milligram per liter
     description: Concentration of dissolved oxygen in the oil field produced fluids
       as it contributes to oxgen-corrosion and microbial activity (e.g. Mic)
     title: dissolved oxygen in fluids
     keywords:
-      - dissolved
-      - oxygen
+    - dissolved
+    - oxygen
     slot_uri: MIXS:0000438
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6180,81 +5968,79 @@ slots:
     description: Dominant hand of the subject
     title: dominant hand
     examples:
-      - value: right
+    - value: right
     slot_uri: MIXS:0000944
     range: DominantHandEnum
   door_comp_type:
     description: The composite type of the door
     title: door type, composite
     examples:
-      - value: revolving
+    - value: revolving
     keywords:
-      - door
-      - type
+    - door
+    - type
     slot_uri: MIXS:0000795
     range: DoorCompTypeEnum
   door_cond:
     description: The phsical condition of the door
     title: door condition
     examples:
-      - value: new
+    - value: new
     keywords:
-      - condition
-      - door
+    - condition
+    - door
     slot_uri: MIXS:0000788
     range: DamagedRupturedEnum
   door_direct:
     description: The direction the door opens
     title: door direction of opening
     examples:
-      - value: inward
+    - value: inward
     keywords:
-      - direction
-      - door
+    - direction
+    - door
     slot_uri: MIXS:0000789
     range: DoorDirectEnum
   door_loc:
     description: The relative location of the door in the room
     title: door location
     examples:
-      - value: north
+    - value: north
     keywords:
-      - door
-      - location
+    - door
+    - location
     slot_uri: MIXS:0000790
     range: CompassDirections8Enum
   door_mat:
     description: The material the door is composed of
     title: door material
     examples:
-      - value: wood
+    - value: wood
     keywords:
-      - door
-      - material
+    - door
+    - material
     slot_uri: MIXS:0000791
     range: DoorMatEnum
   door_move:
     description: The type of movement of the door
     title: door movement
     examples:
-      - value: swinging
+    - value: swinging
     keywords:
-      - door
+    - door
     slot_uri: MIXS:0000792
     range: DoorMoveEnum
   door_size:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The size of the door
     title: door area or size
     examples:
-      - value: 2.5 square meter
+    - value: 2.5 square meter
     keywords:
-      - area
-      - door
-      - size
+    - area
+    - door
+    - size
     slot_uri: MIXS:0000158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6267,34 +6053,32 @@ slots:
     description: The type of door material
     title: door type
     examples:
-      - value: wooden
+    - value: wooden
     keywords:
-      - door
-      - type
+    - door
+    - type
     slot_uri: MIXS:0000794
     range: DoorTypeEnum
   door_type_metal:
     description: The type of metal door
     title: door type, metal
     examples:
-      - value: hollow
+    - value: hollow
     keywords:
-      - door
-      - type
+    - door
+    - type
     slot_uri: MIXS:0000796
     range: DoorTypeMetalEnum
   door_type_wood:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The type of wood door
     title: door type, wood
     examples:
-      - value: battened
+    - value: battened
     keywords:
-      - door
-      - type
+    - door
+    - type
     string_serialization: '[bettened and ledged|battened|ledged and braced|battened|ledged
       and framed|battened|ledged, braced and frame|framed and paneled|glashed or sash|flush|louvered|wire
       gauged]'
@@ -6303,29 +6087,27 @@ slots:
     description: Signs of the presence of mold or mildew on a door
     title: door signs of water/mold
     examples:
-      - value: presence of mold visible
+    - value: presence of mold visible
     keywords:
-      - door
+    - door
     slot_uri: MIXS:0000793
     range: MoldVisibilityEnum
   douche:
     description: Date of most recent douche
     title: douche
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000967
     range: datetime
   down_par:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microEinstein per square meter per second, microEinstein per square
+      Preferred_unit: microEinstein per square meter per second, microEinstein per square
           centimeter per second
     description: Visible waveband radiance and irradiance measurements in the water
       column
     title: downward PAR
     examples:
-      - value: 28.71 microEinstein per square meter per second
+    - value: 28.71 microEinstein per square meter per second
     slot_uri: MIXS:0000703
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6338,9 +6120,9 @@ slots:
     description: Drainage classification from a standard system such as the USDA system
     title: drainage classification
     examples:
-      - value: well
+    - value: well
     keywords:
-      - classification
+    - classification
     slot_uri: MIXS:0001085
     range: DrainageClassEnum
   drawings:
@@ -6348,36 +6130,32 @@ slots:
       phase-conceptual, schematic, design development, and construction documents
     title: drawings
     examples:
-      - value: sketch
+    - value: sketch
     keywords:
-      - drawings
+    - drawings
     slot_uri: MIXS:0000798
     range: DrawingsEnum
   drug_usage:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: drug name;frequency
+      Expected_value: drug name;frequency
     description: Any drug used by subject and the frequency of usage; can include
       multiple drugs used
     title: drug usage
     examples:
-      - value: Lipitor;2/day
+    - value: Lipitor;2/day
     keywords:
-      - drug
-      - use
+    - drug
+    - use
     string_serialization: '{text};{integer}/[year|month|week|day|hour]'
     slot_uri: MIXS:0000894
     multivalued: true
   efficiency_percent:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Percentage of volatile solids removed from the anaerobic digestor
     title: efficiency percent
     keywords:
-      - percent
+    - percent
     slot_uri: MIXS:0000657
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6388,20 +6166,18 @@ slots:
       partial_match: true
   elev:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Elevation of the sampling site is its height above a fixed reference
       point, most commonly the mean sea level. Elevation is mainly used when referring
       to points on the earth's surface, while altitude is used for points above the
       surface, such as an aircraft in flight or a spacecraft in orbit
     title: elevation
     examples:
-      - value: 100 meter
+    - value: 100 meter
     in_subset:
-      - environment
+    - environment
     keywords:
-      - elevation
+    - elevation
     slot_uri: MIXS:0000093
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6414,19 +6190,15 @@ slots:
     description: The number of elevators within the built structure
     title: elevator count
     examples:
-      - value: '2'
+    - value: '2'
     keywords:
-      - count
+    - count
     slot_uri: MIXS:0000799
     range: integer
   emulsions:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: emulsion name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per liter
+      Expected_value: emulsion name;measurement value
+      Preferred_unit: gram per liter
     description: Amount or concentration of substances such as paints, adhesives,
       mayonnaise, hair colorants, emulsified oils, etc.; can include multiple emulsion
       types
@@ -6436,16 +6208,14 @@ slots:
     multivalued: true
   encoded_traits:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for plasmid: antibiotic resistance; for phage: converting genes'
+      Expected_value: 'for plasmid: antibiotic resistance; for phage: converting genes'
     description: Should include key traits like antibiotic resistance or xenobiotic
       degradation phenotypes for plasmids, converting genes for phage
     title: encoded traits
     examples:
-      - value: beta-lactamase class A
+    - value: beta-lactamase class A
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     string_serialization: '{text}'
     slot_uri: MIXS:0000034
   enrichment_protocol:
@@ -6454,10 +6224,10 @@ slots:
       PubMed or DOI reference for published protocols
     title: enrichment protocol
     examples:
-      - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
+    - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
     keywords:
-      - enrichment
-      - protocol
+    - enrichment
+    - protocol
     slot_uri: MIXS:0001177
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -6473,12 +6243,12 @@ slots:
       EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: broad-scale environmental context
     examples:
-      - value: rangeland biome [ENVO:01000247]
+    - value: rangeland biome [ENVO:01000247]
     in_subset:
-      - environment
+    - environment
     keywords:
-      - context
-      - environmental
+    - context
+    - environmental
     slot_uri: MIXS:0000012
     range: string
     required: true
@@ -6489,9 +6259,7 @@ slots:
       partial_match: true
   env_local_scale:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Environmental entities having causal influences upon the entity at
+      Expected_value: Environmental entities having causal influences upon the entity at
           time of sampling
     description: 'Report the entity or entities which are in the sample or specimen
       s local vicinity and which you believe have significant causal influences on
@@ -6502,12 +6270,12 @@ slots:
       field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: local environmental context
     examples:
-      - value: hillside [ENVO:01000333]
+    - value: hillside [ENVO:01000333]
     in_subset:
-      - environment
+    - environment
     keywords:
-      - context
-      - environmental
+    - context
+    - environmental
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000013
     required: true
@@ -6521,11 +6289,11 @@ slots:
       (e.g. a tree, a leaf, a table top)'
     title: environmental medium
     examples:
-      - value: bluegrass field soil [ENVO:00005789]
+    - value: bluegrass field soil [ENVO:00005789]
     in_subset:
-      - environment
+    - environment
     keywords:
-      - environmental
+    - environmental
     slot_uri: MIXS:0000014
     range: string
     required: true
@@ -6536,9 +6304,7 @@ slots:
       partial_match: true
   env_monitoring_zone:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO
+      Expected_value: ENVO
     description: An environmental monitoring zone is a formal designation as part
       of an environmental monitoring program, in which areas of a food production
       facility are categorized, commonly as zones 1-4, based on likelihood or risk
@@ -6548,58 +6314,52 @@ slots:
       taken from
     title: food production environmental monitoring zone
     examples:
-      - value: Zone 1
+    - value: Zone 1
     keywords:
-      - environmental
-      - food
-      - production
+    - environmental
+    - food
+    - production
     string_serialization: '{text}'
     slot_uri: MIXS:0001254
   escalator:
     description: The number of escalators within the built structure
     title: escalator count
     examples:
-      - value: '4'
+    - value: '4'
     keywords:
-      - count
+    - count
     slot_uri: MIXS:0000800
     range: integer
   estimated_size:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: number of base pairs
+      Expected_value: number of base pairs
     description: The estimated size of the genome prior to sequencing. Of particular
       importance in the sequencing of (eukaryotic) genome which could remain in draft
       form for a long or unspecified period
     title: estimated size
     examples:
-      - value: 300000 bp
+    - value: 300000 bp
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - size
+    - size
     string_serialization: '{integer} bp'
     slot_uri: MIXS:0000024
   ethnicity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text recommend from Wikipedia list
+      Expected_value: text recommend from Wikipedia list
     description: A category of people who identify with each other, usually on the
       basis of presumed similarities such as a common language, ancestry, history,
       society, culture, nation or social treatment within their residing area. https://en.wikipedia.org/wiki/List_of_contemporary_ethnic_groups
     title: ethnicity
     examples:
-      - value: native american
+    - value: native american
     string_serialization: '{text}'
     slot_uri: MIXS:0000895
     multivalued: true
   ethylbenzene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of ethylbenzene in the sample
     title: ethylbenzene
     slot_uri: MIXS:0000155
@@ -6613,9 +6373,7 @@ slots:
       partial_match: true
   exp_duct:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The amount of exposed ductwork in the room
     title: exposed ductwork
     slot_uri: MIXS:0000144
@@ -6630,7 +6388,7 @@ slots:
     description: The number of exposed pipes in the room
     title: exposed pipes
     keywords:
-      - pipes
+    - pipes
     slot_uri: MIXS:0000220
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -6640,21 +6398,19 @@ slots:
       partial_match: true
   experimental_factor:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or EFO and/or OBI
+      Expected_value: text or EFO and/or OBI
     description: Variable aspects of an experiment design that can be used to describe
       an experiment, or set of experiments, in an increasingly detailed manner. This
       field accepts ontology terms from Experimental Factor Ontology (EFO) and/or
       Ontology for Biomedical Investigations (OBI)
     title: experimental factor
     examples:
-      - value: time series design [EFO:0001779]
+    - value: time series design [EFO:0001779]
     in_subset:
-      - investigation
+    - investigation
     keywords:
-      - experimental
-      - factor
+    - experimental
+    - factor
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000008
     multivalued: true
@@ -6664,29 +6420,29 @@ slots:
     description: The number of exterior doors in the built structure
     title: exterior door count
     keywords:
-      - count
-      - door
-      - exterior
+    - count
+    - door
+    - exterior
     slot_uri: MIXS:0000170
     range: integer
   ext_wall_orient:
     description: The orientation of the exterior wall
     title: orientations of exterior wall
     examples:
-      - value: northwest
+    - value: northwest
     keywords:
-      - exterior
-      - wall
+    - exterior
+    - wall
     slot_uri: MIXS:0000817
     range: CompassDirections8Enum
   ext_window_orient:
     description: The compass direction the exterior window of the room is facing
     title: orientations of exterior window
     examples:
-      - value: southwest
+    - value: southwest
     keywords:
-      - exterior
-      - window
+    - exterior
+    - window
     slot_uri: MIXS:0000818
     range: CompassDirections8Enum
   extr_weather_event:
@@ -6694,11 +6450,11 @@ slots:
       Multiple terms can be separated by pipes, listed in reverse chronological order
     title: extreme weather event
     examples:
-      - value: hail
+    - value: hail
     keywords:
-      - event
-      - extreme
-      - weather
+    - event
+    - extreme
+    - weather
     slot_uri: MIXS:0001141
     multivalued: true
     range: ExtrWeatherEventEnum
@@ -6708,17 +6464,17 @@ slots:
       (borrelia has 15+ plasmids)
     title: extrachromosomal elements
     examples:
-      - value: '5'
+    - value: '5'
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     slot_uri: MIXS:0000023
     range: integer
   extreme_event:
     description: Unusual physical events that may have affected microbial populations
     title: history/extreme events
     keywords:
-      - event
-      - history
+    - event
+    - history
     slot_uri: MIXS:0000320
     range: datetime
   facility_type:
@@ -6726,10 +6482,10 @@ slots:
       was taken. This is independent of the specific product(s) within the facility
     title: facility type
     examples:
-      - value: manufacturing-processing
+    - value: manufacturing-processing
     keywords:
-      - facility
-      - type
+    - facility
+    - type
     slot_uri: MIXS:0001252
     multivalued: true
     range: FacilityTypeEnum
@@ -6738,9 +6494,9 @@ slots:
       Resources. The list can be found at http://www.fao.org/nr/land/sols/soil/wrb-soil-maps/reference-groups
     title: soil_taxonomic/FAO classification
     examples:
-      - value: Luvisols
+    - value: Luvisols
     keywords:
-      - classification
+    - classification
     slot_uri: MIXS:0001083
     range: FaoClassEnum
   farm_equip:
@@ -6750,11 +6506,11 @@ slots:
       Multiple terms can be separated by pipes
     title: farm equipment used
     examples:
-      - value: combine harvester [AGRO:00000473]
+    - value: combine harvester [AGRO:00000473]
     keywords:
-      - equipment
-      - farm
-      - use
+    - equipment
+    - farm
+    - use
     slot_uri: MIXS:0001126
     multivalued: true
     range: string
@@ -6765,22 +6521,18 @@ slots:
       partial_match: true
   farm_equip_san:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or commercial name of sanitizer or class of sanitizer or active
+      Expected_value: text or commercial name of sanitizer or class of sanitizer or active
           ingredient in sanitizer
-      Preferred_unit:
-        tag: Preferred_unit
-        value: parts per million
+      Preferred_unit: parts per million
     description: Method used to sanitize growing and harvesting equipment. This can
       including type and concentration of sanitizing solution.  Multiple terms can
       be separated by one or more pipes
     title: farm equipment sanitization
     examples:
-      - value: hot water pressure wash, hypochlorite solution, 50 parts per million
+    - value: hot water pressure wash, hypochlorite solution, 50 parts per million
     keywords:
-      - equipment
-      - farm
+    - equipment
+    - farm
     string_serialization: '{text} {float} {unit}'
     slot_uri: MIXS:0001124
     multivalued: true
@@ -6789,11 +6541,11 @@ slots:
       might be on a Daily basis, Weekly, Monthly, Quarterly or Annually
     title: farm equipment sanitization frequency
     examples:
-      - value: Biweekly
+    - value: Biweekly
     keywords:
-      - equipment
-      - farm
-      - frequency
+    - equipment
+    - farm
+    - frequency
     slot_uri: MIXS:0001125
     range: string
   farm_equip_shared:
@@ -6802,10 +6554,10 @@ slots:
       Multiple terms can be separated by pipes
     title: equipment shared with other farms
     examples:
-      - value: combine harvester [AGRO:00000473]
+    - value: combine harvester [AGRO:00000473]
     keywords:
-      - equipment
-      - farm
+    - equipment
+    - farm
     slot_uri: MIXS:0001123
     multivalued: true
     range: string
@@ -6819,12 +6571,12 @@ slots:
       of livestock
     title: farm watering water source
     examples:
-      - value: well
-        description: was water well (ENVO:01000002)
+    - value: well
+      description: was water well (ENVO:01000002)
     keywords:
-      - farm
-      - source
-      - water
+    - farm
+    - source
+    - water
     slot_uri: MIXS:0001110
     range: FarmWaterSourceEnum
     recommended: true
@@ -6833,12 +6585,12 @@ slots:
       etc
     title: feature prediction
     examples:
-      - value: Prodigal;2.6.3;default parameters
+    - value: Prodigal;2.6.3;default parameters
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - feature
-      - predict
+    - feature
+    - predict
     slot_uri: MIXS:0000061
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -6848,48 +6600,42 @@ slots:
       partial_match: true
   ferm_chem_add:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: chemical ingredient
+      Expected_value: chemical ingredient
     description: Any chemicals that are added to the fermentation process to achieve
       the desired final product
     title: fermentation chemical additives
     examples:
-      - value: salt
+    - value: salt
     keywords:
-      - fermentation
+    - fermentation
     string_serialization: '{float} {unit}'
     slot_uri: MIXS:0001185
     multivalued: true
     recommended: true
   ferm_chem_add_perc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: The amount of chemical added to the fermentation process
     title: fermentation chemical additives percentage
     examples:
-      - value: '0.01'
+    - value: '0.01'
     keywords:
-      - fermentation
-      - percent
+    - fermentation
+    - percent
     slot_uri: MIXS:0001186
     multivalued: true
     range: float
     recommended: true
   ferm_headspace_oxy:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: The amount of headspace oxygen in a fermentation vessel
     title: fermentation headspace oxygen
     examples:
-      - value: '0.05'
+    - value: '0.05'
     keywords:
-      - fermentation
-      - oxygen
+    - fermentation
+    - oxygen
     slot_uri: MIXS:0001187
     range: float
     recommended: true
@@ -6899,9 +6645,9 @@ slots:
       source, water, micronutrients and chemical additives
     title: fermentation medium
     examples:
-      - value: molasses
+    - value: molasses
     keywords:
-      - fermentation
+    - fermentation
     slot_uri: MIXS:0001188
     range: string
     recommended: true
@@ -6909,28 +6655,26 @@ slots:
     description: The pH of the fermented food fermentation process
     title: fermentation pH
     examples:
-      - value: '4.5'
+    - value: '4.5'
     keywords:
-      - fermentation
-      - ph
+    - fermentation
+    - ph
     slot_uri: MIXS:0001189
     range: float
     recommended: true
   ferm_rel_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: The relative humidity of the fermented food fermentation process
     title: fermentation relative humidity
     comments:
-      - percent or float?
+    - percent or float?
     examples:
-      - value: 95%
+    - value: 95%
     keywords:
-      - fermentation
-      - humidity
-      - relative
+    - fermentation
+    - humidity
+    - relative
     slot_uri: MIXS:0001190
     range: string
     recommended: true
@@ -6942,16 +6686,14 @@ slots:
       partial_match: true
   ferm_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The temperature of the fermented food fermentation process
     title: fermentation temperature
     examples:
-      - value: 22 degrees Celsius
+    - value: 22 degrees Celsius
     keywords:
-      - fermentation
-      - temperature
+    - fermentation
+    - temperature
     slot_uri: MIXS:0001191
     range: string
     recommended: true
@@ -6963,16 +6705,14 @@ slots:
       partial_match: true
   ferm_time:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days
+      Preferred_unit: days
     description: The time duration of the fermented food fermentation process
     title: fermentation time
     examples:
-      - value: P10D
+    - value: P10D
     keywords:
-      - fermentation
-      - time
+    - fermentation
+    - time
     slot_uri: MIXS:0001192
     range: string
     recommended: true
@@ -6985,9 +6725,9 @@ slots:
     description: The type of vessel used for containment of the fermentation
     title: fermentation vessel
     examples:
-      - value: steel drum
+    - value: steel drum
     keywords:
-      - fermentation
+    - fermentation
     slot_uri: MIXS:0001193
     range: string
     recommended: true
@@ -6999,9 +6739,9 @@ slots:
       order
     title: fertilizer administration
     examples:
-      - value: fish emulsion [AGRO:00000082]
+    - value: fish emulsion [AGRO:00000082]
     keywords:
-      - administration
+    - administration
     slot_uri: MIXS:0001127
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -7015,20 +6755,16 @@ slots:
       order
     title: fertilizer administration date
     examples:
-      - value: '2018-05-11T10:00:00+01:00'
+    - value: '2018-05-11T10:00:00+01:00'
     keywords:
-      - administration
-      - date
+    - administration
+    - date
     slot_uri: MIXS:0001128
     range: datetime
   fertilizer_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: fertilizer name;fertilizer amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Expected_value: fertilizer name;fertilizer amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of fertilizers; should
       include the name of fertilizer, amount administered, treatment regimen including
       how many times the treatment was repeated, how long each treatment lasted, and
@@ -7036,9 +6772,9 @@ slots:
       regimens
     title: fertilizer regimen
     examples:
-      - value: urea;0.6 milligram per liter;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
+    - value: urea;0.6 milligram per liter;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
+    - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000556
     multivalued: true
@@ -7052,10 +6788,10 @@ slots:
     description: A device which removes solid particulates or airborne molecular contaminants
     title: filter type
     examples:
-      - value: HEPA
+    - value: HEPA
     keywords:
-      - filter
-      - type
+    - filter
+    - type
     slot_uri: MIXS:0000765
     multivalued: true
     range: FilterTypeEnum
@@ -7064,35 +6800,33 @@ slots:
     description: Historical and/or physical evidence of fire
     title: history/fire
     keywords:
-      - history
+    - history
     slot_uri: MIXS:0001086
     range: datetime
   fireplace_type:
     description: A firebox with chimney
     title: fireplace type
     examples:
-      - value: wood burning
+    - value: wood burning
     keywords:
-      - type
+    - type
     slot_uri: MIXS:0000802
     range: FireplaceTypeEnum
   flooding:
     description: Historical and/or physical evidence of flooding
     title: history/flooding
     keywords:
-      - history
+    - history
     slot_uri: MIXS:0000319
     range: datetime
   floor_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: years, weeks, days
+      Preferred_unit: years, weeks, days
     description: The time period since installment of the carpet or flooring
     title: floor age
     keywords:
-      - age
-      - floor
+    - age
+    - floor
     slot_uri: MIXS:0000164
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7103,14 +6837,12 @@ slots:
       partial_match: true
   floor_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The area of the floor space within the room
     title: floor area
     keywords:
-      - area
-      - floor
+    - area
+    - floor
     slot_uri: MIXS:0000165
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7124,10 +6856,10 @@ slots:
       or video preferred; use drawings to indicate location of damaged areas
     title: floor condition
     examples:
-      - value: new
+    - value: new
     keywords:
-      - condition
-      - floor
+    - condition
+    - floor
     slot_uri: MIXS:0000803
     range: DamagedEnum
   floor_count:
@@ -7135,22 +6867,20 @@ slots:
       penthouse
     title: floor count
     keywords:
-      - count
-      - floor
+    - count
+    - floor
     slot_uri: MIXS:0000225
     range: integer
   floor_finish_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The floor covering type; the finished surface that is walked on
     title: floor finish material
     examples:
-      - value: carpet
+    - value: carpet
     keywords:
-      - floor
-      - material
+    - floor
+    - material
     string_serialization: '[tile|wood strip or parquet|carpet|rug|laminate wood|lineoleum|vinyl
       composition tile|sheet vinyl|stone|bamboo|cork|terrazo|concrete|none;specify
       unfinished|sealed|clear finish|paint]'
@@ -7160,21 +6890,19 @@ slots:
       flooring is installed
     title: floor structure
     examples:
-      - value: concrete
+    - value: concrete
     keywords:
-      - floor
+    - floor
     slot_uri: MIXS:0000806
     range: FloorStrucEnum
   floor_thermal_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: joule per degree Celsius
+      Preferred_unit: joule per degree Celsius
     description: The ability of the floor to provide inertia against temperature fluctuations
     title: floor thermal mass
     keywords:
-      - floor
-      - mass
+    - floor
+    - mass
     slot_uri: MIXS:0000166
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7187,20 +6915,18 @@ slots:
     description: Signs of the presence of mold or mildew in a room
     title: floor signs of water/mold
     examples:
-      - value: ceiling discoloration
+    - value: ceiling discoloration
     keywords:
-      - floor
+    - floor
     slot_uri: MIXS:0000805
     range: FloorWaterMoldEnum
   fluor:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram chlorophyll a per cubic meter, volts
+      Preferred_unit: milligram chlorophyll a per cubic meter, volts
     description: Raw or converted fluorescence of water
     title: fluorescence
     examples:
-      - value: 2.5 volts
+    - value: 2.5 volts
     slot_uri: MIXS:0000704
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7213,14 +6939,12 @@ slots:
     description: Specification of foetal health status, should also include abortion
     title: amniotic fluid/foetal health status
     keywords:
-      - status
+    - status
     slot_uri: MIXS:0000275
     range: string
   food_additive:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03412972
+      Expected_value: FOODON:03412972
     description: A substance or substances added to food to maintain or improve safety
       and freshness, to improve or maintain nutritional value, or improve taste, texture
       and appearance.  This field accepts terms listed under food additive (http://purl.obolibrary.org/obo/FOODON_03412972).
@@ -7229,24 +6953,22 @@ slots:
       also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
     title: food additive
     examples:
-      - value: xanthan gum [FOODON:03413321]
+    - value: xanthan gum [FOODON:03413321]
     keywords:
-      - food
+    - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001200
     multivalued: true
   food_allergen_label:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03510213
+      Expected_value: FOODON:03510213
     description: A label indication that the product contains a recognized allergen.
       This field accepts terms listed under dietary claim or use (http://purl.obolibrary.org/obo/FOODON_03510213)
     title: food allergen labeling
     examples:
-      - value: food allergen labelling about crustaceans and products thereof [FOODON:03510215]
+    - value: food allergen labelling about crustaceans and products thereof [FOODON:03510215]
     keywords:
-      - food
+    - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001201
     multivalued: true
@@ -7255,61 +6977,55 @@ slots:
       from the food source. Multiple terms can be separated by pipes
     title: food cleaning process
     examples:
-      - value: rinsed with water
-        description: was rinsed with water|scrubbed with brush
-      - value: scrubbed with brush
-        description: was rinsed with water|scrubbed with brush
+    - value: rinsed with water
+      description: was rinsed with water|scrubbed with brush
+    - value: scrubbed with brush
+      description: was rinsed with water|scrubbed with brush
     keywords:
-      - food
-      - process
+    - food
+    - process
     slot_uri: MIXS:0001182
     range: FoodCleanProcEnum
   food_contact_surf:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03500010
+      Expected_value: FOODON:03500010
     description: The specific container or coating materials in direct contact with
       the food. Multiple values can be assigned.  This field accepts terms listed
       under food contact surface (http://purl.obolibrary.org/obo/FOODON_03500010)
     title: food contact surface
     examples:
-      - value: cellulose acetate [FOODON:03500034]
+    - value: cellulose acetate [FOODON:03500034]
     keywords:
-      - food
-      - surface
+    - food
+    - surface
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001131
     multivalued: true
   food_contain_wrap:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03490100
+      Expected_value: FOODON:03490100
     description: Type of container or wrapping defined by the main container material,
       the container form, and the material of the liner lids or ends. Also type of
       container or wrapping by form; prefer description by material first, then by
       form. This field accepts terms listed under food container or wrapping (http://purl.obolibrary.org/obo/FOODON_03490100)
     title: food container or wrapping
     examples:
-      - value: Plastic shrink-pack [FOODON:03490137]
+    - value: Plastic shrink-pack [FOODON:03490137]
     keywords:
-      - food
+    - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001132
   food_cooking_proc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03450002
+      Expected_value: FOODON:03450002
     description: The transformation of raw food by the application of heat. This field
       accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
     title: food cooking process
     examples:
-      - value: food blanching [FOODON:03470175]
+    - value: food blanching [FOODON:03470175]
     keywords:
-      - food
-      - process
+    - food
+    - process
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001202
     multivalued: true
@@ -7322,11 +7038,11 @@ slots:
       Service. Washington, DC. March 2012. http://dx.doi.org/10.9752/MS045.03-2012'
     title: food distribution point geographic location
     examples:
-      - value: 'USA: Delmarva, Peninsula'
+    - value: 'USA: Delmarva, Peninsula'
     keywords:
-      - food
-      - geographic
-      - location
+    - food
+    - geographic
+    - location
     slot_uri: MIXS:0001203
     multivalued: true
     range: string
@@ -7337,9 +7053,7 @@ slots:
       partial_match: true
   food_dis_point_city:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: GAZ:00000448
+      Expected_value: GAZ:00000448
     description: 'A reference to a place on the Earth, by its name or by its geographical
       location that refers to a distribution point along the food chain. This field
       accepts terms listed under geographic location (http://purl.obolibrary.org/obo/GAZ_00000448).
@@ -7348,11 +7062,11 @@ slots:
       Service. Washington, DC. March 2012. http://dx.doi.org/10.9752/MS045.03-2012'
     title: food distribution point geographic location (city)
     examples:
-      - value: Atlanta[GAZ:00004445]
+    - value: Atlanta[GAZ:00004445]
     keywords:
-      - food
-      - geographic
-      - location
+    - food
+    - geographic
+    - location
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001204
     multivalued: true
@@ -7363,18 +7077,16 @@ slots:
       a part of an organism or the whole, and may involve killing the organism
     title: Food harvesting process
     examples:
-      - value: hand-picked
+    - value: hand-picked
     keywords:
-      - food
-      - process
+    - food
+    - process
     slot_uri: MIXS:0001133
     multivalued: true
     range: string
   food_ingredient:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON
+      Expected_value: FOODON
     description: In this field, please list individual ingredients for multi-component
       food [FOODON:00002501] and simple foods that is not captured in food_type.  Please
       use terms that are present in FoodOn.  Multiple terms can be separated by one
@@ -7382,10 +7094,10 @@ slots:
       listed in order as on the food label.  See also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
     title: food ingredient
     examples:
-      - value: bean (whole) [FOODON:00002753]
+    - value: bean (whole) [FOODON:00002753]
     keywords:
-      - food
-      - ingredient
+    - food
+    - ingredient
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001205
     multivalued: true
@@ -7395,11 +7107,11 @@ slots:
       name legal status (http://purl.obolibrary.org/obo/FOODON_03530087)
     title: food product name legal status
     examples:
-      - value: protected geographic indication [FOODON:03530256]
+    - value: protected geographic indication [FOODON:03530256]
     keywords:
-      - food
-      - product
-      - status
+    - food
+    - product
+    - status
     slot_uri: MIXS:0001206
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -7414,12 +7126,12 @@ slots:
       location (http://purl.obolibrary.org/obo/GAZ_00000448)
     title: food product origin geographic location
     examples:
-      - value: 'USA: Delmarva, Peninsula'
+    - value: 'USA: Delmarva, Peninsula'
     keywords:
-      - food
-      - geographic
-      - location
-      - product
+    - food
+    - geographic
+    - location
+    - product
     slot_uri: MIXS:0001207
     range: string
     pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
@@ -7429,16 +7141,14 @@ slots:
       partial_match: true
   food_pack_capacity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: grams
+      Preferred_unit: grams
     description: The maximum number of product units within a package
     title: food package capacity
     examples:
-      - value: 454 grams
+    - value: 454 grams
     keywords:
-      - food
-      - package
+    - food
+    - package
     slot_uri: MIXS:0001208
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7449,25 +7159,21 @@ slots:
       partial_match: true
   food_pack_integrity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03530218
+      Expected_value: FOODON:03530218
     description: A term label and term id to describe the state of the packing material
       and text to explain the exact condition.  This field accepts terms listed under
       food packing medium integrity (http://purl.obolibrary.org/obo/FOODON_03530218)
     title: food packing medium integrity
     examples:
-      - value: food packing medium compromised [FOODON:00002517]
+    - value: food packing medium compromised [FOODON:00002517]
     keywords:
-      - food
+    - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001209
     multivalued: true
   food_pack_medium:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03480020
+      Expected_value: FOODON:03480020
     description: The medium in which the food is packed for preservation and handling
       or the medium surrounding homemade foods, e.g., peaches cooked in sugar syrup.
       The packing medium may provide a controlled environment for the food. It may
@@ -7478,32 +7184,28 @@ slots:
       terms may apply and can be separated by pipes
     title: food packing medium
     keywords:
-      - food
+    - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001134
     multivalued: true
   food_preserv_proc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03470107
+      Expected_value: FOODON:03470107
     description: The methods contributing to the prevention or retardation of microbial,
       enzymatic or oxidative spoilage and thus to the extension of shelf life. This
       field accepts terms listed under food preservation process (http://purl.obolibrary.org/obo/FOODON_03470107)
     title: food preservation process
     examples:
-      - value: food slow freezing [FOODON:03470128]
+    - value: food slow freezing [FOODON:03470128]
     keywords:
-      - food
-      - process
+    - food
+    - process
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001135
     multivalued: true
   food_prior_contact:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03530077
+      Expected_value: FOODON:03530077
     description: The material the food contacted (e.g., was processed in) prior to
       packaging. This field accepts terms listed under material of contact prior to
       food packaging (http://purl.obolibrary.org/obo/FOODON_03530077). If the proper
@@ -7511,11 +7213,11 @@ slots:
       prior to food packaging
     title: material of contact prior to food packaging
     examples:
-      - value: processed in stainless steel container [FOODON:03530081]
+    - value: processed in stainless steel container [FOODON:03530081]
     keywords:
-      - food
-      - material
-      - prior
+    - food
+    - material
+    - prior
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001210
     multivalued: true
@@ -7527,10 +7229,10 @@ slots:
       Multiple terms may apply and can be separated by pipes
     title: food production system characteristics
     examples:
-      - value: organic plant cultivation [FOODON:03530253]
+    - value: organic plant cultivation [FOODON:03530253]
     keywords:
-      - food
-      - production
+    - food
+    - production
     slot_uri: MIXS:0001211
     multivalued: true
     range: string
@@ -7544,10 +7246,10 @@ slots:
       organic, free-range, industrial, dairy, beef
     title: food production characteristics
     examples:
-      - value: wild caught
+    - value: wild caught
     keywords:
-      - food
-      - production
+    - food
+    - production
     slot_uri: MIXS:0001136
     multivalued: true
     range: string
@@ -7556,10 +7258,10 @@ slots:
       or non-English names)
     title: food product synonym
     examples:
-      - value: pinot gris
+    - value: pinot gris
     keywords:
-      - food
-      - product
+    - food
+    - product
     slot_uri: MIXS:0001212
     multivalued: true
     range: string
@@ -7571,11 +7273,11 @@ slots:
       under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
     title: food product by quality
     examples:
-      - value: raw [FOODON:03311126]
+    - value: raw [FOODON:03311126]
     keywords:
-      - food
-      - product
-      - quality
+    - food
+    - product
+    - quality
     slot_uri: MIXS:0001213
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -7585,9 +7287,7 @@ slots:
       partial_match: true
   food_product_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:00001002 or FOODON:03309997
+      Expected_value: FOODON:00001002 or FOODON:03309997
     description: A food product type is a class of food products that is differentiated
       by its food composition (e.g., single- or multi-ingredient), processing and/or
       consumption characteristics. This does not include brand name products but it
@@ -7598,58 +7298,52 @@ slots:
       type. Multiple terms can be separated by one or more pipes
     title: food product type
     keywords:
-      - food
-      - product
-      - type
+    - food
+    - product
+    - type
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001184
   food_quality_date:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration, date
+      Expected_value: enumeration, date
     description: The date recommended for the use of the product while at peak quality,
       this date is not a reflection of safety unless used on infant formula this date
       is not a reflection of safety and is typically labeled on a food product as
       "best if used by," best by," "use by," or "freeze by."
     title: food quality date
     examples:
-      - value: best by 2020-05-24
+    - value: best by 2020-05-24
     keywords:
-      - date
-      - food
-      - quality
+    - date
+    - food
+    - quality
     string_serialization: '[best by|best if used by|freeze by|use by]; date'
     slot_uri: MIXS:0001178
   food_source:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON term
+      Expected_value: FOODON term
     description: Type of plant or animal from which the food product or its major
       ingredient is derived or a chemical food source [FDA CFSAN 1995]
     title: food source
     keywords:
-      - food
-      - source
+    - food
+    - source
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001139
   food_source_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days
+      Preferred_unit: days
     description: The age of the food source host organim. Depending on the type of
       host organism, age may be more appropriate to report in days, weeks, or years
     title: food source age
     comments:
-      - ISO 8601 period or measurement value?
+    - ISO 8601 period or measurement value?
     examples:
-      - value: 6 months
+    - value: 6 months
     keywords:
-      - age
-      - food
-      - source
+    - age
+    - food
+    - source
     slot_uri: MIXS:0001251
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7669,9 +7363,9 @@ slots:
       but also to any foods that contain listed foods as ingredients
     title: food traceability list category
     examples:
-      - value: tropical tree fruits
+    - value: tropical tree fruits
     keywords:
-      - food
+    - food
     slot_uri: MIXS:0001214
     range: FoodTraceListEnum
   food_trav_mode:
@@ -7682,11 +7376,11 @@ slots:
       be separated by one or more pipes
     title: food shipping transportation method
     examples:
-      - value: train travel [GENEPIO:0001060]
+    - value: train travel [GENEPIO:0001060]
     keywords:
-      - food
-      - method
-      - transport
+    - food
+    - method
+    - transport
     slot_uri: MIXS:0001137
     multivalued: true
     range: string
@@ -7697,9 +7391,7 @@ slots:
       partial_match: true
   food_trav_vehic:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:01000604
+      Expected_value: ENVO:01000604
     description: A descriptor for the mobile machine which is used to transport food
       commodities along the food distribution system.  This field accepts terms listed
       under vehicle (http://purl.obolibrary.org/obo/ENVO_01000604). If the proper
@@ -7707,18 +7399,16 @@ slots:
       terms can be separated by one or more pipes
     title: food shipping transportation vehicle
     examples:
-      - value: aircraft [ENVO:01001488]|car [ENVO:01000605]
+    - value: aircraft [ENVO:01001488]|car [ENVO:01000605]
     keywords:
-      - food
-      - transport
+    - food
+    - transport
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001138
     multivalued: true
   food_treat_proc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03460111
+      Expected_value: FOODON:03460111
     description: Used to specifically characterize a food product based on the treatment
       or processes applied to the product or any indexed ingredient. The processes
       include adding, substituting or removing components or modifying the food or
@@ -7726,11 +7416,11 @@ slots:
       fields accepts terms listed under food treatment process (http://purl.obolibrary.org/obo/FOODON_03460111)
     title: food treatment process
     examples:
-      - value: gluten removal process [FOODON:03460750]
+    - value: gluten removal process [FOODON:03460750]
     keywords:
-      - food
-      - process
-      - treatment
+    - food
+    - process
+    - treatment
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001140
     multivalued: true
@@ -7739,16 +7429,16 @@ slots:
       cleaning might be on a Daily basis, Weekly, Monthly, Quarterly or Annually
     title: frequency of cleaning
     examples:
-      - value: Daily
+    - value: Daily
     keywords:
-      - frequency
+    - frequency
     slot_uri: MIXS:0000226
     range: FreqCleanEnum
   freq_cook:
     description: The number of times a meal is cooked per week
     title: frequency of cooking
     keywords:
-      - frequency
+    - frequency
     slot_uri: MIXS:0000227
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -7758,18 +7448,16 @@ slots:
       partial_match: true
   fungicide_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of fungicides; should include
       the name of fungicide, amount administered, treatment regimen including how
       many times the treatment was repeated, how long each treatment lasted, and the
       start and end time of the entire treatment; can include multiple fungicide regimens
     title: fungicide regimen
     examples:
-      - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
+    - regimen
     slot_uri: MIXS:0000557
     multivalued: true
     range: string
@@ -7777,33 +7465,27 @@ slots:
     description: The types of furniture present in the sampled room
     title: furniture
     examples:
-      - value: chair
+    - value: chair
     slot_uri: MIXS:0000807
     range: FurnitureEnum
   gaseous_environment:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Use of conditions with differing gaseous environments; should include
       the name of gaseous compound, amount administered, treatment duration, interval
       and total experimental duration; can include multiple gaseous environment regimens
     title: gaseous environment
     examples:
-      - value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - environment
+    - environment
     slot_uri: MIXS:0000558
     multivalued: true
     range: string
   gaseous_substances:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gaseous substance name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Expected_value: gaseous substance name;measurement value
+      Preferred_unit: micromole per liter
     description: Amount or concentration of substances such as hydrogen sulfide, carbon
       dioxide, methane, etc.; can include multiple substances
     title: gaseous substances
@@ -7817,7 +7499,7 @@ slots:
       gastrointestinal system disease (https://disease-ontology.org/?id=DOID:77)
     title: gastrointestinal tract disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000280
     multivalued: true
     range: string
@@ -7825,21 +7507,19 @@ slots:
     description: The gender type of the restroom
     title: gender of restroom
     examples:
-      - value: male
+    - value: male
     slot_uri: MIXS:0000808
     range: GenderRestroomEnum
   genetic_mod:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: PMID, DOI, URL or text
+      Expected_value: PMID, DOI, URL or text
     description: Genetic modifications of the genome of an organism, which may occur
       naturally by spontaneous mutation, or be introduced by some experimental means,
       e.g. specification of a transgene or the gene knocked-out or details of transient
       transfection
     title: genetic modification
     examples:
-      - value: aox1A transgenic
+    - value: aox1A transgenic
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000859
   geo_loc_name:
@@ -7849,12 +7529,12 @@ slots:
       (http://purl.bioontology.org/ontology/GAZ)
     title: geographic location (country and/or sea,region)
     examples:
-      - value: 'USA: Maryland, Bethesda'
+    - value: 'USA: Maryland, Bethesda'
     in_subset:
-      - environment
+    - environment
     keywords:
-      - geographic
-      - location
+    - geographic
+    - location
     slot_uri: MIXS:0000010
     range: string
     required: true
@@ -7870,13 +7550,11 @@ slots:
     range: string
   glucosidase_act:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mol per liter per hour
+      Preferred_unit: mol per liter per hour
     description: Measurement of glucosidase activity
     title: glucosidase activity
     examples:
-      - value: 5 mol per liter per hour
+    - value: 5 mol per liter per hour
     slot_uri: MIXS:0000137
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7890,17 +7568,13 @@ slots:
       specifying which is used
     title: gravidity
     examples:
-      - value: yes;due date:2018-05-11
+    - value: yes;due date:2018-05-11
     string_serialization: '{boolean};{timestamp}'
     slot_uri: MIXS:0000875
   gravity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gravity factor value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter per square second, g
+      Expected_value: gravity factor value;treatment interval and duration
+      Preferred_unit: meter per square second, g
     description: Information about treatment involving use of gravity factor to study
       various types of responses in presence, absence or modified levels of gravity;
       treatment regimen including how many times the treatment was repeated, how long
@@ -7908,43 +7582,37 @@ slots:
       include multiple treatments
     title: gravity
     examples:
-      - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000559
     multivalued: true
   growth_facil:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: free text or CO
+      Expected_value: free text or CO
     description: 'Type of facility where the sampled plant was grown; controlled vocabulary:
       growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively
       use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
     title: growth facility
     examples:
-      - value: Growth chamber [CO_715:0000189]
+    - value: Growth chamber [CO_715:0000189]
     keywords:
-      - facility
-      - growth
+    - facility
+    - growth
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001043
   growth_habit:
     description: Characteristic shape, appearance or growth form of a plant species
     title: growth habit
     examples:
-      - value: spreading
+    - value: spreading
     keywords:
-      - growth
+    - growth
     slot_uri: MIXS:0001044
     range: GrowthHabitEnum
   growth_hormone_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: growth hormone name;growth hormone amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Expected_value: growth hormone name;growth hormone amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of growth hormones; should
       include the name of growth hormone, amount administered, treatment regimen including
       how many times the treatment was repeated, how long each treatment lasted, and
@@ -7952,10 +7620,10 @@ slots:
       hormone regimens
     title: growth hormone regimen
     examples:
-      - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - growth
-      - regimen
+    - growth
+    - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000560
     multivalued: true
@@ -7965,9 +7633,9 @@ slots:
       Thesaurus).  The name of the medium used to grow the microorganism
     title: growth medium
     examples:
-      - value: LB broth
+    - value: LB broth
     keywords:
-      - growth
+    - growth
     slot_uri: MIXS:0001108
     range: string
   gynecologic_disord:
@@ -7976,7 +7644,7 @@ slots:
       female reproductive system disease (https://disease-ontology.org/?id=DOID:229)
     title: gynecological disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000288
     multivalued: true
     range: string
@@ -7984,16 +7652,16 @@ slots:
     description: The total count of hallways and cooridors in the built structure
     title: hallway/corridor count
     keywords:
-      - corridor
-      - count
-      - hallway
+    - corridor
+    - count
+    - hallway
     slot_uri: MIXS:0000228
     range: integer
   handidness:
     description: The handidness of the individual sampled
     title: handidness
     examples:
-      - value: right handedness
+    - value: right handedness
     slot_uri: MIXS:0000809
     range: HandidnessEnum
   hc_produced:
@@ -8001,10 +7669,10 @@ slots:
       etc). If "other" is specified, please propose entry in "additional info" field
     title: hydrocarbon type produced
     examples:
-      - value: Gas
+    - value: Gas
     keywords:
-      - hydrocarbon
-      - type
+    - hydrocarbon
+    - type
     slot_uri: MIXS:0000989
     range: HcProducedEnum
     required: true
@@ -8018,25 +7686,23 @@ slots:
       entry in "additional info" field
     title: hydrocarbon resource type
     examples:
-      - value: Oil Sand
+    - value: Oil Sand
     keywords:
-      - hydrocarbon
-      - resource
-      - type
+    - hydrocarbon
+    - resource
+    - type
     slot_uri: MIXS:0000988
     range: HcrEnum
     required: true
   hcr_fw_salinity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Original formation water salinity (prior to secondary recovery e.g.
       Waterflooding) expressed as TDS
     title: formation water salinity
     keywords:
-      - salinity
-      - water
+    - salinity
+    - water
     slot_uri: MIXS:0000406
     range: string
     recommended: true
@@ -8051,25 +7717,23 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: hydrocarbon resource geological age
     examples:
-      - value: Silurian
+    - value: Silurian
     keywords:
-      - age
-      - hydrocarbon
-      - resource
+    - age
+    - hydrocarbon
+    - resource
     slot_uri: MIXS:0000993
     range: GeolAgeEnum
     recommended: true
   hcr_pressure:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: atmosphere, kilopascal
+      Preferred_unit: atmosphere, kilopascal
     description: Original pressure of the hydrocarbon resource
     title: hydrocarbon resource original pressure
     keywords:
-      - hydrocarbon
-      - pressure
-      - resource
+    - hydrocarbon
+    - pressure
+    - resource
     slot_uri: MIXS:0000395
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -8079,17 +7743,15 @@ slots:
       partial_match: true
   hcr_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Original temperature of the hydrocarbon resource
     title: hydrocarbon resource original temperature
     examples:
-      - value: 150-295 degree Celsius
+    - value: 150-295 degree Celsius
     keywords:
-      - hydrocarbon
-      - resource
-      - temperature
+    - hydrocarbon
+    - resource
+    - temperature
     slot_uri: MIXS:0000393
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -8101,9 +7763,9 @@ slots:
     description: Methods of conditioning or heating a room or building
     title: heating and cooling system type
     examples:
-      - value: heat pump
+    - value: heat pump
     keywords:
-      - type
+    - type
     slot_uri: MIXS:0000766
     multivalued: true
     range: HeatCoolTypeEnum
@@ -8112,47 +7774,43 @@ slots:
     description: The location of heat delivery within the room
     title: heating delivery locations
     examples:
-      - value: north
+    - value: north
     keywords:
-      - delivery
-      - location
-      - locations
+    - delivery
+    - location
+    - locations
     slot_uri: MIXS:0000810
     range: CompassDirections8Enum
   heat_sys_deliv_meth:
     description: The method by which the heat is delivered through the system
     title: heating system delivery method
     examples:
-      - value: radiant
+    - value: radiant
     keywords:
-      - delivery
-      - method
+    - delivery
+    - method
     slot_uri: MIXS:0000812
     range: HeatSysDelivMethEnum
   heat_system_id:
     description: The heating system identifier
     title: heating system identifier
     keywords:
-      - identifier
+    - identifier
     slot_uri: MIXS:0000833
     range: integer
   heavy_metals:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: heavy metal name;measurement value unit
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per gram
+      Expected_value: heavy metal name;measurement value unit
+      Preferred_unit: microgram per gram
     description: Heavy metals present in the sequenced sample and their concentrations.
       For multiple heavy metals and concentrations, add multiple copies of this field
     title: extreme_unusual_properties/heavy metals
     examples:
-      - value: mercury;0.09 micrograms per gram
+    - value: mercury;0.09 micrograms per gram
     keywords:
-      - extreme
-      - properties
-      - unusual
+    - extreme
+    - properties
+    - unusual
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000652
     multivalued: true
@@ -8160,10 +7818,10 @@ slots:
     description: Reference or method used in determining heavy metals
     title: extreme_unusual_properties/heavy metals method
     keywords:
-      - extreme
-      - method
-      - properties
-      - unusual
+    - extreme
+    - method
+    - properties
+    - unusual
     slot_uri: MIXS:0000343
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -8173,13 +7831,11 @@ slots:
       partial_match: true
   height_carper_fiber:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter
+      Preferred_unit: centimeter
     description: The average carpet fiber height in the indoor environment
     title: height carpet fiber mat
     keywords:
-      - height
+    - height
     slot_uri: MIXS:0000167
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8190,9 +7846,7 @@ slots:
       partial_match: true
   herbicide_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of herbicides; information
       about treatment involving use of growth hormones; should include the name of
       herbicide, amount administered, treatment regimen including how many times the
@@ -8200,9 +7854,9 @@ slots:
       time of the entire treatment; can include multiple regimens
     title: herbicide regimen
     examples:
-      - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
+    - regimen
     slot_uri: MIXS:0000561
     multivalued: true
     range: string
@@ -8210,8 +7864,8 @@ slots:
     description: Reference or method used in determining the horizon
     title: horizon method
     keywords:
-      - horizon
-      - method
+    - horizon
+    - method
     slot_uri: MIXS:0000321
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -8221,16 +7875,14 @@ slots:
       partial_match: true
   host_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: year, day, hour
+      Preferred_unit: year, day, hour
     description: Age of host at the time of sampling; relevant scale depends on species
       and study, e.g. Could be seconds for amoebae or centuries for trees
     title: host age
     keywords:
-      - age
-      - host
-      - host.
+    - age
+    - host
+    - host.
     slot_uri: MIXS:0000255
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8243,24 +7895,22 @@ slots:
     description: Original body habitat where the sample was obtained from
     title: host body habitat
     keywords:
-      - body
-      - habitat
-      - host
-      - host.
+    - body
+    - habitat
+    - host
+    - host.
     slot_uri: MIXS:0000866
     range: string
   host_body_mass_index:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram per square meter
+      Preferred_unit: kilogram per square meter
     description: Body mass index, calculated as weight/(height)squared
     title: host body-mass index
     examples:
-      - value: 22 kilogram per square meter
+    - value: 22 kilogram per square meter
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000317
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8271,49 +7921,43 @@ slots:
       partial_match: true
   host_body_product:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FMA or UBERON
+      Expected_value: FMA or UBERON
     description: Substance produced by the body, e.g. Stool, mucus, where the sample
       was obtained from. Use terms from the foundational model of anatomy ontology
       (fma) or Uber-anatomy ontology (UBERON)
     title: host body product
     examples:
-      - value: mucus [FMA:66938]
+    - value: mucus [FMA:66938]
     keywords:
-      - body
-      - host
-      - host.
-      - product
+    - body
+    - host
+    - host.
+    - product
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000888
   host_body_site:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FMA or UBERON
+      Expected_value: FMA or UBERON
     description: Name of body site where the sample was obtained from, such as a specific
       organ or tissue (tongue, lung etc...). Use terms from the foundational model
       of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
     title: host body site
     keywords:
-      - body
-      - host
-      - site
+    - body
+    - host
+    - site
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000867
   host_body_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Core body temperature of the host when sample was collected
     title: host body temperature
     keywords:
-      - body
-      - host
-      - host.
-      - temperature
+    - body
+    - host
+    - host.
+    - temperature
     slot_uri: MIXS:0000274
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8329,11 +7973,11 @@ slots:
       is localized outside of cells'
     title: host cellular location
     examples:
-      - value: extracellular
+    - value: extracellular
     keywords:
-      - host
-      - host.
-      - location
+    - host
+    - host.
+    - location
     slot_uri: MIXS:0001313
     range: HostCellularLocEnum
     recommended: true
@@ -8341,30 +7985,28 @@ slots:
     description: The color of host
     title: host color
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000260
     range: string
   host_common_name:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ''
+      Preferred_unit: ''
     description: Common name of the host
     title: host common name
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000248
     range: string
   host_dependence:
     description: Type of host dependence for the symbiotic host organism to its host
     title: host dependence
     examples:
-      - value: obligate
+    - value: obligate
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0001315
     range: HostDependenceEnum
     required: true
@@ -8373,45 +8015,41 @@ slots:
       etc., for humans high-fat, meditteranean etc.; can include multiple diet types
     title: host diet
     keywords:
-      - diet
-      - host
-      - host.
+    - diet
+    - host
+    - host.
     slot_uri: MIXS:0000869
     multivalued: true
     range: string
   host_disease_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: disease name or Disease Ontology term
+      Expected_value: disease name or Disease Ontology term
     description: List of diseases with which the host has been diagnosed; can include
       multiple diagnoses. The value of the field depends on host; for humans the terms
       should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org,
       non-human host diseases are free text
     title: host disease status
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - disease
-      - host
-      - host.
-      - status
+    - disease
+    - host
+    - host.
+    - status
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000031
   host_dry_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Preferred_unit: kilogram, gram
     description: Measurement of dry mass
     title: host dry mass
     examples:
-      - value: 500 gram
+    - value: 500 gram
     keywords:
-      - dry
-      - host
-      - host.
-      - mass
+    - dry
+    - host
+    - host.
+    - mass
     slot_uri: MIXS:0000257
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8422,17 +8060,15 @@ slots:
       partial_match: true
   host_fam_rel:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: relationship type;arbitrary identifier
+      Expected_value: relationship type;arbitrary identifier
     description: Relationships to other hosts in the same study; can include multiple
       relationships
     title: host family relationship
     keywords:
-      - family
-      - host
-      - host.
-      - relationship
+    - family
+    - host
+    - host.
+    - relationship
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0000872
     multivalued: true
@@ -8440,20 +8076,20 @@ slots:
     description: Observed genotype
     title: host genotype
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000365
     range: string
   host_growth_cond:
     description: Literature reference giving growth conditions of the host
     title: host growth conditions
     examples:
-      - value: https://academic.oup.com/icesjms/article/68/2/349/617247
+    - value: https://academic.oup.com/icesjms/article/68/2/349/617247
     keywords:
-      - condition
-      - growth
-      - host
-      - host.
+    - condition
+    - growth
+    - host
+    - host.
     slot_uri: MIXS:0000871
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -8463,15 +8099,13 @@ slots:
       partial_match: true
   host_height:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter, millimeter, meter
+      Preferred_unit: centimeter, millimeter, meter
     description: The height of subject
     title: host height
     keywords:
-      - height
-      - host
-      - host.
+    - height
+    - host
+    - host.
     slot_uri: MIXS:0000264
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8482,26 +8116,24 @@ slots:
       partial_match: true
   host_hiv_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: HIV status;HAART initiation status
+      Expected_value: HIV status;HAART initiation status
     description: HIV status of subject, if yes HAART initiation status should also
       be indicated as [YES or NO]
     title: host HIV status
     examples:
-      - value: yes;yes
+    - value: yes;yes
     keywords:
-      - host
-      - host.
-      - status
+    - host
+    - host.
+    - status
     string_serialization: '{boolean};{boolean}'
     slot_uri: MIXS:0000265
   host_infra_spec_name:
     description: Taxonomic information about the host below subspecies level
     title: host infra-specific name
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000253
     range: string
   host_infra_spec_rank:
@@ -8509,38 +8141,34 @@ slots:
       such as variety, form, rank etc
     title: host infra-specific rank
     keywords:
-      - host
-      - host.
-      - rank
+    - host
+    - host.
+    - rank
     slot_uri: MIXS:0000254
     range: string
   host_last_meal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: content;duration
+      Expected_value: content;duration
     description: Content of last meal and time since feeding; can include multiple
       values
     title: host last meal
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     string_serialization: '{text};{duration}'
     slot_uri: MIXS:0000870
     multivalued: true
   host_length:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter, millimeter, meter
+      Preferred_unit: centimeter, millimeter, meter
     description: The length of subject
     title: host length
     examples:
-      - value: 1 meter
+    - value: 1 meter
     keywords:
-      - host
-      - host.
-      - length
+    - host
+    - host.
+    - length
     slot_uri: MIXS:0000256
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8551,51 +8179,45 @@ slots:
       partial_match: true
   host_life_stage:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: stage
+      Expected_value: stage
     description: Description of life stage of host
     title: host life stage
     keywords:
-      - host
-      - host.
-      - life
+    - host
+    - host.
+    - life
     string_serialization: '{text}'
     slot_uri: MIXS:0000251
   host_number:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: count
+      Expected_value: count
     description: Number of symbiotic host individuals pooled at the time of collection
     title: host number individual
     examples:
-      - value: '3'
+    - value: '3'
     keywords:
-      - host
-      - host.
-      - number
+    - host
+    - host.
+    - number
     string_serialization: '{float} m'
     slot_uri: MIXS:0001305
   host_occupation:
     description: Most frequent job performed by subject
     title: host occupation
     comments:
-      - Couldn't convert host_occupation with value veterinary to integer
-      - almost all host_occupation values in the NCBI biosample_set are strings, not
-        integers
+    - Couldn't convert host_occupation with value veterinary to integer
+    - almost all host_occupation values in the NCBI biosample_set are strings, not
+      integers
     examples:
-      - value: veterinary
+    - value: veterinary
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000896
     range: string
   host_of_host_coinf:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: species name of coinfecting organism(s)
+      Expected_value: species name of coinfecting organism(s)
     description: The taxonomic name of any coinfecting organism observed in a symbiotic
       relationship with the host of the sampled host organism. e.g. where a sample
       collected from a host trematode species (A) which was collected from a host_of_host
@@ -8605,40 +8227,36 @@ slots:
       with the host (A) use the term Observed host symbiont
     title: observed coinfecting organisms in host of host
     examples:
-      - value: Maritrema novaezealandense
+    - value: Maritrema novaezealandense
     keywords:
-      - host
-      - host.
-      - observed
-      - organism
+    - host
+    - host.
+    - observed
+    - organism
     string_serialization: '{text}'
     slot_uri: MIXS:0001310
   host_of_host_disease:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: disease name or Disease Ontology term
+      Expected_value: disease name or Disease Ontology term
     description: List of diseases with which the host of the symbiotic host organism
       has been diagnosed; can include multiple diagnoses. The value of the field depends
       on host; for humans the terms should be chosen from the DO (Human Disease Ontology)
       at https://www.disease-ontology.org, non-human host diseases are free text
     title: host of the symbiotic host disease status
     examples:
-      - value: rabies [DOID:11260]
+    - value: rabies [DOID:11260]
     keywords:
-      - disease
-      - host
-      - host.
-      - status
-      - symbiosis
+    - disease
+    - host
+    - host.
+    - status
+    - symbiosis
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0001319
     multivalued: true
   host_of_host_env_loc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: UBERON term(s), multiple values can be separated by pipes
+      Expected_value: UBERON term(s), multiple values can be separated by pipes
     description: For a symbiotic host organism the local anatomical environment within
       its host may have causal influences. Report the anatomical entity(s) which are
       in the direct environment of the symbiotic host organism being sampled and which
@@ -8647,21 +8265,19 @@ slots:
       its local environmental context will be the term for intestine from UBERON (http://uberon.github.io/)
     title: host of the symbiotic host local environmental context
     examples:
-      - value: small intestine[uberon:0002108]
+    - value: small intestine[uberon:0002108]
     keywords:
-      - context
-      - environmental
-      - host
-      - host.
-      - symbiosis
+    - context
+    - environmental
+    - host
+    - host.
+    - symbiosis
     string_serialization: small intestine [UBERON:0002108]
     slot_uri: MIXS:0001325
     multivalued: true
   host_of_host_env_med:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: An ontology term for a material such as a tissue type or excreted substance
+      Expected_value: An ontology term for a material such as a tissue type or excreted substance
     description: 'Report the environmental material(s) immediately surrounding the
       symbiotic host organism at the time of sampling. This usually will be a tissue
       or substance type from the host, but may be another material if the symbiont
@@ -8675,29 +8291,27 @@ slots:
       discrete, countable entities (e.g. intestines, heart)'
     title: host of the symbiotic host environemental medium
     examples:
-      - value: feces[uberon:0001988]
+    - value: feces[uberon:0001988]
     keywords:
-      - environmental
-      - host
-      - host.
-      - symbiosis
+    - environmental
+    - host
+    - host.
+    - symbiosis
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001326
   host_of_host_fam_rel:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: relationship type;arbitrary identifier
+      Expected_value: relationship type;arbitrary identifier
     description: Familial relationship of the host of the symbiotic host organisms
       to other hosts of symbiotic host organism in the same study; can include multiple
       relationships
     title: host of the symbiotic host family relationship
     keywords:
-      - family
-      - host
-      - host.
-      - relationship
-      - symbiosis
+    - family
+    - host
+    - host.
+    - relationship
+    - symbiosis
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0001328
     multivalued: true
@@ -8705,23 +8319,21 @@ slots:
     description: Observed genotype of the host of the symbiotic host organism
     title: host of the symbiotic host genotype
     keywords:
-      - host
-      - host.
-      - symbiosis
+    - host
+    - host.
+    - symbiosis
     slot_uri: MIXS:0001331
     range: string
   host_of_host_gravid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gravidity status;timestamp
+      Expected_value: gravidity status;timestamp
     description: Whether or not the host of the symbiotic host organism is gravid,
       and if yes date due or date post-conception, specifying which is used
     title: host of the symbiotic host gravidity
     keywords:
-      - host
-      - host.
-      - symbiosis
+    - host
+    - host.
+    - symbiosis
     string_serialization: '{boolean};{timestamp}'
     slot_uri: MIXS:0001333
   host_of_host_infname:
@@ -8729,9 +8341,9 @@ slots:
       below subspecies level
     title: host of the symbiotic host infra-specific name
     keywords:
-      - host
-      - host.
-      - symbiosis
+    - host
+    - host.
+    - symbiosis
     slot_uri: MIXS:0001329
     range: string
   host_of_host_infrank:
@@ -8739,35 +8351,33 @@ slots:
       below subspecies level, such as variety, form, rank etc
     title: host of the symbiotic host infra-specific rank
     keywords:
-      - host
-      - host.
-      - rank
-      - symbiosis
+    - host
+    - host.
+    - rank
+    - symbiosis
     slot_uri: MIXS:0001330
     range: string
   host_of_host_name:
     description: Common name of the host of the symbiotic host organism
     title: host of the symbiotic host common name
     examples:
-      - value: snail
+    - value: snail
     keywords:
-      - host
-      - host.
-      - symbiosis
+    - host
+    - host.
+    - symbiosis
     slot_uri: MIXS:0001324
     range: string
   host_of_host_pheno:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: phenotype of the host of the symbiotic organism; PATO
+      Expected_value: phenotype of the host of the symbiotic organism; PATO
     description: Phenotype of the host of the symbiotic host organism. For phenotypic
       quality ontology (PATO) terms, see http://purl.bioontology.org/ontology/pato
     title: host of the symbiotic host phenotype
     keywords:
-      - host
-      - host.
-      - symbiosis
+    - host
+    - host.
+    - symbiosis
     string_serialization: '{term}'
     slot_uri: MIXS:0001332
   host_of_host_sub_id:
@@ -8775,29 +8385,27 @@ slots:
       subject can be referred to, de-identified, e.g. #H14'
     title: host of the symbiotic host subject id
     examples:
-      - value: H3
+    - value: H3
     keywords:
-      - host
-      - host.
-      - identifier
-      - symbiosis
+    - host
+    - host.
+    - identifier
+    - symbiosis
     slot_uri: MIXS:0001327
     range: string
   host_of_host_taxid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCBI taxon identifier of the host of the symbiotic taxon organism
+      Expected_value: NCBI taxon identifier of the host of the symbiotic taxon organism
     description: NCBI taxon id of the host of the symbiotic host organism
     title: host of the symbiotic host taxon id
     examples:
-      - value: '145637'
+    - value: '145637'
     keywords:
-      - host
-      - host.
-      - identifier
-      - symbiosis
-      - taxon
+    - host
+    - host.
+    - identifier
+    - symbiosis
+    - taxon
     string_serialization: '{integer}'
     slot_uri: MIXS:0001306
   host_of_host_totmass:
@@ -8805,11 +8413,11 @@ slots:
       the unit depends on the host
     title: host of the symbiotic host total mass
     keywords:
-      - host
-      - host.
-      - mass
-      - symbiosis
-      - total
+    - host
+    - host.
+    - mass
+    - symbiosis
+    - total
     slot_uri: MIXS:0001334
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8820,28 +8428,26 @@ slots:
       partial_match: true
   host_phenotype:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: PATO or HP
+      Expected_value: PATO or HP
     description: Phenotype of human or other host. Use terms from the phenotypic quality
       ontology (pato) or the Human Phenotype Ontology (HP)
     title: host phenotype
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000874
   host_pred_appr:
     description: Tool or approach used for host prediction
     title: host prediction approach
     examples:
-      - value: CRISPR spacer match
+    - value: CRISPR spacer match
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - host
-      - host.
-      - predict
+    - host
+    - host.
+    - predict
     slot_uri: MIXS:0000088
     range: HostPredApprEnum
   host_pred_est_acc:
@@ -8849,28 +8455,26 @@ slots:
       discovery rates should be included, either computed de novo or from the literature
     title: host prediction estimated accuracy
     examples:
-      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
+    - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
         genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - host
-      - host.
-      - predict
+    - host
+    - host.
+    - predict
     slot_uri: MIXS:0000089
     range: string
   host_pulse:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: beats per minute
+      Preferred_unit: beats per minute
     description: Resting pulse, measured as beats per minute
     title: host pulse
     examples:
-      - value: 65 beats per minute
+    - value: 65 beats per minute
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000333
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8881,17 +8485,15 @@ slots:
       partial_match: true
   host_sex:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Gender or physical sex of the host
     title: host sex
     comments:
-      - example of non-binary from Excel sheets does not match any of the enumerated
-        values
+    - example of non-binary from Excel sheets does not match any of the enumerated
+      values
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     string_serialization: '[female|hermaphrodite|non-binary|male|transgender|transgender
       (female to male)|transgender (male to female)
 
@@ -8901,28 +8503,26 @@ slots:
     description: Morphological shape of host
     title: host shape
     examples:
-      - value: round
+    - value: round
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000261
     range: string
   host_spec_range:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCBI taxid
+      Expected_value: NCBI taxid
     description: The range and diversity of host species that an organism is capable
       of infecting, defined by NCBI taxonomy identifier
     title: host specificity or range
     examples:
-      - value: '9606'
+    - value: '9606'
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - host
-      - host.
-      - range
+    - host
+    - host.
+    - range
     string_serialization: '{integer}'
     slot_uri: MIXS:0000030
     multivalued: true
@@ -8931,10 +8531,10 @@ slots:
       (symbiont able to establish associations with distantly related hosts) or species-specific'
     title: host specificity
     examples:
-      - value: species-specific
+    - value: species-specific
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0001308
     range: HostSpecificityEnum
     recommended: true
@@ -8942,16 +8542,14 @@ slots:
     description: A unique identifier by which each subject can be referred to, de-identified
     title: host subject id
     keywords:
-      - host
-      - host.
-      - identifier
+    - host
+    - host.
+    - identifier
     slot_uri: MIXS:0000861
     range: string
   host_subspecf_genlin:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
+      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
           e.g. serovar, biotype, ecotype, variety, cultivar
     description: Information about the genetic distinctness of the host organism below
       the subspecies level e.g., serovar, serotype, biotype, ecotype, variety, cultivar,
@@ -8960,11 +8558,11 @@ slots:
       name and the lineage rank separated by a colon, e.g., biovar:abc123
     title: host subspecific genetic lineage
     examples:
-      - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
+    - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
     keywords:
-      - host
-      - host.
-      - lineage
+    - host
+    - host.
+    - lineage
     string_serialization: '{rank name}:{text}'
     slot_uri: MIXS:0001318
     multivalued: true
@@ -8972,54 +8570,48 @@ slots:
     description: The growth substrate of the host
     title: host substrate
     examples:
-      - value: rock
+    - value: rock
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000252
     range: string
   host_symbiont:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: species name or common name
+      Expected_value: species name or common name
     description: The taxonomic name of the organism(s) found living in mutualistic,
       commensalistic, or parasitic symbiosis with the specific host. The sampled symbiont
       can have its own symbionts. For example, parasites may have hyperparasites (=parasites
       of the parasite)
     title: observed host symbionts
     keywords:
-      - host
-      - host.
-      - observed
-      - symbiosis
+    - host
+    - host.
+    - observed
+    - symbiosis
     string_serialization: '{text}'
     slot_uri: MIXS:0001298
     multivalued: true
   host_taxid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCBI taxon identifier
+      Expected_value: NCBI taxon identifier
     description: NCBI taxon id of the host, e.g. 9606
     title: host taxid
     keywords:
-      - host
-      - host.
-      - taxon
+    - host
+    - host.
+    - taxon
     slot_uri: MIXS:0000250
   host_tot_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Preferred_unit: kilogram, gram
     description: Total mass of the host at collection, the unit depends on host
     title: host total mass
     keywords:
-      - host
-      - host.
-      - mass
-      - total
+    - host
+    - host.
+    - mass
+    - total
     slot_uri: MIXS:0000263
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9030,18 +8622,16 @@ slots:
       partial_match: true
   host_wet_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Preferred_unit: kilogram, gram
     description: Measurement of wet mass
     title: host wet mass
     examples:
-      - value: 1500 gram
+    - value: 1500 gram
     keywords:
-      - host
-      - host.
-      - mass
-      - wet
+    - host
+    - host.
+    - mass
+    - wet
     slot_uri: MIXS:0000567
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9055,14 +8645,14 @@ slots:
       date
     title: HRT
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000969
     range: datetime
   humidity:
     description: Amount of water vapour in the air, at the time of sampling
     title: humidity
     keywords:
-      - humidity
+    - humidity
     slot_uri: MIXS:0000100
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9073,12 +8663,8 @@ slots:
       partial_match: true
   humidity_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: humidity value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per cubic meter
+      Expected_value: humidity value;treatment interval and duration
+      Preferred_unit: gram per cubic meter
     description: Information about treatment involving an exposure to varying degree
       of humidity; information about treatment involving use of growth hormones; should
       include amount of humidity administered, treatment regimen including how many
@@ -9086,18 +8672,16 @@ slots:
       and end time of the entire treatment; can include multiple regimens
     title: humidity regimen
     examples:
-      - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - humidity
-      - regimen
+    - humidity
+    - regimen
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000568
     multivalued: true
   hygienic_area:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Expected value
+      Expected_value: Expected value
     description: The subdivision of areas within a food production facility according
       to hygienic requirements. This field accepts terms listed under hygienic food
       production area (http://purl.obolibrary.org/obo/ENVO). Please add a term that
@@ -9105,27 +8689,27 @@ slots:
       to the definitions provided
     title: hygienic food production area
     examples:
-      - value: Low Hygiene Area
+    - value: Low Hygiene Area
     keywords:
-      - area
-      - food
-      - production
+    - area
+    - food
+    - production
     string_serialization: '{text}'
     slot_uri: MIXS:0001253
   hysterectomy:
     description: Specification of whether hysterectomy was performed
     title: hysterectomy
     examples:
-      - value: 'no'
+    - value: 'no'
     slot_uri: MIXS:0000287
     range: boolean
   ihmc_medication_code:
     description: Can include multiple medication codes
     title: IHMC medication code
     examples:
-      - value: '810'
+    - value: '810'
     keywords:
-      - code
+    - code
     slot_uri: MIXS:0000884
     multivalued: true
     range: integer
@@ -9134,9 +8718,9 @@ slots:
       discrete areas of a building is used
     title: indoor space
     examples:
-      - value: foyer
+    - value: foyer
     keywords:
-      - indoor
+    - indoor
     slot_uri: MIXS:0000763
     range: IndoorSpaceEnum
     required: true
@@ -9144,22 +8728,20 @@ slots:
     description: Type of indoor surface
     title: indoor surface
     examples:
-      - value: wall
+    - value: wall
     keywords:
-      - indoor
-      - surface
+    - indoor
+    - surface
     slot_uri: MIXS:0000764
     range: IndoorSurfEnum
   indust_eff_percent:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Percentage of industrial effluents received by wastewater treatment
       plant
     title: industrial effluent percent
     keywords:
-      - percent
+    - percent
     slot_uri: MIXS:0000662
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9170,31 +8752,25 @@ slots:
       partial_match: true
   inorg_particles:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: inorganic particle name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mole per liter, milligram per liter
+      Expected_value: inorganic particle name;measurement value
+      Preferred_unit: mole per liter, milligram per liter
     description: Concentration of particles such as sand, grit, metal particles, ceramics,
       etc.; can include multiple particles
     title: inorganic particles
     keywords:
-      - inorganic
-      - particle
+    - inorganic
+    - particle
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000664
     multivalued: true
   inside_lux:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilowatt per square metre
+      Preferred_unit: kilowatt per square metre
     description: The recorded value at sampling time (power density)
     title: inside lux light
     keywords:
-      - inside
-      - light
+    - inside
+    - light
     slot_uri: MIXS:0000168
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9208,26 +8784,24 @@ slots:
       or video preferred; use drawings to indicate location of damaged areas
     title: interior wall condition
     examples:
-      - value: damaged
+    - value: damaged
     keywords:
-      - condition
-      - interior
-      - wall
+    - condition
+    - interior
+    - wall
     slot_uri: MIXS:0000813
     range: DamagedEnum
   intended_consumer:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON_03510136 or NCBI taxid
+      Expected_value: FOODON_03510136 or NCBI taxid
     description: Food consumer type, human or animal, for which the food product is
       produced and marketed. This field accepts terms listed under food consumer group
       (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
     title: intended consumer
     examples:
-      - value: 9606 o rsenior as food consumer [FOODON:03510254]
+    - value: 9606 o rsenior as food consumer [FOODON:03510254]
     keywords:
-      - consumer
+    - consumer
     string_serialization: '{integer}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001144
     multivalued: true
@@ -9237,13 +8811,13 @@ slots:
       the organism/material
     title: isolation and growth condition
     examples:
-      - value: doi:10.1016/j.syapm.2018.01.009
+    - value: doi:10.1016/j.syapm.2018.01.009
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - condition
-      - growth
-      - isolation
+    - condition
+    - growth
+    - isolation
     slot_uri: MIXS:0000003
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9256,28 +8830,26 @@ slots:
       and/or tertiary recovery
     title: injection water breakthrough date of specific well
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     keywords:
-      - date
-      - water
+    - date
+    - water
     slot_uri: MIXS:0001010
     range: datetime
   iwf:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: Proportion of the produced fluids derived from injected water at
       the time of sampling. (e.g. 87%)
     title: injection water fraction
     comments:
-      - pattern was "[0-9]*\\.?[0-9]+ ?%"
-      - percent or float?
+    - pattern was "[0-9]*\\.?[0-9]+ ?%"
+    - percent or float?
     examples:
-      - value: '0.79'
+    - value: '0.79'
     keywords:
-      - fraction
-      - water
+    - fraction
+    - water
     slot_uri: MIXS:0000455
     range: float
     required: true
@@ -9293,7 +8865,7 @@ slots:
       kidney disease (https://disease-ontology.org/?id=DOID:557)
     title: urine/kidney disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000277
     multivalued: true
     range: string
@@ -9301,26 +8873,24 @@ slots:
     description: The last time the floor was cleaned (swept, mopped, vacuumed)
     title: last time swept/mopped/vacuumed
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     keywords:
-      - time
+    - time
     slot_uri: MIXS:0000814
     range: datetime
   lat_lon:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: decimal degrees,  limit to 8 decimal points
+      Expected_value: decimal degrees,  limit to 8 decimal points
     description: The geographical origin of the sample as defined by latitude and
       longitude. The values should be reported in decimal degrees and in WGS84 system
     title: geographic location (latitude and longitude)
     examples:
-      - value: 50.586825 6.408977
+    - value: 50.586825 6.408977
     in_subset:
-      - environment
+    - environment
     keywords:
-      - geographic
-      - location
+    - geographic
+    - location
     string_serialization: '{float} {float}'
     slot_uri: MIXS:0000009
     required: true
@@ -9334,94 +8904,86 @@ slots:
       of reads
     title: library layout
     examples:
-      - value: paired
+    - value: paired
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - library
+    - library
     slot_uri: MIXS:0000041
     range: LibLayoutEnum
   lib_reads_seqd:
     description: Total number of clones sequenced from the library
     title: library reads sequenced
     examples:
-      - value: '20'
+    - value: '20'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - library
+    - library
     slot_uri: MIXS:0000040
     range: integer
   lib_screen:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: screening strategy name
+      Expected_value: screening strategy name
     description: Specific enrichment or screening methods applied before and/or after
       creating libraries
     title: library screening strategy
     examples:
-      - value: enriched, screened, normalized
+    - value: enriched, screened, normalized
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - library
+    - library
     string_serialization: '{text}'
     slot_uri: MIXS:0000043
   lib_size:
     description: Total number of clones in the library prepared for the project
     title: library size
     examples:
-      - value: '50'
+    - value: '50'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - library
-      - size
+    - library
+    - size
     slot_uri: MIXS:0000039
     range: integer
   lib_vector:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: vector
+      Expected_value: vector
     description: Cloning vector type(s) used in construction of libraries
     title: library vector
     examples:
-      - value: Bacteriophage P1
+    - value: Bacteriophage P1
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - library
+    - library
     string_serialization: '{text}'
     slot_uri: MIXS:0000042
   library_prep_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name of library preparation kit
+      Expected_value: name of library preparation kit
     description: Packaged kits (containing adapters, indexes, enzymes, buffers etc.),
       tailored for specific sequencing workflows, which allow the simplified preparation
       of sequencing-ready libraries for small genomes, amplicons, and plasmids
     title: library preparation kit
     keywords:
-      - kit
-      - library
-      - preparation
+    - kit
+    - library
+    - preparation
     string_serialization: '{text}'
     slot_uri: MIXS:0001145
   light_intensity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: lux
+      Preferred_unit: lux
     description: Measurement of light intensity
     title: light intensity
     examples:
-      - value: 0.3 lux
+    - value: 0.3 lux
     keywords:
-      - intensity
-      - light
+    - intensity
+    - light
     slot_uri: MIXS:0000706
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9432,20 +8994,16 @@ slots:
       partial_match: true
   light_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: exposure type;light intensity;light quality
-      Preferred_unit:
-        tag: Preferred_unit
-        value: lux; micrometer, nanometer, angstrom
+      Expected_value: exposure type;light intensity;light quality
+      Preferred_unit: lux; micrometer, nanometer, angstrom
     description: Information about treatment(s) involving exposure to light, including
       both light intensity and quality
     title: light regimen
     examples:
-      - value: incandescant light;10 lux;450 nanometer
+    - value: incandescant light;10 lux;450 nanometer
     keywords:
-      - light
-      - regimen
+    - light
+    - regimen
     string_serialization: '{text};{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000569
   light_type:
@@ -9455,10 +9013,10 @@ slots:
       include absence of light
     title: light type
     examples:
-      - value: desk lamp
+    - value: desk lamp
     keywords:
-      - light
-      - type
+    - light
+    - type
     slot_uri: MIXS:0000769
     multivalued: true
     range: LightTypeEnum
@@ -9467,7 +9025,7 @@ slots:
     description: Link to additional analysis results performed on the sample
     title: links to additional analysis
     keywords:
-      - link
+    - link
     slot_uri: MIXS:0000340
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9477,23 +9035,21 @@ slots:
       partial_match: true
   link_class_info:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: PMID,DOI or url
+      Expected_value: PMID,DOI or url
     description: Link to digitized soil maps or other soil classification information
     title: link to classification information
     keywords:
-      - classification
-      - information
-      - link
+    - classification
+    - information
+    - link
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000329
   link_climate_info:
     description: Link to climate resource
     title: link to climate information
     keywords:
-      - information
-      - link
+    - information
+    - link
     slot_uri: MIXS:0000328
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9506,9 +9062,9 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: lithology
     examples:
-      - value: Volcanic
+    - value: Volcanic
     keywords:
-      - lithology
+    - lithology
     slot_uri: MIXS:0000990
     range: LithologyEnum
     recommended: true
@@ -9518,27 +9074,25 @@ slots:
       liver disease (https://disease-ontology.org/?id=DOID:409)
     title: liver disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000282
     multivalued: true
     range: string
   local_class:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: local classification name
+      Expected_value: local classification name
     description: Soil classification based on local soil classification system
     title: soil_taxonomic/local classification
     keywords:
-      - classification
+    - classification
     string_serialization: '{text}'
     slot_uri: MIXS:0000330
   local_class_meth:
     description: Reference or method used in determining the local soil classification
     title: soil_taxonomic/local classification method
     keywords:
-      - classification
-      - method
+    - classification
+    - method
     slot_uri: MIXS:0000331
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9548,9 +9102,7 @@ slots:
       partial_match: true
   lot_number:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: lot number, item
+      Expected_value: lot number, item
     description: 'A distinctive alpha-numeric identification code assigned by the
       manufacturer or distributor to a specific quantity of manufactured material
       or product within a batch. Synonym: Batch Number.  The submitter should provide
@@ -9558,9 +9110,9 @@ slots:
       provided'
     title: lot number
     examples:
-      - value: 1239ABC01A, split Cornish hens
+    - value: 1239ABC01A, split Cornish hens
     keywords:
-      - number
+    - number
     string_serialization: '{integer}, {text}'
     slot_uri: MIXS:0001147
     multivalued: true
@@ -9569,23 +9121,21 @@ slots:
       as a binning parameter in the extraction of genomes from metagenomic datasets
     title: MAG coverage software
     examples:
-      - value: bbmap
+    - value: bbmap
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     slot_uri: MIXS:0000080
     range: MagCovSoftwareEnum
   magnesium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mole per liter, milligram per liter, parts per million, micromole per
+      Preferred_unit: mole per liter, milligram per liter, parts per million, micromole per
           kilogram
     description: Concentration of magnesium in the sample
     title: magnesium
     examples:
-      - value: 52.8 micromole per kilogram
+    - value: 52.8 micromole per kilogram
     slot_uri: MIXS:0000431
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9598,14 +9148,14 @@ slots:
     description: Specification of the maternal health status
     title: amniotic fluid/maternal health status
     keywords:
-      - status
+    - status
     slot_uri: MIXS:0000273
     range: string
   max_occup:
     description: The maximum amount of people allowed in the indoor environment
     title: maximum occupancy
     keywords:
-      - maximum
+    - maximum
     slot_uri: MIXS:0000229
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -9615,16 +9165,14 @@ slots:
       partial_match: true
   mean_frict_vel:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter per second
+      Preferred_unit: meter per second
     description: Measurement of mean friction velocity
     title: mean friction velocity
     examples:
-      - value: 0.5 meter per second
+    - value: 0.5 meter per second
     keywords:
-      - mean
-      - velocity
+    - mean
+    - velocity
     slot_uri: MIXS:0000498
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9635,17 +9183,15 @@ slots:
       partial_match: true
   mean_peak_frict_vel:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter per second
+      Preferred_unit: meter per second
     description: Measurement of mean peak friction velocity
     title: mean peak friction velocity
     examples:
-      - value: 1 meter per second
+    - value: 1 meter per second
     keywords:
-      - mean
-      - peak
-      - velocity
+    - mean
+    - peak
+    - velocity
     slot_uri: MIXS:0000502
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9658,19 +9204,17 @@ slots:
     description: 'mechanical structure: a moving structure'
     title: mechanical structure
     examples:
-      - value: elevator
+    - value: elevator
     slot_uri: MIXS:0000815
     range: MechStrucEnum
   mechanical_damage:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: damage type;body site
+      Expected_value: damage type;body site
     description: Information about any mechanical damage exerted on the plant; can
       include multiple damages and sites
     title: mechanical damage
     examples:
-      - value: pruning;bark
+    - value: pruning;bark
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0001052
     multivalued: true
@@ -9678,30 +9222,28 @@ slots:
     description: Whether full medical history was collected
     title: medical history performed
     examples:
-      - value: '1'
+    - value: '1'
     keywords:
-      - history
+    - history
     slot_uri: MIXS:0000897
     range: boolean
   menarche:
     description: Date of most recent menstruation
     title: menarche
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000965
     range: datetime
   menopause:
     description: Date of onset of menopause
     title: menopause
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000968
     range: datetime
   methane:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, parts per billion, parts per million
+      Preferred_unit: micromole per liter, parts per billion, parts per million
     description: Methane (gas) amount or concentration at the time of sampling
     title: methane
     slot_uri: MIXS:0000101
@@ -9716,13 +9258,13 @@ slots:
     description: Reference or method used in determining microbial biomass
     title: microbial biomass method
     comments:
-      - slot name/scn was microbial_biomass_meth
+    - slot name/scn was microbial_biomass_meth
     examples:
-      - value: http://dx.doi.org/10.1016/j.soilbio.2005.01.021
+    - value: http://dx.doi.org/10.1016/j.soilbio.2005.01.021
     keywords:
-      - biomass
-      - method
-      - microbial
+    - biomass
+    - method
+    - microbial
     slot_uri: MIXS:0000339
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9738,10 +9280,10 @@ slots:
       not listed please use text to describe the culture medium
     title: microbiological culture medium
     examples:
-      - value: brain heart infusion agar [MICRO:0000566]
+    - value: brain heart infusion agar [MICRO:0000566]
     keywords:
-      - culture
-      - microbiological
+    - culture
+    - microbiological
     slot_uri: MIXS:0001216
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
@@ -9751,26 +9293,20 @@ slots:
       partial_match: true
   microb_start:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03544453
+      Expected_value: FOODON:03544453
     description: Any type of microorganisms used in food production.  This field accepts
       terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
     title: microbial starter
     examples:
-      - value: starter cultures [FOODON:03544454]
+    - value: starter cultures [FOODON:03544454]
     keywords:
-      - microbial
+    - microbial
     string_serialization: '{term label} [{termID}]|{text}'
     slot_uri: MIXS:0001217
   microb_start_count:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: organism name; measurement value; enumeration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: colony forming units per milliliter; colony forming units per gram
+      Expected_value: organism name; measurement value; enumeration
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram
           of dry weight
     description: 'Total cell count of starter culture per gram, volume or area of
       sample and the method that was used for the enumeration (e.g. qPCR, atp, mpn,
@@ -9778,24 +9314,22 @@ slots:
       ml; qPCR)'
     title: microbial starter organism count
     examples:
-      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
+    - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
     keywords:
-      - count
-      - microbial
-      - organism
+    - count
+    - microbial
+    - organism
     string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|spread plate|other]'
     slot_uri: MIXS:0001218
   microb_start_inoc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram or gram
+      Preferred_unit: milligram or gram
     description: The amount of starter culture used to inoculate a new batch
     title: microbial starter inoculation
     examples:
-      - value: 100 milligrams
+    - value: 100 milligrams
     keywords:
-      - microbial
+    - microbial
     slot_uri: MIXS:0001219
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9809,10 +9343,10 @@ slots:
       inoculum
     title: microbial starter preparation
     examples:
-      - value: liquid starter culture, propagated 3 cycles in milk prior to inoculation
+    - value: liquid starter culture, propagated 3 cycles in milk prior to inoculation
     keywords:
-      - microbial
-      - preparation
+    - microbial
+    - preparation
     slot_uri: MIXS:0001220
     range: string
   microb_start_source:
@@ -9820,10 +9354,10 @@ slots:
       commercially supplied, list supplier
     title: microbial starter source
     examples:
-      - value: backslopped, GetCulture
+    - value: backslopped, GetCulture
     keywords:
-      - microbial
-      - source
+    - microbial
+    - source
     slot_uri: MIXS:0001221
     range: string
   microb_start_taxID:
@@ -9832,12 +9366,12 @@ slots:
       two or more microbes
     title: microbial starter NCBI taxonomy ID
     examples:
-      - value: Lactobacillus rhamnosus [NCIT:C123495]
+    - value: Lactobacillus rhamnosus [NCIT:C123495]
     keywords:
-      - identifier
-      - microbial
-      - ncbi
-      - taxon
+    - identifier
+    - microbial
+    - ncbi
+    - taxon
     slot_uri: MIXS:0001222
     range: string
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
@@ -9847,16 +9381,14 @@ slots:
       partial_match: true
   microbial_biomass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ton, kilogram, gram per kilogram soil
+      Preferred_unit: ton, kilogram, gram per kilogram soil
     description: The part of the organic matter in the soil that constitutes living
       microorganisms smaller than 5-10 micrometer. If you keep this, you would need
       to have correction factors used for conversion to the final units
     title: microbial biomass
     keywords:
-      - biomass
-      - microbial
+    - biomass
+    - microbial
     slot_uri: MIXS:0000650
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9871,11 +9403,11 @@ slots:
       be reported in uppercase letters
     title: multiplex identifiers
     examples:
-      - value: GTGAATAT
+    - value: GTGAATAT
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - identifier
+    - identifier
     slot_uri: MIXS:0000047
     range: string
     pattern: ^[ACGTRKSYMWBHDVN]+$
@@ -9885,13 +9417,9 @@ slots:
       partial_match: true
   mineral_nutr_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: mineral nutrient name;mineral nutrient amount;treatment interval and
+      Expected_value: mineral nutrient name;mineral nutrient amount;treatment interval and
           duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of mineral supplements;
       should include the name of mineral nutrient, amount administered, treatment
       regimen including how many times the treatment was repeated, how long each treatment
@@ -9899,26 +9427,24 @@ slots:
       mineral nutrient regimens
     title: mineral nutrient regimen
     examples:
-      - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - mineral
-      - nutrient
-      - regimen
+    - mineral
+    - nutrient
+    - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000570
     multivalued: true
   misc_param:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: parameter name;measurement value
+      Expected_value: parameter name;measurement value
     description: Any other measurement performed or parameter collected, that is not
       listed here
     title: miscellaneous parameter
     examples:
-      - value: Bicarbonate ion concentration;2075 micromole per kilogram
+    - value: Bicarbonate ion concentration;2075 micromole per kilogram
     keywords:
-      - parameter
+    - parameter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000752
     multivalued: true
@@ -9927,47 +9453,41 @@ slots:
       host from which it was sampled
     title: mode of transmission
     examples:
-      - value: horizontal:castrator
+    - value: horizontal:castrator
     slot_uri: MIXS:0001312
     range: ModeTransmissionEnum
     recommended: true
   n_alkanes:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: n-alkane name;measurement value
+      Expected_value: n-alkane name;measurement value
     description: Concentration of n-alkanes; can include multiple n-alkanes
     title: n-alkanes
     examples:
-      - value: n-hexadecane;100 milligram per liter
+    - value: n-hexadecane;100 milligram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000503
     multivalued: true
   neg_cont_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration or text
+      Expected_value: enumeration or text
     description: The substance or equipment used as a negative control in an investigation
     title: negative control type
     in_subset:
-      - investigation
+    - investigation
     keywords:
-      - type
+    - type
     slot_uri: MIXS:0001321
     range: NegContTypeEnum
     recommended: true
   nitrate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of nitrate in the sample
     title: nitrate
     examples:
-      - value: 65 micromole per liter
+    - value: 65 micromole per liter
     keywords:
-      - nitrate
+    - nitrate
     slot_uri: MIXS:0000425
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9978,15 +9498,13 @@ slots:
       partial_match: true
   nitrite:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of nitrite in the sample
     title: nitrite
     examples:
-      - value: 0.5 micromole per liter
+    - value: 0.5 micromole per liter
     keywords:
-      - nitrite
+    - nitrite
     slot_uri: MIXS:0000426
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9997,15 +9515,13 @@ slots:
       partial_match: true
   nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of nitrogen (total)
     title: nitrogen
     examples:
-      - value: 4.2 micromole per liter
+    - value: 4.2 micromole per liter
     keywords:
-      - nitrogen
+    - nitrogen
     slot_uri: MIXS:0000504
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10016,9 +9532,7 @@ slots:
       partial_match: true
   non_min_nutr_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the exposure of plant to non-mineral
       nutrient such as oxygen, hydrogen or carbon; should include the name of non-mineral
       nutrient, amount administered, treatment regimen including how many times the
@@ -10026,11 +9540,11 @@ slots:
       time of the entire treatment; can include multiple non-mineral nutrient regimens
     title: non-mineral nutrient regimen
     examples:
-      - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
+    - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
     keywords:
-      - non-mineral
-      - nutrient
-      - regimen
+    - non-mineral
+    - nutrient
+    - regimen
     slot_uri: MIXS:0000571
     multivalued: true
     range: string
@@ -10042,7 +9556,7 @@ slots:
       or upper respiratory tract disease (https://disease-ontology.org/?id=DOID:974)
     title: nose/mouth/teeth/throat disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000283
     multivalued: true
     range: string
@@ -10053,7 +9567,7 @@ slots:
       tract disease (https://disease-ontology.org/?id=DOID:974)
     title: nose throat disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000270
     multivalued: true
     range: string
@@ -10063,9 +9577,9 @@ slots:
       TMA, NASBA) of specific nucleic acids
     title: nucleic acid amplification
     examples:
-      - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
+    - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
     in_subset:
-      - sequencing
+    - sequencing
     slot_uri: MIXS:0000038
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -10079,9 +9593,9 @@ slots:
       the nucleic acid fraction from a sample
     title: nucleic acid extraction
     examples:
-      - value: https://mobio.com/media/wysiwyg/pdfs/protocols/12888.pdf
+    - value: https://mobio.com/media/wysiwyg/pdfs/protocols/12888.pdf
     in_subset:
-      - sequencing
+    - sequencing
     slot_uri: MIXS:0000037
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -10091,35 +9605,31 @@ slots:
       partial_match: true
   nucl_acid_ext_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: The name of an extraction kit
+      Expected_value: The name of an extraction kit
     description: The name of the extraction kit used to recover the nucleic acid fraction
       of an input material is performed
     title: nucleic acid extraction kit
     examples:
-      - value: Qiagen PowerSoil Kit
+    - value: Qiagen PowerSoil Kit
     keywords:
-      - kit
+    - kit
     string_serialization: '{text}'
     slot_uri: MIXS:0001223
     multivalued: true
   num_replicons:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses:
+      Expected_value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses:
           segments'
     description: Reports the number of replicons in a nuclear genome of eukaryotes,
       in the genome of a bacterium or archaea or the number of segments in a segmented
       virus. Always applied to the haploid chromosome count of a eukaryote
     title: number of replicons
     examples:
-      - value: '2'
+    - value: '2'
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - number
+    - number
     string_serialization: '{integer}'
     slot_uri: MIXS:0000022
     range: integer
@@ -10127,10 +9637,10 @@ slots:
     description: The number of samples collected during the current sampling event
     title: number of samples collected
     examples:
-      - value: 116 samples
+    - value: 116 samples
     keywords:
-      - number
-      - sample
+    - number
+    - sample
     slot_uri: MIXS:0001224
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10144,18 +9654,18 @@ slots:
       up a given genome, SAG, MAG, or UViG
     title: number of contigs
     examples:
-      - value: '40'
+    - value: '40'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - number
+    - number
     slot_uri: MIXS:0000060
     range: integer
   number_pets:
     description: The number of pets residing in the sampled space
     title: number of pets
     keywords:
-      - number
+    - number
     slot_uri: MIXS:0000231
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -10167,7 +9677,7 @@ slots:
     description: The number of plant(s) in the sampling space
     title: number of houseplants
     keywords:
-      - number
+    - number
     slot_uri: MIXS:0000230
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -10179,7 +9689,7 @@ slots:
     description: The number of individuals currently occupying in the sampling location
     title: number of residents
     keywords:
-      - number
+    - number
     slot_uri: MIXS:0000232
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -10191,9 +9701,9 @@ slots:
     description: Average number of occupants at time of sampling per square footage
     title: occupant density at sampling
     examples:
-      - value: '0.1'
+    - value: '0.1'
     keywords:
-      - density
+    - density
     slot_uri: MIXS:0000217
     range: float
     required: true
@@ -10201,16 +9711,16 @@ slots:
     description: The type of documentation of occupancy
     title: occupancy documentation
     examples:
-      - value: estimate
+    - value: estimate
     keywords:
-      - documentation
+    - documentation
     slot_uri: MIXS:0000816
     range: OccupDocumentEnum
   occup_samp:
     description: Number of occupants present at time of sample within the given space
     title: occupancy at sampling
     examples:
-      - value: '10'
+    - value: '10'
     slot_uri: MIXS:0000772
     range: float
     required: true
@@ -10223,10 +9733,10 @@ slots:
     description: Concentration of organic carbon
     title: organic carbon
     examples:
-      - value: 1.5 microgram per liter
+    - value: 1.5 microgram per liter
     keywords:
-      - carbon
-      - organic
+    - carbon
+    - organic
     slot_uri: MIXS:0000508
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10237,14 +9747,10 @@ slots:
       partial_match: true
   org_count_qpcr_info:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
+      Expected_value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
           denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
           elongation:degrees_minutes; total cycles
-      Preferred_unit:
-        tag: Preferred_unit
-        value: number of cells per gram (or ml or cm^2)
+      Preferred_unit: number of cells per gram (or ml or cm^2)
     description: 'If qpcr was used for the cell count, the target gene name, the primer
       sequence and the cycling conditions should also be provided. (Example: 16S rrna;
       FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min; denaturation:90C_2min;
@@ -10252,23 +9758,21 @@ slots:
       30 cycles)'
     title: organism count qPCR information
     keywords:
-      - count
-      - information
-      - organism
+    - count
+    - information
+    - organism
     string_serialization: '{text};FWD:{dna};REV:{dna};initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
       elongation:degrees_minutes; total cycles'
     slot_uri: MIXS:0000099
   org_matter:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter
+      Preferred_unit: microgram per liter
     description: Concentration of organic matter
     title: organic matter
     examples:
-      - value: 1.75 milligram per cubic meter
+    - value: 1.75 milligram per cubic meter
     keywords:
-      - organic
+    - organic
     slot_uri: MIXS:0000204
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10281,10 +9785,10 @@ slots:
     description: Concentration of organic nitrogen
     title: organic nitrogen
     examples:
-      - value: 4 micromole per liter
+    - value: 4 micromole per liter
     keywords:
-      - nitrogen
-      - organic
+    - nitrogen
+    - organic
     slot_uri: MIXS:0000205
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10295,100 +9799,86 @@ slots:
       partial_match: true
   org_particles:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: particle name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per liter
+      Expected_value: particle name;measurement value
+      Preferred_unit: gram per liter
     description: Concentration of particles such as faeces, hairs, food, vomit, paper
       fibers, plant material, humus, etc
     title: organic particles
     keywords:
-      - organic
-      - particle
+    - organic
+    - particle
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000665
     multivalued: true
   organism_count:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: organism name;measurement value;enumeration
+      Expected_value: organism name;measurement value;enumeration
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
       The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should
       also be provided. (example: total prokaryotes; 3.5e7 cells per ml; qpcr)'
     title: organism count
     keywords:
-      - count
-      - organism
+    - count
+    - organism
     string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|other]'
     slot_uri: MIXS:0000103
     multivalued: true
   otu_class_appr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: cutoffs and method used
+      Expected_value: cutoffs and method used
     description: Cutoffs and approach used when clustering  species-level  OTUs. Note
       that results from standard 95% ANI / 85% AF clustering should be provided alongside
       OTUS defined from another set of thresholds, even if the latter are the ones
       primarily used during the analysis
     title: OTU classification approach
     examples:
-      - value: 95% ANI;85% AF; greedy incremental clustering
+    - value: 95% ANI;85% AF; greedy incremental clustering
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - classification
-      - otu
+    - classification
+    - otu
     string_serialization: '{ANI cutoff};{AF cutoff};{clustering method}'
     slot_uri: MIXS:0000085
   otu_db:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: database and version
+      Expected_value: database and version
     description: Reference database (i.e. sequences not generated as part of the current
       study) used to cluster new genomes in "species-level" OTUs, if any
     title: OTU database
     examples:
-      - value: NCBI Viral RefSeq;83
+    - value: NCBI Viral RefSeq;83
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - database
-      - otu
+    - database
+    - otu
     string_serialization: '{database};{version}'
     slot_uri: MIXS:0000087
   otu_seq_comp_appr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: software name, version and relevant parameters
+      Expected_value: software name, version and relevant parameters
     description: Tool and thresholds used to compare sequences when computing "species-level"
       OTUs
     title: OTU sequence comparison approach
     examples:
-      - value: 'blastn;2.6.0+;e-value cutoff: 0.001'
+    - value: 'blastn;2.6.0+;e-value cutoff: 0.001'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - otu
+    - otu
     string_serialization: '{software};{version};{parameters}'
     slot_uri: MIXS:0000086
   owc_tvdss:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Depth of the original oil water contact (OWC) zone (average) (m TVDSS)
     title: oil water contact depth
     keywords:
-      - depth
-      - oil
-      - water
+    - depth
+    - oil
+    - water
     slot_uri: MIXS:0000405
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10401,24 +9891,22 @@ slots:
     description: Oxygenation status of sample
     title: oxygenation status of sample
     examples:
-      - value: aerobic
+    - value: aerobic
     keywords:
-      - oxygen
-      - sample
-      - status
+    - oxygen
+    - sample
+    - status
     slot_uri: MIXS:0000753
     range: OxyStatSampEnum
   oxygen:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Oxygen (gas) amount or concentration at the time of sampling
     title: oxygen
     examples:
-      - value: 600 parts per million
+    - value: 600 parts per million
     keywords:
-      - oxygen
+    - oxygen
     slot_uri: MIXS:0000104
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10431,12 +9919,12 @@ slots:
     description: Concentration of particulate organic carbon
     title: particulate organic carbon
     examples:
-      - value: 1.92 micromole per liter
+    - value: 1.92 micromole per liter
     keywords:
-      - carbon
-      - organic
-      - particle
-      - particulate
+    - carbon
+    - organic
+    - particle
+    - particulate
     slot_uri: MIXS:0000515
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10447,18 +9935,16 @@ slots:
       partial_match: true
   part_org_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Concentration of particulate organic nitrogen
     title: particulate organic nitrogen
     examples:
-      - value: 0.3 micromole per liter
+    - value: 0.3 micromole per liter
     keywords:
-      - nitrogen
-      - organic
-      - particle
-      - particulate
+    - nitrogen
+    - organic
+    - particle
+    - particulate
     slot_uri: MIXS:0000719
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10469,97 +9955,81 @@ slots:
       partial_match: true
   part_plant_animal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03420116
+      Expected_value: FOODON:03420116
     description: The anatomical part of the organism being involved in food production
       or consumption; e.g., a carrot is the root of the plant (root vegetable). This
       field accepts terms listed under part of plant or animal (http://purl.obolibrary.org/obo/FOODON_03420116)
     title: part of plant or animal
     examples:
-      - value: chuck [FOODON:03530021]
+    - value: chuck [FOODON:03530021]
     keywords:
-      - animal
-      - plant
+    - animal
+    - plant
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001149
     multivalued: true
   particle_class:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: particle name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micrometer
+      Expected_value: particle name;measurement value
+      Preferred_unit: micrometer
     description: Particles are classified, based on their size, into six general categories:clay,
       silt, sand, gravel, cobbles, and boulders; should include amount of particle
       preceded by the name of the particle type; can include multiple values
     title: particle classification
     keywords:
-      - classification
-      - particle
+    - classification
+    - particle
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000206
     multivalued: true
   pathogenicity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names of organisms that the entity is pathogenic to
+      Expected_value: names of organisms that the entity is pathogenic to
     description: To what is the entity pathogenic
     title: known pathogenicity
     examples:
-      - value: human, animal, plant, fungi, bacteria
+    - value: human, animal, plant, fungi, bacteria
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     string_serialization: '{text}'
     slot_uri: MIXS:0000027
   pcr_cond:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
+      Expected_value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
           elongation:degrees_minutes;total cycles
     description: Description of reaction conditions and components of PCR in the form
       of 'initial denaturation:94degC_1.5min; annealing=...'
     title: pcr conditions
     examples:
-      - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
+    - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - condition
-      - pcr
+    - condition
+    - pcr
     string_serialization: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
       elongation:degrees_minutes;total cycles
     slot_uri: MIXS:0000049
   pcr_primers:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'FWD: forward primer sequence;REV:reverse primer sequence'
+      Expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
     description: PCR primers that were used to amplify the sequence of the targeted
       gene, locus or subfragment. This field should contain all the primers used for
       a single PCR reaction if multiple forward or reverse primers are present in
       a single PCR reaction. The primer sequence should be reported in uppercase letters
     title: pcr primers
     examples:
-      - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
+    - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - pcr
+    - pcr
     string_serialization: FWD:{dna};REV:{dna}
     slot_uri: MIXS:0000046
   permeability:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value range
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mD
+      Expected_value: measurement value range
+      Preferred_unit: mD
     description: 'Measure of the ability of a hydrocarbon resource to allow fluids
       to pass through it. (Additional information: https://en.wikipedia.org/wiki/Permeability_(earth_sciences))'
     title: permeability
@@ -10567,26 +10037,22 @@ slots:
     slot_uri: MIXS:0000404
   perturbation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: perturbation type name;perturbation interval and duration
+      Expected_value: perturbation type name;perturbation interval and duration
     description: Type of perturbation, e.g. chemical administration, physical disturbance,
       etc., coupled with perturbation regimen including how many times the perturbation
       was repeated, how long each perturbation lasted, and the start and end time
       of the entire perturbation period; can include multiple perturbation types
     title: perturbation
     examples:
-      - value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
+    - value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
     keywords:
-      - perturbation
+    - perturbation
     string_serialization: '{text};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000754
     multivalued: true
   pesticide_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of insecticides; should
       include the name of pesticide, amount administered, treatment regimen including
       how many times the treatment was repeated, how long each treatment lasted, and
@@ -10594,42 +10060,38 @@ slots:
       regimens
     title: pesticide regimen
     examples:
-      - value: pyrethrum;0.6 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: pyrethrum;0.6 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
+    - regimen
     slot_uri: MIXS:0000573
     multivalued: true
     range: string
   pet_farm_animal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: presence status;type of animal or pet
+      Expected_value: presence status;type of animal or pet
     description: Specification of presence of pets or farm animals in the environment
       of subject, if yes the animals should be specified; can include multiple animals
       present
     title: presence of pets or farm animals
     examples:
-      - value: yes; 5 cats
+    - value: yes; 5 cats
     keywords:
-      - animal
-      - farm
-      - presence
+    - animal
+    - farm
+    - presence
     string_serialization: '{boolean};{text}'
     slot_uri: MIXS:0000267
     multivalued: true
   petroleum_hydrocarb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of petroleum hydrocarbon
     title: petroleum hydrocarbon
     examples:
-      - value: 0.05 micromole per liter
+    - value: 0.05 micromole per liter
     keywords:
-      - hydrocarbon
-      - petroleum
+    - hydrocarbon
+    - petroleum
     slot_uri: MIXS:0000516
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10643,19 +10105,19 @@ slots:
       phase of the fluid
     title: pH
     examples:
-      - value: '7.2'
+    - value: '7.2'
     keywords:
-      - ph
+    - ph
     slot_uri: MIXS:0001001
     range: float
   ph_meth:
     description: Reference or method used in determining pH
     title: pH method
     examples:
-      - value: https://www.epa.gov/sites/production/files/2015-12/documents/9040c.pdf
+    - value: https://www.epa.gov/sites/production/files/2015-12/documents/9040c.pdf
     keywords:
-      - method
-      - ph
+    - method
+    - ph
     slot_uri: MIXS:0001106
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -10670,39 +10132,33 @@ slots:
       end time of the entire treatment; can include multiple regimen
     title: pH regimen
     examples:
-      - value: 7.6;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
+    - value: 7.6;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - ph
-      - regimen
+    - ph
+    - regimen
     slot_uri: MIXS:0001056
     multivalued: true
     range: string
   phaeopigments:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: phaeopigment name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter
+      Expected_value: phaeopigment name;measurement value
+      Preferred_unit: milligram per cubic meter
     description: Concentration of phaeopigments; can include multiple phaeopigments
     title: phaeopigments
     examples:
-      - value: 2.5 milligram per cubic meter
+    - value: 2.5 milligram per cubic meter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000180
     multivalued: true
   phosphate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of phosphate
     title: phosphate
     examples:
-      - value: 0.7 micromole per liter
+    - value: 0.7 micromole per liter
     keywords:
-      - phosphate
+    - phosphate
     slot_uri: MIXS:0000505
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10713,25 +10169,21 @@ slots:
       partial_match: true
   phosplipid_fatt_acid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: phospholipid fatty acid name;measurement value
+      Expected_value: phospholipid fatty acid name;measurement value
     description: Concentration of phospholipid fatty acids; can include multiple values
     title: phospholipid fatty acid
     examples:
-      - value: 2.98 milligram per liter
+    - value: 2.98 milligram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000181
     multivalued: true
   photon_flux:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: number of photons per second per unit area
+      Preferred_unit: number of photons per second per unit area
     description: Measurement of photon flux
     title: photon flux
     examples:
-      - value: 3.926 micromole photons per second per square meter
+    - value: 3.926 micromole photons per second per square meter
     slot_uri: MIXS:0000725
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10742,17 +10194,15 @@ slots:
       partial_match: true
   photosynt_activ:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mol m-2 s-1
+      Preferred_unit: mol m-2 s-1
     description: Measurement of photosythetic activity (i.e. leaf gas exchange / chlorophyll
       fluorescence emissions / reflectance / transpiration) Please also include the
       term method term detailing the method of activity measurement
     title: photosynthetic activity
     examples:
-      - value: 0.1 mol CO2 m-2 s-1
-        description: added a magnitude to the example from the XLSX file, " mol CO2
-          m-2 s-1"
+    - value: 0.1 mol CO2 m-2 s-1
+      description: added a magnitude to the example from the XLSX file, " mol CO2
+        m-2 s-1"
     slot_uri: MIXS:0001296
     range: string
     recommended: true
@@ -10766,7 +10216,7 @@ slots:
     description: Reference or method used in measurement of photosythetic activity
     title: photosynthetic activity method
     keywords:
-      - method
+    - method
     slot_uri: MIXS:0001336
     multivalued: true
     range: string
@@ -10778,9 +10228,7 @@ slots:
       partial_match: true
   plant_growth_med:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: EO or enumeration
+      Expected_value: EO or enumeration
     description: Specification of the media for growing the plants or tissue cultured
       samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in
       vitro liquid culture medium. Recommended value is a specific value from EO:plant
@@ -10788,39 +10236,35 @@ slots:
       or other controlled vocabulary
     title: plant growth medium
     keywords:
-      - growth
-      - plant
+    - growth
+    - plant
     string_serialization: '{termLabel} [{termID}] or [husk|other artificial liquid
       medium|other artificial solid medium|peat moss|perlite|pumice|sand|soil|vermiculite|water]'
     slot_uri: MIXS:0001057
   plant_part_maturity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03530050
+      Expected_value: FOODON:03530050
     description: A description of the stage of development of a plant or plant part
       based on maturity or ripeness. This field accepts terms listed under degree
       of plant maturity (http://purl.obolibrary.org/obo/FOODON_03530050)
     title: degree of plant part maturity
     examples:
-      - value: ripe or mature [FOODON:03530052]
+    - value: ripe or mature [FOODON:03530052]
     keywords:
-      - degree
-      - plant
+    - degree
+    - plant
     string_serialization: '{term label}{term ID}'
     slot_uri: MIXS:0001120
   plant_product:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: product name
+      Expected_value: product name
     description: Substance produced by the plant, where the sample was obtained from
     title: plant product
     examples:
-      - value: xylem sap [PO:0025539]
+    - value: xylem sap [PO:0025539]
     keywords:
-      - plant
-      - product
+    - plant
+    - product
     string_serialization: '{text}'
     slot_uri: MIXS:0001058
   plant_reprod_crop:
@@ -10828,9 +10272,9 @@ slots:
       the crop
     title: plant reproductive part
     examples:
-      - value: seedling
+    - value: seedling
     keywords:
-      - plant
+    - plant
     slot_uri: MIXS:0001150
     multivalued: true
     range: PlantReprodCropEnum
@@ -10839,9 +10283,9 @@ slots:
       staminate, monoecieous, hermaphrodite
     title: plant sex
     examples:
-      - value: Hermaphroditic
+    - value: Hermaphroditic
     keywords:
-      - plant
+    - plant
     slot_uri: MIXS:0001059
     range: PlantSexEnum
   plant_struc:
@@ -10851,9 +10295,9 @@ slots:
       sex of it can be recorded here
     title: plant structure
     examples:
-      - value: epidermis [PO:0005679]
+    - value: epidermis [PO:0005679]
     keywords:
-      - plant
+    - plant
     slot_uri: MIXS:0001060
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -10867,12 +10311,12 @@ slots:
       Multiple terms can be separated by pipes
     title: plant water delivery method
     examples:
-      - value: drip irrigation process [AGRO:00000056]
+    - value: drip irrigation process [AGRO:00000056]
     keywords:
-      - delivery
-      - method
-      - plant
-      - water
+    - delivery
+    - method
+    - plant
+    - water
     slot_uri: MIXS:0001111
     range: string
     recommended: true
@@ -10890,9 +10334,9 @@ slots:
       to http://purl.bioontology.org/ontology/PATO
     title: ploidy
     examples:
-      - value: allopolyploidy [PATO:0001379]
+    - value: allopolyploidy [PATO:0001379]
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     slot_uri: MIXS:0000021
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -10902,51 +10346,39 @@ slots:
       partial_match: true
   pollutants:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: pollutant name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter, microgram per cubic meter
+      Expected_value: pollutant name;measurement value
+      Preferred_unit: gram, mole per liter, milligram per liter, microgram per cubic meter
     description: Pollutant types and, amount or concentrations measured at the time
       of sampling; can report multiple pollutants by entering numeric values preceded
       by name of pollutant
     title: pollutants
     examples:
-      - value: lead;0.15 microgram per cubic meter
+    - value: lead;0.15 microgram per cubic meter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000107
     multivalued: true
   pool_dna_extracts:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: pooling status;number of pooled extracts
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, milliliter, microliter
+      Expected_value: pooling status;number of pooled extracts
+      Preferred_unit: gram, milliliter, microliter
     description: Indicate whether multiple DNA extractions were mixed. If the answer
       yes, the number of extracts that were pooled should be given
     title: pooling of DNA extracts (if done)
     examples:
-      - value: yes, 5
+    - value: yes, 5
     keywords:
-      - dna
-      - pooling
+    - dna
+    - pooling
     slot_uri: MIXS:0000325
   porosity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value or range
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Expected_value: measurement value or range
+      Preferred_unit: percentage
     description: Porosity of deposited sediment is volume of voids divided by the
       total volume of sample
     title: porosity
     keywords:
-      - porosity
+    - porosity
     string_serialization: '{float} - {float} {unit}'
     slot_uri: MIXS:0000211
   pos_cont_type:
@@ -10954,21 +10386,19 @@ slots:
       a process which is part of an investigation delivers a true positive
     title: positive control type
     in_subset:
-      - investigation
+    - investigation
     keywords:
-      - type
+    - type
     string_serialization: '{term} or {text}'
     slot_uri: MIXS:0001322
     recommended: true
   potassium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of potassium in the sample
     title: potassium
     examples:
-      - value: 463 milligram per liter
+    - value: 463 milligram per liter
     slot_uri: MIXS:0000430
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10979,9 +10409,7 @@ slots:
       partial_match: true
   pour_point:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: 'Temperature at which a liquid becomes semi solid and loses its flow
       characteristics. In crude oil a high  pour point  is generally associated with
       a high paraffin content, typically found in crude deriving from a larger proportion
@@ -10997,9 +10425,7 @@ slots:
       partial_match: true
   pre_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: pre-treatment type
+      Expected_value: pre-treatment type
     description: The process of pre-treatment removes materials that can be easily
       collected from the raw wastewater
     title: pre-treatment
@@ -11009,62 +10435,56 @@ slots:
     description: Expected structure of the viral genome
     title: predicted genome structure
     examples:
-      - value: non-segmented
+    - value: non-segmented
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - predict
+    - predict
     slot_uri: MIXS:0000083
     range: PredGenomeStrucEnum
   pred_genome_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Type of genome predicted for the UViG
     title: predicted genome type
     examples:
-      - value: dsDNA
+    - value: dsDNA
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - predict
-      - type
+    - predict
+    - type
     string_serialization: '[DNA|dsDNA|ssDNA|RNA|dsRNA|ssRNA|ssRNA (+)|ssRNA (-)|mixed|uncharacterized]'
     slot_uri: MIXS:0000082
   pregnancy:
     description: Date due of pregnancy
     title: pregnancy
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000966
     range: datetime
   pres_animal_insect:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;count
+      Expected_value: enumeration;count
     description: The type and number of animals or insects present in the sampling
       space
     title: presence of pets, animals, or insects
     examples:
-      - value: cat;5
+    - value: cat;5
     keywords:
-      - animal
-      - presence
+    - animal
+    - presence
     string_serialization: '[cat|dog|rodent|snake|other];{integer}'
     slot_uri: MIXS:0000819
   pressure:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: atmosphere
+      Preferred_unit: atmosphere
     description: Pressure to which the sample is subject to, in atmospheres
     title: pressure
     examples:
-      - value: 50 atmosphere
+    - value: 50 atmosphere
     keywords:
-      - pressure
+    - pressure
     slot_uri: MIXS:0000412
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11077,10 +10497,10 @@ slots:
     description: Reference or method used in determining previous land use and dates
     title: history/previous land use method
     keywords:
-      - history
-      - land
-      - method
-      - use
+    - history
+    - land
+    - method
+    - use
     slot_uri: MIXS:0000316
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -11090,32 +10510,28 @@ slots:
       partial_match: true
   previous_land_use:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: land use name;date
+      Expected_value: land use name;date
     description: Previous land use and dates
     title: history/previous land use
     examples:
-      - value: fallow; 2018-05-11:T14:30Z
+    - value: fallow; 2018-05-11:T14:30Z
     keywords:
-      - history
-      - land
-      - use
+    - history
+    - land
+    - use
     string_serialization: '{text};{timestamp}'
     slot_uri: MIXS:0000315
   primary_prod:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter per day, gram per square meter per day
+      Preferred_unit: milligram per cubic meter per day, gram per square meter per day
     description: Measurement of primary production, generally measured as isotope
       uptake
     title: primary production
     examples:
-      - value: 100 milligram per cubic meter per day
+    - value: 100 milligram per cubic meter per day
     keywords:
-      - primary
-      - production
+    - primary
+    - production
     slot_uri: MIXS:0000728
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11126,16 +10542,14 @@ slots:
       partial_match: true
   primary_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: primary treatment type
+      Expected_value: primary treatment type
     description: The process to produce both a generally homogeneous liquid capable
       of being treated biologically and a sludge that can be separately treated or
       processed
     title: primary treatment
     keywords:
-      - primary
-      - treatment
+    - primary
+    - treatment
     string_serialization: '{text}'
     slot_uri: MIXS:0000349
   prod_label_claims:
@@ -11144,22 +10558,20 @@ slots:
       include more than one term, separated by ";"
     title: production labeling claims
     examples:
-      - value: free range
+    - value: free range
     keywords:
-      - production
+    - production
     slot_uri: MIXS:prod_label_claims
     multivalued: true
     range: string
   prod_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per day
+      Preferred_unit: cubic meter per day
     description: Oil and/or gas production rates per well (e.g. 524 m3 / day)
     title: production rate
     keywords:
-      - production
-      - rate
+    - production
+    - rate
     slot_uri: MIXS:0000452
     range: string
     recommended: true
@@ -11173,11 +10585,11 @@ slots:
     description: Date of field's first production
     title: production start date
     examples:
-      - value: '2013-03-25T12:42:31+01:00'
+    - value: '2013-03-25T12:42:31+01:00'
     keywords:
-      - date
-      - production
-      - start
+    - date
+    - production
+    - start
     slot_uri: MIXS:0001008
     range: datetime
     recommended: true
@@ -11186,26 +10598,24 @@ slots:
       area position in relation to surrounding areas
     title: profile position
     examples:
-      - value: summit
+    - value: summit
     slot_uri: MIXS:0001084
     range: ProfilePositionEnum
   project_name:
     description: Name of the project within which the sequencing was organized
     title: project name
     examples:
-      - value: Forest soil metagenome
+    - value: Forest soil metagenome
     in_subset:
-      - investigation
+    - investigation
     keywords:
-      - project
+    - project
     slot_uri: MIXS:0000092
     range: string
     required: true
   propagation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid:
+      Expected_value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid:
           incompatibility group; for eukaryote: asexual, sexual; other more specific
           values (e.g., incompatibility group) are allowed'
     description: 'The type of reproduction from the parent stock. Values for this
@@ -11213,9 +10623,9 @@ slots:
       lytic. For plasmids: incompatibility group. For eukaryotes: sexual/asexual'
     title: propagation
     examples:
-      - value: lytic
+    - value: lytic
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     string_serialization: '{text}'
     slot_uri: MIXS:0000033
   pulmonary_disord:
@@ -11224,7 +10634,7 @@ slots:
       lung disease (https://disease-ontology.org/?id=DOID:850)
     title: lung/pulmonary disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000269
     multivalued: true
     range: string
@@ -11232,17 +10642,13 @@ slots:
     description: The quadrant position of the sampling room within the building
     title: quadrant position
     examples:
-      - value: West side
+    - value: West side
     slot_uri: MIXS:0000820
     range: QuadPosEnum
   radiation_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: radiation type name;radiation amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: rad, gray
+      Expected_value: radiation type name;radiation amount;treatment interval and duration
+      Preferred_unit: rad, gray
     description: Information about treatment involving exposure of plant or a plant
       part to a particular radiation regimen; should include the radiation type, amount
       or intensity administered, treatment regimen including how many times the treatment
@@ -11250,44 +10656,38 @@ slots:
       the entire treatment; can include multiple radiation regimens
     title: radiation regimen
     examples:
-      - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
+    - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000575
     multivalued: true
   rainfall_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter
+      Expected_value: measurement value;treatment interval and duration
+      Preferred_unit: millimeter
     description: Information about treatment involving an exposure to a given amount
       of rainfall, treatment regimen including how many times the treatment was repeated,
       how long each treatment lasted, and the start and end time of the entire treatment;
       can include multiple regimens
     title: rainfall regimen
     examples:
-      - value: 15 millimeter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: 15 millimeter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - rain
-      - regimen
+    - rain
+    - regimen
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000576
     multivalued: true
   reactor_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: reactor type name
+      Expected_value: reactor type name
     description: Anaerobic digesters can be designed and engineered to operate using
       a number of different process configurations, as batch or continuous, mesophilic,
       high solid or low solid, and single stage or multistage
     title: reactor type
     keywords:
-      - type
+    - type
     string_serialization: '{text}'
     slot_uri: MIXS:0000350
   reassembly_bin:
@@ -11295,23 +10695,21 @@ slots:
       assembly?
     title: reassembly post binning
     examples:
-      - value: 'no'
+    - value: 'no'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - post
+    - post
     slot_uri: MIXS:0000079
     range: boolean
   redox_potential:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millivolt
+      Preferred_unit: millivolt
     description: Redox potential, measured relative to a hydrogen cell, indicating
       oxidation or reduction potential
     title: redox potential
     examples:
-      - value: 300 millivolt
+    - value: 300 millivolt
     slot_uri: MIXS:0000182
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11325,9 +10723,9 @@ slots:
       primary genome report
     title: reference for biomaterial
     examples:
-      - value: doi:10.1016/j.syapm.2018.01.009
+    - value: doi:10.1016/j.syapm.2018.01.009
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     slot_uri: MIXS:0000025
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -11337,37 +10735,33 @@ slots:
       partial_match: true
   ref_db:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names, versions, and references of databases
+      Expected_value: names, versions, and references of databases
     description: List of database(s) used for ORF annotation, along with version number
       and reference to website or publication
     title: reference database(s)
     examples:
-      - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017
-          doi:10.1093/nar/gkw975
+    - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017
+        doi:10.1093/nar/gkw975
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - database
+    - database
     string_serialization: '{database};{version};{reference}'
     slot_uri: MIXS:0000062
   rel_air_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Partial vapor and air pressure, density of the vapor and air, or
       by the actual mass of the vapor and air
     title: relative air humidity
     comments:
-      - percent or float?
+    - percent or float?
     examples:
-      - value: '0.8'
+    - value: '0.8'
     keywords:
-      - air
-      - humidity
-      - relative
+    - air
+    - humidity
+    - relative
     slot_uri: MIXS:0000121
     range: float
     required: true
@@ -11379,16 +10773,14 @@ slots:
       partial_match: true
   rel_humidity_out:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram of air, kilogram of air
+      Preferred_unit: gram of air, kilogram of air
     description: The recorded outside relative humidity value at the time of sampling
     title: outside relative humidity
     examples:
-      - value: 12 per kilogram of air
+    - value: 12 per kilogram of air
     keywords:
-      - humidity
-      - relative
+    - humidity
+    - relative
     slot_uri: MIXS:0000188
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11402,21 +10794,21 @@ slots:
       plant, near irrigation ditch, from the dirt road
     title: relative location of sample
     examples:
-      - value: furrow
+    - value: furrow
     keywords:
-      - location
-      - relative
-      - sample
+    - location
+    - relative
+    - sample
     slot_uri: MIXS:0001161
     range: string
   rel_samp_loc:
     description: The sampling location within the train car
     title: relative sampling location
     examples:
-      - value: center of car
+    - value: center of car
     keywords:
-      - location
-      - relative
+    - location
+    - relative
     slot_uri: MIXS:0000821
     range: RelSampLocEnum
   rel_to_oxygen:
@@ -11424,25 +10816,23 @@ slots:
       anaerobic are valid descriptors for microbial environments
     title: relationship to oxygen
     examples:
-      - value: aerobe
+    - value: aerobe
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - oxygen
-      - relationship
+    - oxygen
+    - relationship
     slot_uri: MIXS:0000015
     range: RelToOxygenEnum
   repository_name:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Institution
+      Expected_value: Institution
     description: The name of the institution where the sample or DNA extract is held
       or "sample not available" if the sample was used in its entirety for analysis
       or otherwise not retained
     title: repository name
     examples:
-      - value: FDA CFSAN Microbiology Laboratories
+    - value: FDA CFSAN Microbiology Laboratories
     string_serialization: '{text}'
     slot_uri: MIXS:0001152
     multivalued: true
@@ -11454,9 +10844,7 @@ slots:
     recommended: true
   resins_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
@@ -11473,15 +10861,13 @@ slots:
       partial_match: true
   room_air_exch_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: liter per hour
+      Preferred_unit: liter per hour
     description: The rate at which outside air replaces indoor air in a given space
     title: room air exchange rate
     keywords:
-      - air
-      - rate
-      - room
+    - air
+    - rate
+    - room
     slot_uri: MIXS:0000169
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11495,27 +10881,27 @@ slots:
       of a distinguisahable space within a built structure
     title: room architectural elements
     keywords:
-      - room
+    - room
     slot_uri: MIXS:0000233
     range: string
   room_condt:
     description: The condition of the room at the time of sampling
     title: room condition
     examples:
-      - value: new
+    - value: new
     keywords:
-      - condition
-      - room
+    - condition
+    - room
     slot_uri: MIXS:0000822
     range: RoomCondtEnum
   room_connected:
     description: List of rooms connected to the sampling room by a doorway
     title: rooms connected by a doorway
     examples:
-      - value: office
+    - value: office
     keywords:
-      - doorway
-      - room
+    - doorway
+    - room
     slot_uri: MIXS:0000826
     range: RoomConnectedEnum
   room_count:
@@ -11523,39 +10909,33 @@ slots:
       types
     title: room count
     keywords:
-      - count
-      - room
+    - count
+    - room
     slot_uri: MIXS:0000234
     range: integer
   room_dim:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: measurement value
+      Preferred_unit: meter
     description: The length, width and height of sampling room
     title: room dimensions
     examples:
-      - value: 4 meter x 4 meter x 4 meter
+    - value: 4 meter x 4 meter x 4 meter
     keywords:
-      - dimensions
-      - room
+    - dimensions
+    - room
     string_serialization: '{integer} {unit} x {integer} {unit} x {integer} {unit}'
     slot_uri: MIXS:0000192
   room_door_dist:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Distance between doors (meters) in the hallway between the sampling
       room and adjacent rooms
     title: room door distance
     keywords:
-      - distance
-      - door
-      - room
+    - distance
+    - door
+    - room
     slot_uri: MIXS:0000193
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11568,8 +10948,8 @@ slots:
       sampling room
     title: rooms that share a door with sampling room
     keywords:
-      - door
-      - room
+    - door
+    - room
     slot_uri: MIXS:0000242
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -11582,8 +10962,8 @@ slots:
       as sampling room
     title: rooms that are on the same hallway
     keywords:
-      - hallway
-      - room
+    - hallway
+    - room
     slot_uri: MIXS:0000238
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -11595,10 +10975,10 @@ slots:
     description: The position of the room within the building
     title: room location in building
     examples:
-      - value: interior room
+    - value: interior room
     keywords:
-      - location
-      - room
+    - location
+    - room
     slot_uri: MIXS:0000823
     range: RoomLocEnum
   room_moist_dam_hist:
@@ -11606,21 +10986,19 @@ slots:
       of events of moisture damage or mold observed
     title: room moisture damage or mold history
     keywords:
-      - history
-      - moisture
-      - room
+    - history
+    - moisture
+    - room
     slot_uri: MIXS:0000235
     range: integer
   room_net_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square feet, square meter
+      Preferred_unit: square feet, square meter
     description: The net floor area of sampling room. Net area excludes wall thicknesses
     title: room net area
     keywords:
-      - area
-      - room
+    - area
+    - room
     slot_uri: MIXS:0000194
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11632,7 +11010,7 @@ slots:
     description: Count of room occupancy at time of sampling
     title: room occupancy
     keywords:
-      - room
+    - room
     slot_uri: MIXS:0000236
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11645,38 +11023,34 @@ slots:
       elements
     title: room sampling position
     examples:
-      - value: south corner
+    - value: south corner
     keywords:
-      - room
+    - room
     slot_uri: MIXS:0000824
     range: RoomSampPosEnum
   room_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The main purpose or activity of the sampling room. A room is any
       distinguishable space within a structure
     title: room type
     examples:
-      - value: bathroom
+    - value: bathroom
     keywords:
-      - room
-      - type
+    - room
+    - type
     string_serialization: '[attic|bathroom|closet|conference room|elevator|examining
       room|hallway|kitchen|mail room|private office|open office|stairwell|,restroom|lobby|vestibule|mechanical
       or electrical room|data center|laboratory_wet|laboratory_dry|gymnasium|natatorium|auditorium|lockers|cafe|warehouse]'
     slot_uri: MIXS:0000825
   room_vol:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic feet, cubic meter
+      Preferred_unit: cubic feet, cubic meter
     description: Volume of sampling room
     title: room volume
     keywords:
-      - room
-      - volume
+    - room
+    - volume
     slot_uri: MIXS:0000195
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11689,8 +11063,8 @@ slots:
       sampling room
     title: rooms that share a wall with sampling room
     keywords:
-      - room
-      - wall
+    - room
+    - wall
     slot_uri: MIXS:0000243
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -11702,9 +11076,9 @@ slots:
     description: Number of windows in the room
     title: room window count
     keywords:
-      - count
-      - room
-      - window
+    - count
+    - room
+    - window
     slot_uri: MIXS:0000237
     range: integer
   root_cond:
@@ -11712,9 +11086,9 @@ slots:
       container dimensions, number of plants per container
     title: rooting conditions
     examples:
-      - value: http://himedialabs.com/TD/PT158.pdf
+    - value: http://himedialabs.com/TD/PT158.pdf
     keywords:
-      - condition
+    - condition
     slot_uri: MIXS:0001061
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11724,76 +11098,60 @@ slots:
       partial_match: true
   root_med_carbon:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: carbon source name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: carbon source name;measurement value
+      Preferred_unit: milligram per liter
     description: Source of organic carbon in the culture rooting medium; e.g. sucrose
     title: rooting medium carbon
     examples:
-      - value: sucrose
+    - value: sucrose
     keywords:
-      - carbon
+    - carbon
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000577
   root_med_macronutr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: macronutrient name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: macronutrient name;measurement value
+      Preferred_unit: milligram per liter
     description: Measurement of the culture rooting medium macronutrients (N,P, K,
       Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
     title: rooting medium macronutrients
     examples:
-      - value: KH2PO4;170  milligram per liter
+    - value: KH2PO4;170  milligram per liter
     keywords:
-      - macronutrients
+    - macronutrients
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000578
   root_med_micronutr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: micronutrient name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: micronutrient name;measurement value
+      Preferred_unit: milligram per liter
     description: Measurement of the culture rooting medium micronutrients (Fe, Mn,
       Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
     title: rooting medium micronutrients
     examples:
-      - value: H3BO3;6.2  milligram per liter
+    - value: H3BO3;6.2  milligram per liter
     keywords:
-      - micronutrients
+    - micronutrients
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000579
   root_med_ph:
     description: pH measurement of the culture rooting medium; e.g. 5.5
     title: rooting medium pH
     examples:
-      - value: '7.5'
+    - value: '7.5'
     keywords:
-      - ph
+    - ph
     slot_uri: MIXS:0001062
     range: float
   root_med_regl:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: regulator name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: regulator name;measurement value
+      Preferred_unit: milligram per liter
     description: Growth regulators in the culture rooting medium such as cytokinins,
       auxins, gybberellins, abscisic acid; e.g. 0.5  mg/L NAA
     title: rooting medium regulators
     examples:
-      - value: abscisic acid;0.75 milligram per liter
+    - value: abscisic acid;0.75 milligram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000581
   root_med_solid:
@@ -11801,25 +11159,21 @@ slots:
       e.g. agar
     title: rooting medium solidifier
     examples:
-      - value: agar
+    - value: agar
     slot_uri: MIXS:0001063
     range: string
   root_med_suppl:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: supplement name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: supplement name;measurement value
+      Preferred_unit: milligram per liter
     description: Organic supplements of the culture rooting medium, such as vitamins,
       amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid
       (0.5  mg/L)
     title: rooting medium organic supplements
     examples:
-      - value: nicotinic acid;0.5 milligram per liter
+    - value: nicotinic acid;0.5 milligram per liter
     keywords:
-      - organic
+    - organic
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000580
   route_transmission:
@@ -11829,14 +11183,12 @@ slots:
       in mode_transmission)
     title: route of transmission
     keywords:
-      - route
+    - route
     slot_uri: MIXS:0001316
     range: RouteTransmissionEnum
   salinity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: practical salinity unit, percentage
+      Preferred_unit: practical salinity unit, percentage
     description: The total concentration of all dissolved salts in a liquid or solid
       sample. While salinity can be measured by a complete chemical analysis, this
       method is difficult and time consuming. More often, it is instead derived from
@@ -11845,9 +11197,9 @@ slots:
       seawater
     title: salinity
     examples:
-      - value: 25 practical salinity unit
+    - value: 25 practical salinity unit
     keywords:
-      - salinity
+    - salinity
     slot_uri: MIXS:0000183
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11858,9 +11210,7 @@ slots:
       partial_match: true
   salt_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, mole per liter, gram per liter
+      Preferred_unit: gram, microgram, mole per liter, gram per liter
     description: Information about treatment involving use of salts as supplement
       to liquid and soil growth media; should include the name of salt, amount administered,
       treatment regimen including how many times the treatment was repeated, how long
@@ -11868,10 +11218,10 @@ slots:
       include multiple salt regimens
     title: salt regimen
     examples:
-      - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
-      - salt
+    - regimen
+    - salt
     slot_uri: MIXS:0000582
     multivalued: true
     range: string
@@ -11879,36 +11229,34 @@ slots:
     description: Reason for the sample
     title: sample capture status
     examples:
-      - value: farm sample
+    - value: farm sample
     keywords:
-      - sample
-      - status
+    - sample
+    - status
     slot_uri: MIXS:0000860
     range: SampCaptStatusEnum
   samp_collect_device:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: device name
+      Expected_value: device name
     description: The device used to collect an environmental sample. This field accepts
       terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
       This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094)
     title: sample collection device
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - device
-      - sample
+    - device
+    - sample
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000002
   samp_collect_method:
     description: The method employed for collecting the sample
     title: sample collection method
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - method
-      - sample
+    - method
+    - sample
     slot_uri: MIXS:0001225
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11922,9 +11270,9 @@ slots:
       in "additional info" field
     title: sample collection point
     examples:
-      - value: well
+    - value: well
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0001015
     range: SampCollectPointEnum
     required: true
@@ -11933,41 +11281,37 @@ slots:
       penetration, infection, growth and reproduction, dissemination of pathogen
     title: sample disease stage
     examples:
-      - value: infection
+    - value: infection
     keywords:
-      - disease
-      - sample
+    - disease
+    - sample
     slot_uri: MIXS:0000249
     range: SampDisStageEnum
   samp_floor:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The floor of the building, where the sampling room is located
     title: sampling floor
     examples:
-      - value: 4th floor
+    - value: 4th floor
     keywords:
-      - floor
+    - floor
     string_serialization: '[1st floor|2nd floor|{integer} floor|basement|lobby]'
     slot_uri: MIXS:0000828
   samp_loc_condition:
     description: The condition of the sample location at the time of sampling
     title: sample location condition
     examples:
-      - value: new
+    - value: new
     keywords:
-      - condition
-      - location
-      - sample
+    - condition
+    - location
+    - sample
     slot_uri: MIXS:0001257
     range: SampLocConditionEnum
   samp_loc_corr_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter per year
+      Preferred_unit: millimeter per year
     description: Metal corrosion rate is the speed of metal deterioration due to environmental
       conditions. As environmental conditions change corrosion rates change accordingly.
       Therefore, long term corrosion rates are generally more informative than short
@@ -11977,9 +11321,9 @@ slots:
       in MIC as well as potential microbial interplays
     title: corrosion rate at sample location
     keywords:
-      - location
-      - rate
-      - sample
+    - location
+    - rate
+    - sample
     slot_uri: MIXS:0000136
     range: string
     recommended: true
@@ -11994,23 +11338,19 @@ slots:
       performed
     title: sample material processing
     examples:
-      - value: filtering of seawater, storing samples in ethanol
+    - value: filtering of seawater, storing samples in ethanol
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - material
-      - process
-      - sample
+    - material
+    - process
+    - sample
     slot_uri: MIXS:0000016
     range: string
   samp_md:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;enumeration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: measurement value;enumeration
+      Preferred_unit: meter
     description: In non deviated well, measured depth is equal to the true vertical
       depth, TVD (TVD=TVDSS plus the reference or datum it refers to). In deviated
       wells, the MD is the length of trajectory of the borehole measured from the
@@ -12019,18 +11359,16 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: sample measured depth
     examples:
-      - value: 1534 meter;MSL
+    - value: 1534 meter;MSL
     keywords:
-      - depth
-      - measurement
-      - sample
+    - depth
+    - measurement
+    - sample
     string_serialization: '{float} {unit};[GL|DF|RT|KB|MSL|other]'
     slot_uri: MIXS:0000413
   samp_name:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ''
+      Preferred_unit: ''
     description: A local identifier or name that for the material sample used for
       extracting nucleic acids, and subsequent sequencing. It can refer either to
       the original material collected or to any derived sub-samples. It can have any
@@ -12040,11 +11378,11 @@ slots:
       field source_mat_id is recommended in addition to sample_name
     title: sample name
     examples:
-      - value: ISDsoil1
+    - value: ISDsoil1
     in_subset:
-      - investigation
+    - investigation
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0001107
     range: string
     required: true
@@ -12054,23 +11392,21 @@ slots:
       cells. Please provide a short description of the samples that were pooled
     title: sample pooling
     examples:
-      - value: 5uL of extracted genomic DNA from 5 leaves were pooled
+    - value: 5uL of extracted genomic DNA from 5 leaves were pooled
     keywords:
-      - pooling
-      - sample
+    - pooling
+    - sample
     slot_uri: MIXS:0001153
     multivalued: true
     range: string
   samp_preserv:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliliter
+      Preferred_unit: milliliter
     description: Preservative added to the sample (e.g. Rnalater, alcohol, formaldehyde,
       etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)
     title: preservative added to sample
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0000463
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -12080,15 +11416,13 @@ slots:
       partial_match: true
   samp_purpose:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration or {text}
+      Expected_value: enumeration or {text}
     description: The reason that the sample was collected
     title: purpose of sampling
     examples:
-      - value: field trial
+    - value: field trial
     keywords:
-      - purpose
+    - purpose
     string_serialization: '[active surveillance in response to an outbreak|active
       surveillance not initiated by an outbreak|clinical trial|cluster investigation|environmental
       assessment|farm sample|field trial|for cause|industry internal investigation|market
@@ -12100,9 +11434,9 @@ slots:
       variation
     title: biological sample replicate
     examples:
-      - value: 6 replicates
+    - value: 6 replicates
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0001226
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12116,9 +11450,9 @@ slots:
       of the noise associated with the equipment and the protocols
     title: technical sample replicate
     examples:
-      - value: 10 replicates
+    - value: 10 replicates
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0001227
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12132,8 +11466,8 @@ slots:
       on the building floor plans
     title: sampling room ID or name
     keywords:
-      - identifier
-      - room
+    - identifier
+    - room
     slot_uri: MIXS:0000244
     range: integer
   samp_size:
@@ -12141,12 +11475,12 @@ slots:
       sample collected
     title: amount or size of sample collected
     examples:
-      - value: 5 liter
+    - value: 5 liter
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - sample
-      - size
+    - sample
+    - size
     slot_uri: MIXS:0000001
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12162,45 +11496,41 @@ slots:
       in a cascade impactor
     title: sample size sorting method
     keywords:
-      - method
-      - sample
-      - size
+    - method
+    - sample
+    - size
     slot_uri: MIXS:0000216
     multivalued: true
     range: string
   samp_source_mat_cat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: GENEPIO:0001237
+      Expected_value: GENEPIO:0001237
     description: This is the scientific role or category that the subject organism
       or material has with respect to an investigation.  This field accepts terms
       listed under specimen source material category (http://purl.obolibrary.org/obo/GENEPIO_0001237
       or http://purl.obolibrary.org/obo/OBI_0100051)
     title: sample source material category
     examples:
-      - value: environmental (swab or sampling) [GENEPIO:0001732]
+    - value: environmental (swab or sampling) [GENEPIO:0001732]
     keywords:
-      - material
-      - sample
-      - source
+    - material
+    - sample
+    - source
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001154
   samp_stor_device:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C4318
+      Expected_value: NCIT:C4318
     description: The container used to store the  sample. This field accepts terms
       listed under container (http://purl.obolibrary.org/obo/NCIT_C43186). If the
       proper descriptor is not listed please use text to describe the storage device
     title: sample storage device
     examples:
-      - value: Whirl Pak sampling bag [GENEPIO:0002122]
+    - value: Whirl Pak sampling bag [GENEPIO:0002122]
     keywords:
-      - device
-      - sample
-      - storage
+    - device
+    - sample
+    - storage
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001228
   samp_stor_media:
@@ -12212,10 +11542,10 @@ slots:
       storage media
     title: sample storage media
     examples:
-      - value: peptone water medium [MICRO:0000548]
+    - value: peptone water medium [MICRO:0000548]
     keywords:
-      - sample
-      - storage
+    - sample
+    - storage
     slot_uri: MIXS:0001229
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
@@ -12228,12 +11558,12 @@ slots:
       which the sample was stored written in ISO 8601 format
     title: sample storage duration
     examples:
-      - value: P1Y6M
+    - value: P1Y6M
     keywords:
-      - duration
-      - period
-      - sample
-      - storage
+    - duration
+    - period
+    - sample
+    - storage
     slot_uri: MIXS:0000116
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -12243,46 +11573,40 @@ slots:
       partial_match: true
   samp_store_loc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: location name
+      Expected_value: location name
     description: Location at which sample was stored, usually name of a specific freezer/room
     title: sample storage location
     examples:
-      - value: Freezer no:5
+    - value: Freezer no:5
     keywords:
-      - location
-      - sample
-      - storage
+    - location
+    - sample
+    - storage
     string_serialization: '{text}'
     slot_uri: MIXS:0000755
   samp_store_sol:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: solution name
+      Expected_value: solution name
     description: Solution within which sample was stored, if any
     title: sample storage solution
     examples:
-      - value: 5% ethanol
+    - value: 5% ethanol
     keywords:
-      - sample
-      - storage
+    - sample
+    - storage
     string_serialization: '{text}'
     slot_uri: MIXS:0001317
   samp_store_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature at which sample was stored, e.g. -80 degree Celsius
     title: sample storage temperature
     examples:
-      - value: -80 degree Celsius
+    - value: -80 degree Celsius
     keywords:
-      - sample
-      - storage
-      - temperature
+    - sample
+    - storage
+    - temperature
     slot_uri: MIXS:0000110
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12297,9 +11621,9 @@ slots:
       please propose entry in "additional info" field
     title: sample subtype
     examples:
-      - value: biofilm
+    - value: biofilm
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0000999
     range: SampSubtypeEnum
     recommended: true
@@ -12309,11 +11633,11 @@ slots:
       If no surface moisture is present indicate not present
     title: sample surface moisture
     examples:
-      - value: submerged
+    - value: submerged
     keywords:
-      - moisture
-      - sample
-      - surface
+    - moisture
+    - sample
+    - surface
     slot_uri: MIXS:0001256
     multivalued: true
     range: SampSurfMoistureEnum
@@ -12323,14 +11647,14 @@ slots:
       'blank sample' for negative controls
     title: taxonomy ID of DNA sample
     examples:
-      - value: Gut Metagenome [NCBITaxon:749906]
+    - value: Gut Metagenome [NCBITaxon:749906]
     in_subset:
-      - investigation
+    - investigation
     keywords:
-      - dna
-      - identifier
-      - sample
-      - taxon
+    - dna
+    - identifier
+    - sample
+    - taxon
     slot_uri: MIXS:0001320
     range: string
     required: true
@@ -12341,35 +11665,27 @@ slots:
       partial_match: true
   samp_time_out:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: time
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hour
+      Expected_value: time
+      Preferred_unit: hour
     description: The recent and long term history of outside sampling
     title: sampling time outside
     keywords:
-      - time
+    - time
     string_serialization: '{float}'
     slot_uri: MIXS:0000196
   samp_transport_cond:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days;degree Celsius
+      Expected_value: measurement value;measurement value
+      Preferred_unit: days;degree Celsius
     description: Sample transport duration (in days or hrs) and temperature the sample
       was exposed to (e.g. 5.5 days; 20   C)
     title: sample transport conditions
     examples:
-      - value: 5 days;-20 degree Celsius
+    - value: 5 days;-20 degree Celsius
     keywords:
-      - condition
-      - sample
-      - transport
+    - condition
+    - sample
+    - transport
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000410
   samp_transport_cont:
@@ -12377,27 +11693,25 @@ slots:
       the location name
     title: sample transport  container
     examples:
-      - value: cooler
+    - value: cooler
     keywords:
-      - sample
-      - transport
+    - sample
+    - transport
     slot_uri: MIXS:0001230
     range: SampTransportContEnum
   samp_transport_dur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days
+      Preferred_unit: days
     description: The duration of time from when the sample was collected until processed.
       Indicate the duration for which the sample was stored written in ISO 8601 format
     title: sample transport duration
     examples:
-      - value: P10D
+    - value: P10D
     keywords:
-      - duration
-      - period
-      - sample
-      - transport
+    - duration
+    - period
+    - sample
+    - transport
     slot_uri: MIXS:0001231
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -12407,38 +11721,30 @@ slots:
       partial_match: true
   samp_transport_temp:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Expected_value: text or measurement value
+      Preferred_unit: degree Celsius
     description: Temperature at which sample was transported, e.g. -20 or 4 degree
       Celsius
     title: sample transport temperature
     examples:
-      - value: 4 degree Celsius
+    - value: 4 degree Celsius
     keywords:
-      - sample
-      - temperature
-      - transport
+    - sample
+    - temperature
+    - transport
     string_serialization: '{float} {unit} {text}'
     slot_uri: MIXS:0001232
   samp_tvdss:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value or measurement value range
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: measurement value or measurement value range
+      Preferred_unit: meter
     description: Depth of the sample i.e. The vertical distance between the sea level
       and the sampled position in the subsurface. Depth can be reported as an interval
       for subsurface samples e.g. 1325.75-1362.25 m
     title: sample true vertical depth subsea
     keywords:
-      - depth
-      - sample
+    - depth
+    - sample
     string_serialization: '{float}-{float} {unit}'
     slot_uri: MIXS:0000409
     recommended: true
@@ -12451,10 +11757,10 @@ slots:
       This field accepts terms listed under environmental specimen (http://purl.obolibrary.org/obo/GENEPIO_0001246)
     title: sample type
     examples:
-      - value: built environment sample [GENEPIO:0001248]
+    - value: built environment sample [GENEPIO:0001248]
     keywords:
-      - sample
-      - type
+    - sample
+    - type
     slot_uri: MIXS:0000998
     range: string
     required: true
@@ -12465,22 +11771,20 @@ slots:
       partial_match: true
   samp_vol_we_dna_ext:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliliter, gram, milligram, square centimeter
+      Preferred_unit: milliliter, gram, milligram, square centimeter
     description: 'Volume (ml) or mass (g) of total collected sample processed for
       DNA extraction. Note: total sample collected should be entered under the term
       Sample Size (MIXS:0000001)'
     title: sample volume or weight for DNA extraction
     examples:
-      - value: 1500 milliliter
+    - value: 1500 milliliter
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - dna
-      - sample
-      - volume
-      - weight
+    - dna
+    - sample
+    - volume
+    - weight
     slot_uri: MIXS:0000111
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12493,25 +11797,23 @@ slots:
     description: The weather on the sampling day
     title: sampling day weather
     examples:
-      - value: foggy
+    - value: foggy
     keywords:
-      - day
-      - weather
+    - day
+    - weather
     slot_uri: MIXS:0000827
     range: SampWeatherEnum
   samp_well_name:
     description: Name of the well (e.g. BXA1123) where sample was taken
     title: sample well name
     keywords:
-      - sample
+    - sample
     slot_uri: MIXS:0000296
     range: string
     recommended: true
   saturates_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
@@ -12530,50 +11832,46 @@ slots:
     description: Method used to free DNA from interior of the cell(s) or particle(s)
     title: single cell or viral particle lysis approach
     examples:
-      - value: enzymatic
+    - value: enzymatic
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - particle
-      - single
+    - particle
+    - single
     slot_uri: MIXS:0000076
     range: ScLysisApproachEnum
   sc_lysis_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: kit, protocol name
+      Expected_value: kit, protocol name
     description: Name of the kit or standard protocol used for cell(s) or particle(s)
       lysis
     title: single cell or viral particle lysis kit protocol
     examples:
-      - value: ambion single cell lysis kit
+    - value: ambion single cell lysis kit
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - kit
-      - particle
-      - protocol
-      - single
+    - kit
+    - particle
+    - protocol
+    - single
     string_serialization: '{text}'
     slot_uri: MIXS:0000054
   season:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732], winter
+      Expected_value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732], winter
           [NCIT:C94730]
     description: The season when sampling occurred. Any of the four periods into which
       the year is divided by the equinoxes and solstices. This field accepts terms
       listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
     title: season
     comments:
-      - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
-      - would require ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:[a-zA-Z0-9]\\]$
+    - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
+    - would require ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:[a-zA-Z0-9]\\]$
     examples:
-      - value: autumn [NCIT:C94733]
+    - value: autumn [NCIT:C94733]
     keywords:
-      - season
+    - season
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000829
     range: string
@@ -12585,10 +11883,10 @@ slots:
       the entire treatment
     title: seasonal environment
     examples:
-      - value: rainy;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: rainy;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - environment
-      - season
+    - environment
+    - season
     slot_uri: MIXS:0001068
     multivalued: true
     range: string
@@ -12596,13 +11894,13 @@ slots:
     description: Average humidity of the region throughout the growing season
     title: mean seasonal humidity
     comments:
-      - percent or float?
+    - percent or float?
     examples:
-      - value: '0.25'
+    - value: '0.25'
     keywords:
-      - humidity
-      - mean
-      - season
+    - humidity
+    - mean
+    - season
     slot_uri: MIXS:0001148
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12613,17 +11911,15 @@ slots:
       partial_match: true
   season_precpt:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter
+      Preferred_unit: millimeter
     description: The average of all seasonal precipitation values known, or an estimated
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean seasonal precipitation
     examples:
-      - value: 75 millimeters
+    - value: 75 millimeters
     keywords:
-      - mean
-      - season
+    - mean
+    - season
     slot_uri: MIXS:0000645
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12634,17 +11930,15 @@ slots:
       partial_match: true
   season_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Mean seasonal temperature
     title: mean seasonal temperature
     examples:
-      - value: 18 degree Celsius
+    - value: 18 degree Celsius
     keywords:
-      - mean
-      - season
-      - temperature
+    - mean
+    - season
+    - temperature
     slot_uri: MIXS:0000643
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12657,33 +11951,31 @@ slots:
     description: The seasons the space is occupied
     title: seasonal use
     examples:
-      - value: Winter
+    - value: Winter
     keywords:
-      - season
-      - use
+    - season
+    - use
     slot_uri: MIXS:0000830
     range: SeasonUseEnum
   secondary_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: secondary treatment type
+      Expected_value: secondary treatment type
     description: The process for substantially degrading the biological content of
       the sewage
     title: secondary treatment
     keywords:
-      - secondary
-      - treatment
+    - secondary
+    - treatment
     string_serialization: '{text}'
     slot_uri: MIXS:0000351
   sediment_type:
     description: Information about the sediment type based on major constituents
     title: sediment type
     examples:
-      - value: biogenous
+    - value: biogenous
     keywords:
-      - sediment
-      - type
+    - sediment
+    - type
     slot_uri: MIXS:0001078
     range: SedimentTypeEnum
   seq_meth:
@@ -12691,11 +11983,11 @@ slots:
       from the OBI list of DNA sequencers (http://purl.obolibrary.org/obo/OBI_0400103)
     title: sequencing method
     examples:
-      - value: 454 Genome Sequencer FLX [OBI:0000702]
+    - value: 454 Genome Sequencer FLX [OBI:0000702]
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - method
+    - method
     slot_uri: MIXS:0000050
     range: string
     required: true
@@ -12706,27 +11998,23 @@ slots:
       partial_match: true
   seq_quality_check:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: none or manually edited
+      Expected_value: none or manually edited
     description: Indicate if the sequence has been called by automatic systems (none)
       or undergone a manual editing procedure (e.g. by inspecting the raw data or
       chromatograms). Applied only for sequences that are not submitted to SRA,ENA
       or DRA
     title: sequence quality check
     examples:
-      - value: none
+    - value: none
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - quality
+    - quality
     slot_uri: MIXS:0000051
     range: SeqQualityCheckEnum
   sequencing_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name of sequencing kit used
+      Expected_value: name of sequencing kit used
     description: Pre-filled, ready-to-use reagent cartridges. Used to produce improved
       chemistry, cluster density and read length as well as improve quality (Q) scores.
       Reagent components are encoded to interact with the sequencing system to validate
@@ -12734,9 +12022,9 @@ slots:
       kit
     title: sequencing kit
     examples:
-      - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
+    - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
     keywords:
-      - kit
+    - kit
     string_serialization: '{text}'
     slot_uri: MIXS:0001155
   sequencing_location:
@@ -12744,9 +12032,9 @@ slots:
       of the lab or core facility where samples were sequenced
     title: sequencing location
     examples:
-      - value: University of Maryland Genomics Resource Center
+    - value: University of Maryland Genomics Resource Center
     keywords:
-      - location
+    - location
     slot_uri: MIXS:0001156
     range: string
   serovar_or_serotype:
@@ -12756,7 +12044,7 @@ slots:
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
     title: serovar or serotype
     examples:
-      - value: Escherichia coli strain O157:H7 [NCIT:C86883]
+    - value: Escherichia coli strain O157:H7 [NCIT:C86883]
     slot_uri: MIXS:0001157
     multivalued: true
     range: string
@@ -12767,20 +12055,16 @@ slots:
       partial_match: true
   sewage_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: sewage type name
+      Expected_value: sewage type name
     description: Type of wastewater treatment plant as municipial or industrial
     title: sewage type
     keywords:
-      - type
+    - type
     string_serialization: '{text}'
     slot_uri: MIXS:0000215
   sexual_act:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: partner sex;frequency
+      Expected_value: partner sex;frequency
     description: Current sexual partner and frequency of sex
     title: sexual activity
     string_serialization: '{text}'
@@ -12789,59 +12073,55 @@ slots:
     description: Signs of the presence of mold or mildew on the shading device
     title: shading device signs of water/mold
     examples:
-      - value: no presence of mold visible
+    - value: no presence of mold visible
     keywords:
-      - device
+    - device
     slot_uri: MIXS:0000834
     range: MoldVisibilityEnum
   shading_device_cond:
     description: The physical condition of the shading device at the time of sampling
     title: shading device condition
     examples:
-      - value: new
+    - value: new
     keywords:
-      - condition
-      - device
+    - condition
+    - device
     slot_uri: MIXS:0000831
     range: DamagedRupturedEnum
   shading_device_loc:
     description: The location of the shading device in relation to the built structure
     title: shading device location
     examples:
-      - value: exterior
+    - value: exterior
     keywords:
-      - device
-      - location
+    - device
+    - location
     slot_uri: MIXS:0000832
     range: ShadingDeviceLocEnum
   shading_device_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: material name
+      Expected_value: material name
     description: The material the shading device is composed of
     title: shading device material
     keywords:
-      - device
-      - material
+    - device
+    - material
     string_serialization: '{text}'
     slot_uri: MIXS:0000245
   shading_device_type:
     description: The type of shading device
     title: shading device type
     examples:
-      - value: slatted aluminum
-        description: was slatted aluminum awning
+    - value: slatted aluminum
+      description: was slatted aluminum awning
     keywords:
-      - device
-      - type
+    - device
+    - type
     slot_uri: MIXS:0000835
     range: ShadingDeviceTypeEnum
   sieving:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: design name and/or size;amount
+      Expected_value: design name and/or size;amount
     description: Collection design of pooled samples and/or sieve size and amount
       of sample sieved
     title: sieving
@@ -12849,13 +12129,11 @@ slots:
     slot_uri: MIXS:0000322
   silicate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of silicate
     title: silicate
     examples:
-      - value: 0.05 micromole per liter
+    - value: 0.05 micromole per liter
     slot_uri: MIXS:0000184
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12869,11 +12147,11 @@ slots:
       used
     title: similarity search method
     examples:
-      - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
+    - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - method
+    - method
     slot_uri: MIXS:0000063
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -12883,32 +12161,28 @@ slots:
       partial_match: true
   size_frac:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: filter size value range
+      Expected_value: filter size value range
     description: Filtering pore size used in sample preparation
     title: size fraction selected
     examples:
-      - value: 0-0.22 micrometer
+    - value: 0-0.22 micrometer
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - fraction
-      - size
+    - fraction
+    - size
     string_serialization: '{float}-{float} {unit}'
     slot_uri: MIXS:0000017
   size_frac_low:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micrometer
+      Preferred_unit: micrometer
     description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample.
       Materials larger than the size threshold are excluded from the sample
     title: size-fraction lower threshold
     examples:
-      - value: 0.2 micrometer
+    - value: 0.2 micrometer
     keywords:
-      - lower
+    - lower
     slot_uri: MIXS:0000735
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12919,16 +12193,14 @@ slots:
       partial_match: true
   size_frac_up:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micrometer
+      Preferred_unit: micrometer
     description: Mesh or pore size of the device used to retain the sample. Materials
       smaller than the size threshold are excluded from the sample
     title: size-fraction upper threshold
     examples:
-      - value: 20 micrometer
+    - value: 20 micrometer
     keywords:
-      - upper
+    - upper
     slot_uri: MIXS:0000736
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12939,16 +12211,14 @@ slots:
       partial_match: true
   slope_aspect:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree
+      Preferred_unit: degree
     description: The direction a slope faces. While looking down a slope use a compass
       to record the direction you are facing (direction or degrees); e.g., nw or 315
       degrees. This measure provides an indication of sun and wind exposure that will
       influence soil temperature and evapotranspiration
     title: slope aspect
     keywords:
-      - slope
+    - slope
     slot_uri: MIXS:0000647
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12959,15 +12229,13 @@ slots:
       partial_match: true
   slope_gradient:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Commonly called 'slope'. The angle between ground surface and a horizontal
       line (in percent). This is the direction that overland water would flow. This
       measure is usually taken with a hand level meter or clinometer
     title: slope gradient
     keywords:
-      - slope
+    - slope
     slot_uri: MIXS:0000646
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12978,13 +12246,11 @@ slots:
       partial_match: true
   sludge_retent_time:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours
+      Preferred_unit: hours
     description: The time activated sludge remains in reactor
     title: sludge retention time
     keywords:
-      - time
+    - time
     slot_uri: MIXS:0000669
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12997,18 +12263,16 @@ slots:
     description: Specification of smoking status
     title: smoker
     examples:
-      - value: 'yes'
+    - value: 'yes'
     slot_uri: MIXS:0000262
     range: boolean
   sodium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Sodium concentration in the sample
     title: sodium
     examples:
-      - value: 10.5 milligram per liter
+    - value: 10.5 milligram per liter
     slot_uri: MIXS:0000428
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13019,14 +12283,12 @@ slots:
       partial_match: true
   soil_conductivity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliSiemens per centimeter
+      Preferred_unit: milliSiemens per centimeter
     title: soil conductivity
     examples:
-      - value: 10 milliSiemens per centimeter
+    - value: 10 milliSiemens per centimeter
     keywords:
-      - soil
+    - soil
     slot_uri: MIXS:0001158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13037,16 +12299,14 @@ slots:
       partial_match: true
   soil_cover:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
+      Expected_value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
     description: Material covering the sampled soil. This field accepts terms under
       ENVO:00010483, environmental material
     title: soil cover
     examples:
-      - value: bare soil [ENVO01001616]
+    - value: bare soil [ENVO01001616]
     keywords:
-      - soil
+    - soil
     string_serialization: bare soil [ENVO:01001616]
     slot_uri: MIXS:0001159
   soil_horizon:
@@ -13055,52 +12315,46 @@ slots:
       above and beneath
     title: soil horizon
     examples:
-      - value: A horizon
+    - value: A horizon
     keywords:
-      - horizon
-      - soil
+    - horizon
+    - soil
     slot_uri: MIXS:0001082
     range: SoilHorizonEnum
   soil_pH:
     title: soil pH
     examples:
-      - value: '7.2'
+    - value: '7.2'
     keywords:
-      - ph
-      - soil
+    - ph
+    - soil
     slot_uri: MIXS:0001160
     range: float
   soil_porosity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: percent porosity
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Expected_value: percent porosity
+      Preferred_unit: percentage
     description: Porosity of soil or deposited sediment is volume of voids divided
       by the total volume of sample
     title: soil sediment porosity
     examples:
-      - value: '0.2'
+    - value: '0.2'
     keywords:
-      - porosity
-      - sediment
-      - soil
+    - porosity
+    - sediment
+    - soil
     string_serialization: '{percentage}'
     slot_uri: MIXS:0001162
   soil_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of soil at the time of sampling
     title: soil temperature
     examples:
-      - value: 25 degrees Celsius
+    - value: 25 degrees Celsius
     keywords:
-      - soil
-      - temperature
+    - soil
+    - temperature
     slot_uri: MIXS:0001163
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13116,8 +12370,8 @@ slots:
       clay loam) optional
     title: soil texture
     keywords:
-      - soil
-      - texture
+    - soil
+    - texture
     slot_uri: MIXS:0000335
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13132,22 +12386,22 @@ slots:
       (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
     title: soil texture classification
     examples:
-      - value: silty clay loam
+    - value: silty clay loam
     keywords:
-      - classification
-      - soil
-      - texture
+    - classification
+    - soil
+    - texture
     slot_uri: MIXS:0001164
     range: SoilTextureClassEnum
   soil_texture_meth:
     description: Reference or method used in determining soil texture
     title: soil texture method
     examples:
-      - value: https://uwlab.soils.wisc.edu/wp-content/uploads/sites/17/2015/09/particle_size.pdf
+    - value: https://uwlab.soils.wisc.edu/wp-content/uploads/sites/17/2015/09/particle_size.pdf
     keywords:
-      - method
-      - soil
-      - texture
+    - method
+    - soil
+    - texture
     slot_uri: MIXS:0000336
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -13157,29 +12411,27 @@ slots:
       partial_match: true
   soil_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:00001998
+      Expected_value: ENVO:00001998
     description: Description of the soil type or classification. This field accepts
       terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple terms
       can be separated by pipes
     title: soil type
     examples:
-      - value: plinthosol [ENVO:00002250]
+    - value: plinthosol [ENVO:00002250]
     keywords:
-      - soil
-      - type
+    - soil
+    - type
     slot_uri: MIXS:0000332
   soil_type_meth:
     description: Reference or method used in determining soil series name or other
       lower-level classification
     title: soil type method
     examples:
-      - value: https://www.lrh.usace.army.mil/Portals/38/docs/PR/BluestoneSFEIS/Appendix%20K-Soil%20Descriptions.pdf
+    - value: https://www.lrh.usace.army.mil/Portals/38/docs/PR/BluestoneSFEIS/Appendix%20K-Soil%20Descriptions.pdf
     keywords:
-      - method
-      - soil
-      - type
+    - method
+    - soil
+    - type
     slot_uri: MIXS:0000334
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -13189,15 +12441,13 @@ slots:
       partial_match: true
   solar_irradiance:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilowatts per square meter per day, ergs per square centimeter per
+      Preferred_unit: kilowatts per square meter per day, ergs per square centimeter per
           second
     description: The amount of solar energy that arrives at a specific area of a surface
       during a specific time interval
     title: solar irradiance
     examples:
-      - value: 1.36 kilowatts per square meter per day
+    - value: 1.36 kilowatts per square meter per day
     slot_uri: MIXS:0000112
     multivalued: true
     range: string
@@ -13209,52 +12459,42 @@ slots:
       partial_match: true
   soluble_inorg_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: soluble inorganic material name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, mole per liter, gram per liter, parts per million
+      Expected_value: soluble inorganic material name;measurement value
+      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
     description: Concentration of substances such as ammonia, road-salt, sea-salt,
       cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc
     title: soluble inorganic material
     keywords:
-      - inorganic
-      - material
-      - soluble
+    - inorganic
+    - material
+    - soluble
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000672
     multivalued: true
   soluble_org_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: soluble organic material name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, mole per liter, gram per liter, parts per million
+      Expected_value: soluble organic material name;measurement value
+      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
     description: Concentration of substances such as urea, fruit sugars, soluble proteins,
       drugs, pharmaceuticals, etc
     title: soluble organic material
     keywords:
-      - material
-      - organic
-      - soluble
+    - material
+    - organic
+    - soluble
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000673
     multivalued: true
   soluble_react_phosp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of soluble reactive phosphorus
     title: soluble reactive phosphorus
     examples:
-      - value: 0.1 milligram per liter
+    - value: 0.1 milligram per liter
     keywords:
-      - phosphorus
-      - soluble
+    - phosphorus
+    - soluble
     slot_uri: MIXS:0000738
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13265,18 +12505,16 @@ slots:
       partial_match: true
   sop:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: reference to SOP
+      Expected_value: reference to SOP
     description: Standard operating procedures used in assembly and/or annotation
       of genomes, metagenomes or environmental sequences
     title: relevant standard operating procedures
     examples:
-      - value: http://press.igsb.anl.gov/earthmicrobiome/protocols-and-standards/its/
+    - value: http://press.igsb.anl.gov/earthmicrobiome/protocols-and-standards/its/
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - procedures
+    - procedures
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000090
     multivalued: true
@@ -13284,16 +12522,14 @@ slots:
     description: Method used to sort/isolate cells or particles of interest
     title: sorting technology
     examples:
-      - value: optical manipulation
+    - value: optical manipulation
     in_subset:
-      - sequencing
+    - sequencing
     slot_uri: MIXS:0000075
     range: SortTechEnum
   source_mat_id:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for cultures of microorganisms: identifiers for two culture collections;
+      Expected_value: 'for cultures of microorganisms: identifiers for two culture collections;
           for other material a unique arbitrary identifer'
     description: A unique identifier assigned to a material sample (as defined by
       http://rs.tdwg.org/dwc/terms/materialSampleID, and as opposed to a particular
@@ -13309,29 +12545,27 @@ slots:
       acids were extracted (e.g. xatc123 or ark:/2154/R2)
     title: source material identifiers
     examples:
-      - value: MPI012345
+    - value: MPI012345
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - identifier
-      - material
-      - source
+    - identifier
+    - material
+    - source
     string_serialization: '{text}'
     slot_uri: MIXS:0000026
     multivalued: true
   source_uvig:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Type of dataset from which the UViG was obtained
     title: source of UViGs
     examples:
-      - value: viral fraction metagenome (virome)
+    - value: viral fraction metagenome (virome)
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - source
+    - source
     string_serialization: '[metagenome (not viral targeted)|viral fraction metagenome
       (virome)|sequence-targeted metagenome|metatranscriptome (not viral targeted)|viral
       fraction RNA metagenome (RNA virome)|sequence-targeted RNA metagenome|microbial
@@ -13342,7 +12576,7 @@ slots:
     description: Customary or normal state of the space
     title: space typical state
     examples:
-      - value: typically occupied
+    - value: typically occupied
     slot_uri: MIXS:0000770
     range: SpaceTypStateEnum
     required: true
@@ -13352,9 +12586,9 @@ slots:
       (http://purl.obolibrary.org/obo/FOODON_03510136)
     title: specific intended consumer
     examples:
-      - value: senior as food consumer [FOODON:03510254]
+    - value: senior as food consumer [FOODON:03510254]
     keywords:
-      - consumer
+    - consumer
     slot_uri: MIXS:0001234
     multivalued: true
     range: string
@@ -13365,15 +12599,13 @@ slots:
       partial_match: true
   special_diet:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Specification of special diet; can include multiple special diets
     title: special diet
     examples:
-      - value: other:vegan
+    - value: other:vegan
     keywords:
-      - diet
+    - diet
     string_serialization: '[low carb|reduced calorie|vegetarian|other(to be specified)]'
     slot_uri: MIXS:0000905
     multivalued: true
@@ -13382,38 +12614,34 @@ slots:
       conceptual, schematic, design development, construction documents'
     title: specifications
     examples:
-      - value: construction
+    - value: construction
     slot_uri: MIXS:0000836
     range: SpecificEnum
   specific_host:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: host scientific name, taxonomy ID
+      Expected_value: host scientific name, taxonomy ID
     description: Report the host's taxonomic name and/or NCBI taxonomy ID
     title: host scientific name
     examples:
-      - value: Homo sapiens and/or 9606
+    - value: Homo sapiens and/or 9606
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     string_serialization: '{text}|{NCBI taxid}'
     slot_uri: MIXS:0000029
   specific_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram of air, kilogram of air
+      Preferred_unit: gram of air, kilogram of air
     description: The mass of water vapour in a unit mass of moist air, usually expressed
       as grams of vapour per kilogram of air, or, in air conditioning, as grains per
       pound
     title: specific humidity
     examples:
-      - value: 15 per kilogram of air
+    - value: 15 per kilogram of air
     keywords:
-      - humidity
+    - humidity
     slot_uri: MIXS:0000214
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13424,46 +12652,38 @@ slots:
       partial_match: true
   spikein_AMR:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value ARO:3004299
+      Expected_value: measurement value ARO:3004299
     description: Qualitative description of a microbial response to antimicrobial
       agents. Bacteria may be susceptible or resistant to a broad range of antibiotic
       drugs or drug classes, with several intermediate states or phases. This field
       accepts terms under antimicrobial phenotype (http://purl.obolibrary.org/obo/ARO_3004299)
     title: antimicrobial phenotype of spike-in bacteria
     examples:
-      - value: wild type [ARO:3004432]
+    - value: wild type [ARO:3004432]
     keywords:
-      - antimicrobial
-      - spike
+    - antimicrobial
+    - spike
     string_serialization: '{float} {unit};{termLabel} [{termID}]'
     slot_uri: MIXS:0001235
     multivalued: true
   spikein_antibiotic:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: drug name; concentration
+      Expected_value: drug name; concentration
     description: Antimicrobials used in research study to assess effects of exposure
       on microbiome of a specific site.  Please list antimicrobial, common name and/or
       class and concentration used for spike-in
     title: spike-in with antibiotics
     examples:
-      - value: Tetracycline at 5 mg/ml
+    - value: Tetracycline at 5 mg/ml
     keywords:
-      - spike
+    - spike
     string_serialization: '{text} {integer}'
     slot_uri: MIXS:0001171
     multivalued: true
   spikein_count:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: organism name;measurement value;enumeration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: colony forming units per milliliter; colony forming units per gram
+      Expected_value: organism name;measurement value;enumeration
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram
           of dry weight
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
@@ -13471,11 +12691,11 @@ slots:
       also be provided (example: total prokaryotes; 3.5e7 cells per ml; qPCR)'
     title: spike-in organism count
     examples:
-      - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+    - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
     keywords:
-      - count
-      - organism
-      - spike
+    - count
+    - organism
+    - spike
     string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|other]'
     slot_uri: MIXS:0001335
   spikein_growth_med:
@@ -13490,10 +12710,10 @@ slots:
       in growth media
     title: spike-in growth medium
     examples:
-      - value: LB broth [MCO:0000036]
+    - value: LB broth [MCO:0000036]
     keywords:
-      - growth
-      - spike
+    - growth
+    - spike
     slot_uri: MIXS:0001169
     multivalued: true
     range: string
@@ -13504,18 +12724,16 @@ slots:
       partial_match: true
   spikein_metal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: heavy metal name or chemical symbol; concentration
+      Expected_value: heavy metal name or chemical symbol; concentration
     description: Heavy metals used in research study to assess effects of exposure
       on microbiome of a specific site.  Please list heavy metals and concentration
       used for spike-in
     title: spike-in with heavy metals
     examples:
-      - value: Cd at 20 ppm
+    - value: Cd at 20 ppm
     keywords:
-      - heavy
-      - spike
+    - heavy
+    - spike
     string_serialization: '{text} {integer}'
     slot_uri: MIXS:0001172
     multivalued: true
@@ -13526,10 +12744,10 @@ slots:
       Multiple terms can be separated by pipes
     title: spike in organism
     examples:
-      - value: Listeria monocytogenes [NCIT:C86502]|28901
+    - value: Listeria monocytogenes [NCIT:C86502]|28901
     keywords:
-      - organism
-      - spike
+    - organism
+    - spike
     slot_uri: MIXS:0001167
     multivalued: true
     range: string
@@ -13540,36 +12758,32 @@ slots:
       partial_match: true
   spikein_serovar:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C14250 or antigenic formula or serovar name
+      Expected_value: NCIT:C14250 or antigenic formula or serovar name
     description: Taxonomic information about the spike-in organism(s) at the serovar
       or serotype level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
       Multiple terms can be separated by pipes
     title: spike-in bacterial serovar or serotype
     examples:
-      - value: Escherichia coli strain O157:H7 [NCIT:C86883]|83334
+    - value: Escherichia coli strain O157:H7 [NCIT:C86883]|83334
     keywords:
-      - spike
+    - spike
     string_serialization: '{termLabel} [{termID}]|{integer}'
     slot_uri: MIXS:0001168
     multivalued: true
   spikein_strain:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C14250 or NCBI taxid or text
+      Expected_value: NCIT:C14250 or NCBI taxid or text
     description: Taxonomic information about the spike-in organism(s) at the strain
       level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
       Multiple terms can be separated by pipes
     title: spike-in microbial strain
     examples:
-      - value: '169963'
+    - value: '169963'
     keywords:
-      - microbial
-      - spike
+    - microbial
+    - spike
     string_serialization: '{termLabel} [{termID}]|{integer}'
     slot_uri: MIXS:0001170
     multivalued: true
@@ -13578,10 +12792,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: source rock depositional environment
     examples:
-      - value: Marine
+    - value: Marine
     keywords:
-      - environment
-      - source
+    - environment
+    - source
     slot_uri: MIXS:0000996
     range: SrDepEnvEnum
   sr_geol_age:
@@ -13589,10 +12803,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: source rock geological age
     examples:
-      - value: Silurian
+    - value: Silurian
     keywords:
-      - age
-      - source
+    - age
+    - source
     slot_uri: MIXS:0000997
     range: GeolAgeEnum
   sr_kerog_type:
@@ -13603,10 +12817,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: source rock kerogen type
     examples:
-      - value: Type IV
+    - value: Type IV
     keywords:
-      - source
-      - type
+    - source
+    - type
     slot_uri: MIXS:0000994
     range: SrKerogTypeEnum
   sr_lithology:
@@ -13614,10 +12828,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: source rock lithology
     examples:
-      - value: Coal
+    - value: Coal
     keywords:
-      - lithology
-      - source
+    - lithology
+    - source
     slot_uri: MIXS:0000995
     range: SrLithologyEnum
   standing_water_regm:
@@ -13627,67 +12841,59 @@ slots:
       the start and end time of the entire treatment; can include multiple regimens
     title: standing water regimen
     examples:
-      - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
-      - water
+    - regimen
+    - water
     slot_uri: MIXS:0001069
     multivalued: true
     range: string
   ster_meth_samp_room:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:01001026
+      Expected_value: ENVO:01001026
     description: The method used to sterilize the sampling room. This field accepts
       terms listed under electromagnetic radiation (http://purl.obolibrary.org/obo/ENVO_01001026).
       If the proper descriptor is not listed, please use text to describe the sampling
       room sterilization method. Multiple terms can be separated by pipes
     title: sampling room sterilization method
     examples:
-      - value: ultraviolet radiation [ENVO:21001216]|infrared radiation [ENVO:21001214]
+    - value: ultraviolet radiation [ENVO:21001216]|infrared radiation [ENVO:21001214]
     keywords:
-      - method
-      - room
+    - method
+    - room
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001259
     multivalued: true
   store_cond:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: storage condition type;duration
+      Expected_value: storage condition type;duration
     description: Explain how and for how long the soil sample was stored before DNA
       extraction (fresh/frozen/other)
     title: storage conditions
     examples:
-      - value: -20 degree Celsius freezer;P2Y10D
+    - value: -20 degree Celsius freezer;P2Y10D
     keywords:
-      - condition
-      - storage
+    - condition
+    - storage
     string_serialization: '{text};{period}'
     slot_uri: MIXS:0000327
   study_complt_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
+      Expected_value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
           up (4)other-specify
     description: Specification of study completion status, if no the reason should
       be specified
     title: study completion status
     examples:
-      - value: no;non-compliance
+    - value: no;non-compliance
     keywords:
-      - status
+    - status
     string_serialization: '{boolean};[adverse event|non-compliance|lost to follow
       up|other-specify]'
     slot_uri: MIXS:0000898
   study_design:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: OBI:0500000
+      Expected_value: OBI:0500000
     description: A plan specification comprised of protocols (which may specify how
       and what kinds of data will be gathered) that are executed as part of an investigation
       and is realized during a study design execution. This field accepts terms under
@@ -13696,24 +12902,22 @@ slots:
       be separated by pipes
     title: study design
     examples:
-      - value: in vitro design [OBI:0001285]
+    - value: in vitro design [OBI:0001285]
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001236
     multivalued: true
   study_inc_dur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours or days
+      Preferred_unit: hours or days
     description: Sample incubation duration if unpublished or unvalidated method is
       used. Indicate the timepoint written in ISO 8601 format
     title: study incubation duration
     examples:
-      - value: PT24H
+    - value: PT24H
     keywords:
-      - duration
-      - incubation
-      - period
+    - duration
+    - incubation
+    - period
     slot_uri: MIXS:0001237
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -13723,17 +12927,15 @@ slots:
       partial_match: true
   study_inc_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Sample incubation temperature if unpublished or unvalidated method
       is used
     title: study incubation temperature
     examples:
-      - value: 37 degree Celsius
+    - value: 37 degree Celsius
     keywords:
-      - incubation
-      - temperature
+    - incubation
+    - temperature
     slot_uri: MIXS:0001238
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13744,18 +12946,16 @@ slots:
       partial_match: true
   study_timecourse:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: dpi
+      Preferred_unit: dpi
     description: For time-course research studies involving samples of the food commodity,
       indicate the total duration of the time-course study
     title: time-course duration
     examples:
-      - value: 2 days post inoculation
+    - value: 2 days post inoculation
     keywords:
-      - duration
-      - period
-      - time
+    - duration
+    - period
+    - time
     slot_uri: MIXS:0001239
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13766,9 +12966,7 @@ slots:
       partial_match: true
   study_tmnt:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: MCO:0000866
+      Expected_value: MCO:0000866
     description: A process in which the act is intended to modify or alter some other
       material entity.  From the study design, each treatment is comprised of one
       level of one or multiple factors. This field accepts terms listed under treatment
@@ -13777,17 +12975,15 @@ slots:
       separated by one or more pipes
     title: study treatment
     examples:
-      - value: Factor A|spike-in|levels high, medium, low
+    - value: Factor A|spike-in|levels high, medium, low
     keywords:
-      - treatment
+    - treatment
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001240
     multivalued: true
   subspecf_gen_lin:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
+      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
           e.g. serovar, biotype, ecotype, variety, cultivar
     description: Information about the genetic distinctness of the sequenced organism
       below the subspecies level, e.g., serovar, serotype, biotype, ecotype, or any
@@ -13796,11 +12992,11 @@ slots:
       name and the lineage rank separated by a colon, e.g., biovar:abc123
     title: subspecific genetic lineage
     examples:
-      - value: serovar:Newport
+    - value: serovar:Newport
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - lineage
+    - lineage
     string_serialization: '{rank name}:{text}'
     slot_uri: MIXS:0000020
   substructure_type:
@@ -13808,23 +13004,21 @@ slots:
       of the building which is built off the foundations to the ground floor level
     title: substructure type
     examples:
-      - value: basement
+    - value: basement
     keywords:
-      - type
+    - type
     slot_uri: MIXS:0000767
     multivalued: true
     range: SubstructureTypeEnum
   sulfate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of sulfate in the sample
     title: sulfate
     examples:
-      - value: 5 micromole per liter
+    - value: 5 micromole per liter
     keywords:
-      - sulfate
+    - sulfate
     slot_uri: MIXS:0000423
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13835,14 +13029,12 @@ slots:
       partial_match: true
   sulfate_fw:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Original sulfate concentration in the hydrocarbon resource
     title: sulfate in formation water
     keywords:
-      - sulfate
-      - water
+    - sulfate
+    - water
     slot_uri: MIXS:0000407
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13853,15 +13045,13 @@ slots:
       partial_match: true
   sulfide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of sulfide in the sample
     title: sulfide
     examples:
-      - value: 2 micromole per liter
+    - value: 2 micromole per liter
     keywords:
-      - sulfide
+    - sulfide
     slot_uri: MIXS:0000424
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13874,25 +13064,23 @@ slots:
     description: Contaminant identified on surface
     title: surface-air contaminant
     examples:
-      - value: radon
+    - value: radon
     slot_uri: MIXS:0000759
     multivalued: true
     range: SurfAirContEnum
     recommended: true
   surf_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: 'Surfaces: water activity as a function of air and material moisture'
     title: surface humidity
     comments:
-      - percent or float?
+    - percent or float?
     examples:
-      - value: '0.1'
+    - value: '0.1'
     keywords:
-      - humidity
-      - surface
+    - humidity
+    - surface
     slot_uri: MIXS:0000123
     range: float
     recommended: true
@@ -13906,24 +13094,22 @@ slots:
     description: Surface materials at the point of sampling
     title: surface material
     examples:
-      - value: wood
+    - value: wood
     keywords:
-      - material
-      - surface
+    - material
+    - surface
     slot_uri: MIXS:0000758
     range: SurfMaterialEnum
   surf_moisture:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: parts per million, gram per cubic meter, gram per square meter
+      Preferred_unit: parts per million, gram per cubic meter, gram per square meter
     description: Water held on a surface
     title: surface moisture
     examples:
-      - value: 0.01 gram per square meter
+    - value: 0.01 gram per square meter
     keywords:
-      - moisture
-      - surface
+    - moisture
+    - surface
     slot_uri: MIXS:0000128
     range: string
     recommended: true
@@ -13937,26 +13123,24 @@ slots:
     description: ph measurement of surface
     title: surface moisture pH
     examples:
-      - value: '7'
+    - value: '7'
     keywords:
-      - moisture
-      - ph
-      - surface
+    - moisture
+    - ph
+    - surface
     slot_uri: MIXS:0000760
     range: float
     recommended: true
   surf_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of the surface at the time of sampling
     title: surface temperature
     examples:
-      - value: 15 degree Celsius
+    - value: 15 degree Celsius
     keywords:
-      - surface
-      - temperature
+    - surface
+    - temperature
     slot_uri: MIXS:0000125
     range: string
     recommended: true
@@ -13968,17 +13152,15 @@ slots:
       partial_match: true
   suspend_part_matter:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Concentration of suspended particulate matter
     title: suspended particulate matter
     examples:
-      - value: 0.5 milligram per liter
+    - value: 0.5 milligram per liter
     keywords:
-      - particle
-      - particulate
-      - suspended
+    - particle
+    - particulate
+    - suspended
     slot_uri: MIXS:0000741
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13989,40 +13171,34 @@ slots:
       partial_match: true
   suspend_solids:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: suspended solid name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, milligram per liter, mole per liter, gram per liter,
+      Expected_value: suspended solid name;measurement value
+      Preferred_unit: gram, microgram, milligram per liter, mole per liter, gram per liter,
           part per million
     description: Concentration of substances including a wide variety of material,
       such as silt, decaying plant and animal matter; can include multiple substances
     title: suspended solids
     keywords:
-      - solids
-      - suspended
+    - solids
+    - suspended
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000150
     multivalued: true
   sym_life_cycle_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: type of life cycle of the symbiotic organism (host of the samples)
+      Expected_value: type of life cycle of the symbiotic organism (host of the samples)
     description: Type of life cycle of the symbiotic host species (the thing being
       sampled). Simple life cycles occur within a single host, complex ones within
       multiple different hosts over the course of their normal life cycle
     title: symbiotic host organism life cycle type
     examples:
-      - value: complex life cycle
+    - value: complex life cycle
     keywords:
-      - host
-      - host.
-      - life
-      - organism
-      - symbiosis
-      - type
+    - host
+    - host.
+    - life
+    - organism
+    - symbiosis
+    - type
     slot_uri: MIXS:0001300
     range: SymLifeCycleTypeEnum
     required: true
@@ -14030,27 +13206,25 @@ slots:
     description: Role of the host in the life cycle of the symbiotic organism
     title: host of the symbiont role
     examples:
-      - value: intermediate
+    - value: intermediate
     keywords:
-      - host
-      - host.
-      - symbiosis
+    - host
+    - host.
+    - symbiosis
     slot_uri: MIXS:0001303
     range: SymbiontHostRoleEnum
     recommended: true
   tan:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: 'Total Acid Number  (TAN) is a measurement of acidity that is determined
       by the amount of  potassium hydroxide  in milligrams that is needed to neutralize
       the acids in one gram of oil.  It is an important quality measurement of  crude
       oil. (source: https://en.wikipedia.org/wiki/Total_acid_number)'
     title: total acid number
     keywords:
-      - number
-      - total
+    - number
+    - total
     slot_uri: MIXS:0000120
     range: string
     recommended: true
@@ -14064,11 +13238,11 @@ slots:
     description: Targeted gene or locus name for marker gene studies
     title: target gene
     examples:
-      - value: 16S rRNA, 18S rRNA, nif, amoA, rpo
+    - value: 16S rRNA, 18S rRNA, nif, amoA, rpo
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - target
+    - target
     slot_uri: MIXS:0000044
     range: string
   target_subfragment:
@@ -14076,11 +13250,11 @@ slots:
       special regions on marker genes like V6 on 16S rRNA
     title: target subfragment
     examples:
-      - value: V6, V9, ITS
+    - value: V6, V9, ITS
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - target
+    - target
     slot_uri: MIXS:0000045
     range: string
   tax_class:
@@ -14088,13 +13262,13 @@ slots:
       used, classification rank, and thresholds used to classify new genomes
     title: taxonomic classification
     examples:
-      - value: vConTACT vContact2 (references from NCBI RefSeq v83, genus rank classification,
-          default parameters)
+    - value: vConTACT vContact2 (references from NCBI RefSeq v83, genus rank classification,
+        default parameters)
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - classification
-      - taxon
+    - classification
+    - taxon
     slot_uri: MIXS:0000064
     range: string
   tax_ident:
@@ -14102,29 +13276,27 @@ slots:
       SAG or MAG
     title: taxonomic identity marker
     examples:
-      - value: other
-        description: was other <colon> rpoB gene
+    - value: other
+      description: was other <colon> rpoB gene
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - identifier
-      - marker
-      - taxon
+    - identifier
+    - marker
+    - taxon
     slot_uri: MIXS:0000053
     range: TaxIdentEnum
   temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of the sample at the time of sampling
     title: temperature
     examples:
-      - value: 25 degree Celsius
+    - value: 25 degree Celsius
     in_subset:
-      - environment
+    - environment
     keywords:
-      - temperature
+    - temperature
     slot_uri: MIXS:0000113
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14135,16 +13307,14 @@ slots:
       partial_match: true
   temp_out:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The recorded temperature value at sampling time outside
     title: temperature outside house
     examples:
-      - value: 5 degree Celsius
+    - value: 5 degree Celsius
     keywords:
-      - house
-      - temperature
+    - house
+    - temperature
     slot_uri: MIXS:0000197
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14155,30 +13325,28 @@ slots:
       partial_match: true
   tertiary_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: tertiary treatment type
+      Expected_value: tertiary treatment type
     description: The process providing a final treatment stage to raise the effluent
       quality before it is discharged to the receiving environment
     title: tertiary treatment
     keywords:
-      - treatment
+    - treatment
     string_serialization: '{text}'
     slot_uri: MIXS:0000352
   tidal_stage:
     description: Stage of tide
     title: tidal stage
     examples:
-      - value: high tide
+    - value: high tide
     slot_uri: MIXS:0000750
     range: TidalStageEnum
   tillage:
     description: Note method(s) used for tilling
     title: history/tillage
     examples:
-      - value: chisel
+    - value: chisel
     keywords:
-      - history
+    - history
     slot_uri: MIXS:0001081
     multivalued: true
     range: TillageEnum
@@ -14186,12 +13354,12 @@ slots:
     description: Specification of the time since last toothbrushing
     title: time since last toothbrushing
     comments:
-      - P2H45M does not match ^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d+[HMS])(\\d+H)?(\\d+M)?(\\d+S)?)?$
-      - problematic ISO 8601 period validation
+    - P2H45M does not match ^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d+[HMS])(\\d+H)?(\\d+M)?(\\d+S)?)?$
+    - problematic ISO 8601 period validation
     examples:
-      - value: PT2H45M
+    - value: PT2H45M
     keywords:
-      - time
+    - time
     slot_uri: MIXS:0000924
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -14203,9 +13371,9 @@ slots:
     description: Specification of the time since last wash
     title: time since last wash
     examples:
-      - value: P1D
+    - value: P1D
     keywords:
-      - time
+    - time
     slot_uri: MIXS:0000943
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -14215,17 +13383,15 @@ slots:
       partial_match: true
   timepoint:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours or days
+      Preferred_unit: hours or days
     description: Time point at which a sample or observation is made or taken from
       a biomaterial as measured from some reference point. Indicate the timepoint
       written in ISO 8601 format
     title: timepoint
     examples:
-      - value: PT24H
+    - value: PT24H
     keywords:
-      - time
+    - time
     slot_uri: MIXS:0001173
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -14237,10 +13403,10 @@ slots:
     description: Description of plant tissue culture growth media used
     title: tissue culture growth media
     examples:
-      - value: https://link.springer.com/content/pdf/10.1007/BF02796489.pdf
+    - value: https://link.springer.com/content/pdf/10.1007/BF02796489.pdf
     keywords:
-      - culture
-      - growth
+    - culture
+    - growth
     slot_uri: MIXS:0001070
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -14250,9 +13416,7 @@ slots:
       partial_match: true
   toluene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of toluene in the sample
     title: toluene
     slot_uri: MIXS:0000154
@@ -14268,8 +13432,8 @@ slots:
     description: Total carbon content
     title: total carbon
     keywords:
-      - carbon
-      - total
+    - carbon
+    - total
     slot_uri: MIXS:0000525
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14280,17 +13444,15 @@ slots:
       partial_match: true
   tot_depth_water_col:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Measurement of total depth of water column
     title: total depth of water column
     examples:
-      - value: 500 meter
+    - value: 500 meter
     keywords:
-      - depth
-      - total
-      - water
+    - depth
+    - total
+    - water
     slot_uri: MIXS:0000634
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14301,18 +13463,16 @@ slots:
       partial_match: true
   tot_diss_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter
+      Preferred_unit: microgram per liter
     description: 'Total dissolved nitrogen concentration, reported as nitrogen, measured
       by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen'
     title: total dissolved nitrogen
     examples:
-      - value: 40 microgram per liter
+    - value: 40 microgram per liter
     keywords:
-      - dissolved
-      - nitrogen
-      - total
+    - dissolved
+    - nitrogen
+    - total
     slot_uri: MIXS:0000744
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14323,17 +13483,15 @@ slots:
       partial_match: true
   tot_inorg_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter
+      Preferred_unit: microgram per liter
     description: Total inorganic nitrogen content
     title: total inorganic nitrogen
     examples:
-      - value: 40 microgram per liter
+    - value: 40 microgram per liter
     keywords:
-      - inorganic
-      - nitrogen
-      - total
+    - inorganic
+    - nitrogen
+    - total
     slot_uri: MIXS:0000745
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14344,13 +13502,11 @@ slots:
       partial_match: true
   tot_iron:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, milligram per kilogram
+      Preferred_unit: milligram per liter, milligram per kilogram
     description: Concentration of total iron in the sample
     title: total iron
     keywords:
-      - total
+    - total
     slot_uri: MIXS:0000105
     range: string
     recommended: true
@@ -14362,19 +13518,17 @@ slots:
       partial_match: true
   tot_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter, milligram per liter
+      Preferred_unit: microgram per liter, micromole per liter, milligram per liter
     description: 'Total nitrogen concentration of water samples, calculated by: total
       nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured
       without filtering, reported as nitrogen'
     title: total nitrogen concentration
     examples:
-      - value: 50 micromole per liter
+    - value: 50 micromole per liter
     keywords:
-      - concentration
-      - nitrogen
-      - total
+    - concentration
+    - nitrogen
+    - total
     slot_uri: MIXS:0000102
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14387,12 +13541,12 @@ slots:
     description: Reference or method used in determining the total nitrogen
     title: total nitrogen content method
     examples:
-      - value: https://currentprotocols.onlinelibrary.wiley.com/doi/abs/10.1002/0471142913.fab0102s00
+    - value: https://currentprotocols.onlinelibrary.wiley.com/doi/abs/10.1002/0471142913.fab0102s00
     keywords:
-      - content
-      - method
-      - nitrogen
-      - total
+    - content
+    - method
+    - nitrogen
+    - total
     slot_uri: MIXS:0000338
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -14404,11 +13558,11 @@ slots:
     description: Total nitrogen content of the sample
     title: total nitrogen content
     examples:
-      - value: 35 milligrams Nitrogen per kilogram of soil
+    - value: 35 milligrams Nitrogen per kilogram of soil
     keywords:
-      - content
-      - nitrogen
-      - total
+    - content
+    - nitrogen
+    - total
     slot_uri: MIXS:0000530
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14421,12 +13575,12 @@ slots:
     description: Reference or method used in determining total organic carbon
     title: total organic carbon method
     examples:
-      - value: https://www.epa.gov/sites/production/files/2015-12/documents/9060a.pdf
+    - value: https://www.epa.gov/sites/production/files/2015-12/documents/9060a.pdf
     keywords:
-      - carbon
-      - method
-      - organic
-      - total
+    - carbon
+    - method
+    - organic
+    - total
     slot_uri: MIXS:0000337
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -14436,17 +13590,15 @@ slots:
       partial_match: true
   tot_org_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram Carbon per kilogram sample material
+      Preferred_unit: gram Carbon per kilogram sample material
     description: Total organic carbon content
     title: total organic carbon
     examples:
-      - value: '0.02'
+    - value: '0.02'
     keywords:
-      - carbon
-      - organic
-      - total
+    - carbon
+    - organic
+    - total
     slot_uri: MIXS:0000533
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14457,18 +13609,16 @@ slots:
       partial_match: true
   tot_part_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Total particulate carbon content
     title: total particulate carbon
     examples:
-      - value: 35 micromole per liter
+    - value: 35 micromole per liter
     keywords:
-      - carbon
-      - particle
-      - particulate
-      - total
+    - carbon
+    - particle
+    - particulate
+    - total
     slot_uri: MIXS:0000747
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14479,17 +13629,15 @@ slots:
       partial_match: true
   tot_phosp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: 'Total phosphorus concentration in the sample, calculated by: total
       phosphorus = total dissolved phosphorus + particulate phosphorus'
     title: total phosphorus
     examples:
-      - value: 0.03 milligram per liter
+    - value: 0.03 milligram per liter
     keywords:
-      - phosphorus
-      - total
+    - phosphorus
+    - total
     slot_uri: MIXS:0000117
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14500,14 +13648,12 @@ slots:
       partial_match: true
   tot_phosphate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Total amount or concentration of phosphate
     title: total phosphate
     keywords:
-      - phosphate
-      - total
+    - phosphate
+    - total
     slot_uri: MIXS:0000689
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14518,14 +13664,12 @@ slots:
       partial_match: true
   tot_sulfur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of total sulfur in the sample
     title: total sulfur
     keywords:
-      - sulfur
-      - total
+    - sulfur
+    - total
     slot_uri: MIXS:0000419
     range: string
     recommended: true
@@ -14539,42 +13683,40 @@ slots:
     description: The subway line name
     title: train line
     examples:
-      - value: red
+    - value: red
     keywords:
-      - train
+    - train
     slot_uri: MIXS:0000837
     range: TrainLineEnum
   train_stat_loc:
     description: The train station collection location
     title: train station collection location
     examples:
-      - value: forest hills
+    - value: forest hills
     keywords:
-      - location
-      - train
+    - location
+    - train
     slot_uri: MIXS:0000838
     range: TrainStatLocEnum
   train_stop_loc:
     description: The train stop collection location
     title: train stop collection location
     examples:
-      - value: end
+    - value: end
     keywords:
-      - location
-      - stop
-      - train
+    - location
+    - stop
+    - train
     slot_uri: MIXS:0000839
     range: TrainStopLocEnum
   travel_out_six_month:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: country name
+      Expected_value: country name
     description: Specification of the countries travelled in the last six months;
       can include multiple travels
     title: travel outside the country in last six months
     keywords:
-      - months
+    - months
     string_serialization: '{text}'
     slot_uri: MIXS:0000268
     multivalued: true
@@ -14582,11 +13724,11 @@ slots:
     description: Tools used for tRNA identification
     title: tRNA extraction software
     examples:
-      - value: infernal;v2;default parameters
+    - value: infernal;v2;default parameters
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - software
+    - software
     slot_uri: MIXS:0000068
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -14596,17 +13738,15 @@ slots:
       partial_match: true
   trnas:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: value from 0-21
+      Expected_value: value from 0-21
     description: The total number of tRNAs identified from the SAG or MAG
     title: number of standard tRNAs extracted
     examples:
-      - value: '18'
+    - value: '18'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - number
+    - number
     string_serialization: '{integer}'
     slot_uri: MIXS:0000067
   trophic_level:
@@ -14614,11 +13754,11 @@ slots:
       can be a range of producers (e.g. chemolithotroph)
     title: trophic level
     examples:
-      - value: heterotroph
+    - value: heterotroph
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - level
+    - level
     slot_uri: MIXS:0000032
     range: TrophicLevelEnum
   turbidity:
@@ -14626,7 +13766,7 @@ slots:
       individual particles
     title: turbidity
     examples:
-      - value: 0.3 nephelometric turbidity units
+    - value: 0.3 nephelometric turbidity units
     slot_uri: MIXS:0000191
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14637,17 +13777,15 @@ slots:
       partial_match: true
   tvdss_of_hcr_press:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where
       the original pressure was measured (e.g. 1578 m)
     title: depth (TVDSS) of hydrocarbon resource pressure
     keywords:
-      - depth
-      - hydrocarbon
-      - pressure
-      - resource
+    - depth
+    - hydrocarbon
+    - pressure
+    - resource
     slot_uri: MIXS:0000397
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14658,17 +13796,15 @@ slots:
       partial_match: true
   tvdss_of_hcr_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where
       the original temperature was measured (e.g. 1345 m)
     title: depth (TVDSS) of hydrocarbon resource temperature
     keywords:
-      - depth
-      - hydrocarbon
-      - resource
-      - temperature
+    - depth
+    - hydrocarbon
+    - resource
+    - temperature
     slot_uri: MIXS:0000394
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14681,18 +13817,18 @@ slots:
     description: Specification of twin sibling presence
     title: twin sibling presence
     examples:
-      - value: 'yes'
+    - value: 'yes'
     keywords:
-      - presence
+    - presence
     slot_uri: MIXS:0000326
     range: boolean
   typ_occup_density:
     description: Customary or normal density of occupants
     title: typical occupant density
     examples:
-      - value: '25'
+    - value: '25'
     keywords:
-      - density
+    - density
     slot_uri: MIXS:0000771
     range: float
     required: true
@@ -14701,10 +13837,10 @@ slots:
       host organism being sampled and its respective host
     title: type of symbiosis
     examples:
-      - value: parasitic
+    - value: parasitic
     keywords:
-      - symbiosis
-      - type
+    - symbiosis
+    - type
     slot_uri: MIXS:0001307
     range: TypeOfSymbiosisEnum
     recommended: true
@@ -14712,21 +13848,19 @@ slots:
     description: Specification of urine collection method
     title: urine/collection method
     examples:
-      - value: catheter
+    - value: catheter
     keywords:
-      - method
+    - method
     slot_uri: MIXS:0000899
     range: UrineCollectMethEnum
   urobiom_sex:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: sex of the symbiotic organism (host of the samples); enumeration
+      Expected_value: sex of the symbiotic organism (host of the samples); enumeration
     description: Physical sex of the host
     title: host sex
     keywords:
-      - host
-      - host.
+    - host
+    - host.
     slot_uri: MIXS:0000862
     range: UrobiomSexEnum
   urogenit_disord:
@@ -14736,7 +13870,7 @@ slots:
       system disease (https://disease-ontology.org/?id=DOID:18)
     title: urogenital disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000289
     multivalued: true
     range: string
@@ -14746,21 +13880,19 @@ slots:
       urinary system disease (https://disease-ontology.org/?id=DOID:18)
     title: urine/urogenital tract disorder
     keywords:
-      - disorder
+    - disorder
     slot_uri: MIXS:0000278
     multivalued: true
     range: string
   ventilation_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per minute, liters per second
+      Preferred_unit: cubic meter per minute, liters per second
     description: Ventilation rate of the system in the sampled premises
     title: ventilation rate
     examples:
-      - value: 750 cubic meter per minute
+    - value: 750 cubic meter per minute
     keywords:
-      - rate
+    - rate
     slot_uri: MIXS:0000114
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14771,23 +13903,19 @@ slots:
       partial_match: true
   ventilation_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ventilation type name
+      Expected_value: ventilation type name
     description: Ventilation system used in the sampled premises
     title: ventilation type
     examples:
-      - value: Operable windows
+    - value: Operable windows
     keywords:
-      - type
+    - type
     string_serialization: '{text}'
     slot_uri: MIXS:0000756
     multivalued: true
   vfa:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of Volatile Fatty Acids in the sample
     title: volatile fatty acids
     slot_uri: MIXS:0000152
@@ -14801,13 +13929,11 @@ slots:
       partial_match: true
   vfa_fw:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Original volatile fatty acid concentration in the hydrocarbon resource
     title: vfa in formation water
     keywords:
-      - water
+    - water
     slot_uri: MIXS:0000408
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14818,59 +13944,51 @@ slots:
       partial_match: true
   vir_ident_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: software name, version and relevant parameters
+      Expected_value: software name, version and relevant parameters
     description: Tool(s) used for the identification of UViG as a viral genome, software
       or protocol name including version number, parameters, and cutoffs used
     title: viral identification software
     examples:
-      - value: VirSorter; 1.0.4; Virome database, category 2
+    - value: VirSorter; 1.0.4; Virome database, category 2
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - identifier
-      - software
+    - identifier
+    - software
     string_serialization: '{software};{version};{parameters}'
     slot_uri: MIXS:0000081
   virus_enrich_appr:
     description: List of approaches used to enrich the sample for viruses, if any
     title: virus enrichment approach
     examples:
-      - value: filtration
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
-      - value: FeCl Precipitation
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
-      - value: ultracentrifugation
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
-      - value: DNAse
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+    - value: filtration
+      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+    - value: FeCl Precipitation
+      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+    - value: ultracentrifugation
+      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+    - value: DNAse
+      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
     in_subset:
-      - nucleic acid sequence source
+    - nucleic acid sequence source
     keywords:
-      - enrichment
+    - enrichment
     slot_uri: MIXS:0000036
     range: VirusEnrichApprEnum
   vis_media:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The building visual media
     title: visual media
     examples:
-      - value: 3D scans
+    - value: 3D scans
     string_serialization: '[photos|videos|commonly of the building|site context (adjacent
       buildings, vegetation, terrain, streets)|interiors|equipment|3D scans]'
     slot_uri: MIXS:0000840
   viscosity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cP at degree Celsius
+      Expected_value: measurement value;measurement value
+      Preferred_unit: cP at degree Celsius
     description: A measure of oil's resistance  to gradual deformation by  shear stress  or  tensile
       stress (e.g. 3.5 cp; 100   C)
     title: viscosity
@@ -14878,33 +13996,27 @@ slots:
     slot_uri: MIXS:0000126
   volatile_org_comp:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: volatile organic compound name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per cubic meter, parts per million, nanogram per liter
+      Expected_value: volatile organic compound name;measurement value
+      Preferred_unit: microgram per cubic meter, parts per million, nanogram per liter
     description: Concentration of carbon-based chemicals that easily evaporate at
       room temperature; can report multiple volatile organic compounds by entering
       numeric values preceded by name of compound
     title: volatile organic compounds
     examples:
-      - value: formaldehyde;500 nanogram per liter
+    - value: formaldehyde;500 nanogram per liter
     keywords:
-      - organic
+    - organic
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000115
     multivalued: true
   wall_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The total area of the sampled room's walls
     title: wall area
     keywords:
-      - area
-      - wall
+    - area
+    - wall
     slot_uri: MIXS:0000198
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14918,32 +14030,30 @@ slots:
       building elements and fire-resistance rating
     title: wall construction type
     examples:
-      - value: fire resistive
+    - value: fire resistive
     keywords:
-      - type
-      - wall
+    - type
+    - wall
     slot_uri: MIXS:0000841
     range: WallConstTypeEnum
   wall_finish_mat:
     description: The material utilized to finish the outer most layer of the wall
     title: wall finish material
     examples:
-      - value: wood
+    - value: wood
     keywords:
-      - material
-      - wall
+    - material
+    - wall
     slot_uri: MIXS:0000842
     range: WallFinishMatEnum
   wall_height:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter
+      Preferred_unit: centimeter
     description: The average height of the walls in the sampled room
     title: wall height
     keywords:
-      - height
-      - wall
+    - height
+    - wall
     slot_uri: MIXS:0000221
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14956,45 +14066,43 @@ slots:
     description: The relative location of the wall within the room
     title: wall location
     examples:
-      - value: north
+    - value: north
     keywords:
-      - location
-      - wall
+    - location
+    - wall
     slot_uri: MIXS:0000843
     range: CompassDirections8Enum
   wall_surf_treatment:
     description: The surface treatment of interior wall
     title: wall surface treatment
     examples:
-      - value: paneling
+    - value: paneling
     keywords:
-      - surface
-      - treatment
-      - wall
+    - surface
+    - treatment
+    - wall
     slot_uri: MIXS:0000845
     range: WallSurfTreatmentEnum
   wall_texture:
     description: The feel, appearance, or consistency of a wall surface
     title: wall texture
     examples:
-      - value: popcorn
+    - value: popcorn
     keywords:
-      - texture
-      - wall
+    - texture
+    - wall
     slot_uri: MIXS:0000846
     range: CeilingWallTextureEnum
   wall_thermal_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: joule per degree Celsius
+      Preferred_unit: joule per degree Celsius
     description: The ability of the wall to provide inertia against temperature fluctuations.
       Generally this means concrete or concrete block that is either exposed or covered
       only with paint
     title: wall thermal mass
     keywords:
-      - mass
-      - wall
+    - mass
+    - wall
     slot_uri: MIXS:0000222
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -15007,30 +14115,28 @@ slots:
     description: Signs of the presence of mold or mildew on a wall
     title: wall signs of water/mold
     examples:
-      - value: no presence of mold visible
+    - value: no presence of mold visible
     keywords:
-      - wall
+    - wall
     slot_uri: MIXS:0000844
     range: MoldVisibilityEnum
   wastewater_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: wastewater type name
+      Expected_value: wastewater type name
     description: The origin of wastewater such as human waste, rainfall, storm drains,
       etc
     title: wastewater type
     keywords:
-      - type
+    - type
     string_serialization: '{text}'
     slot_uri: MIXS:0000353
   water_cont_soil_meth:
     description: Reference or method used in determining the water content of soil
     title: water content method
     keywords:
-      - content
-      - method
-      - water
+    - content
+    - method
+    - water
     slot_uri: MIXS:0000323
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -15040,14 +14146,12 @@ slots:
       partial_match: true
   water_content:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per gram or cubic centimeter per cubic centimeter
+      Preferred_unit: gram per gram or cubic centimeter per cubic centimeter
     description: Water content measurement
     title: water content
     keywords:
-      - content
-      - water
+    - content
+    - water
     slot_uri: MIXS:0000185
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -15058,15 +14162,13 @@ slots:
       partial_match: true
   water_current:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per second, knots
+      Preferred_unit: cubic meter per second, knots
     description: Measurement of magnitude and direction of flow within a fluid
     title: water current
     examples:
-      - value: 10 cubic meter per second
+    - value: 10 cubic meter per second
     keywords:
-      - water
+    - water
     slot_uri: MIXS:0000203
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -15077,18 +14179,16 @@ slots:
       partial_match: true
   water_cut:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: Current amount of water (%) in a produced fluid stream; or the average
       of the combined streams
     title: water cut
     comments:
-      - percent or float?
+    - percent or float?
     examples:
-      - value: 45%
+    - value: 45%
     keywords:
-      - water
+    - water
     slot_uri: MIXS:0000454
     range: string
     required: true
@@ -15100,15 +14200,13 @@ slots:
       partial_match: true
   water_feat_size:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The size of the water feature
     title: water feature size
     keywords:
-      - feature
-      - size
-      - water
+    - feature
+    - size
+    - water
     slot_uri: MIXS:0000223
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -15121,51 +14219,45 @@ slots:
     description: The type of water feature present within the building being sampled
     title: water feature type
     examples:
-      - value: stream
+    - value: stream
     keywords:
-      - feature
-      - type
-      - water
+    - feature
+    - type
+    - water
     slot_uri: MIXS:0000847
     range: WaterFeatTypeEnum
   water_frequency:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: rate
-      Preferred_unit:
-        tag: Preferred_unit
-        value: per day, per week, per month
+      Expected_value: rate
+      Preferred_unit: per day, per week, per month
     description: Number of water delivery events within a given period of time
     title: water delivery frequency
     examples:
-      - value: 2 per day
+    - value: 2 per day
     keywords:
-      - delivery
-      - frequency
-      - water
+    - delivery
+    - frequency
+    - water
     string_serialization: '{float}{unit}'
     slot_uri: MIXS:0001174
   water_pH:
     title: water pH
     examples:
-      - value: '7.2'
+    - value: '7.2'
     keywords:
-      - ph
-      - water
+    - ph
+    - water
     slot_uri: MIXS:0001175
     range: float
   water_prod_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per day
+      Preferred_unit: cubic meter per day
     description: Water production rates per well (e.g. 987 m3 / day)
     title: water production rate
     keywords:
-      - production
-      - rate
-      - water
+    - production
+    - rate
+    - water
     slot_uri: MIXS:0000453
     range: string
     recommended: true
@@ -15177,75 +14269,67 @@ slots:
       partial_match: true
   water_source_adjac:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO_01001110 or ENVO_00000070
+      Expected_value: ENVO_01001110 or ENVO_00000070
     description: Description of the environmental features that are adjacent to the
       farm water source. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110)
       and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple
       terms can be separated by pipes
     title: environmental feature adjacent water source
     examples:
-      - value: feedlot [ENVO:01000627]
+    - value: feedlot [ENVO:01000627]
     keywords:
-      - adjacent
-      - environmental
-      - feature
-      - source
-      - water
+    - adjacent
+    - environmental
+    - feature
+    - source
+    - water
     string_serialization: '{text}'
     slot_uri: MIXS:0001122
     multivalued: true
   water_source_shared:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Other users sharing access to the same water source. Multiple terms
       can be separated by one or more pipes
     title: water source shared
     examples:
-      - value: no sharing
+    - value: no sharing
     keywords:
-      - source
-      - water
+    - source
+    - water
     string_serialization: '[multiple users, agricutural|multiple users, other|no sharing]'
     slot_uri: MIXS:0001176
     multivalued: true
   water_temp_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Information about treatment involving an exposure to water with varying
       degree of temperature, treatment regimen including how many times the treatment
       was repeated, how long each treatment lasted, and the start and end time of
       the entire treatment; can include multiple regimens
     title: water temperature regimen
     examples:
-      - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
-      - temperature
-      - water
+    - regimen
+    - temperature
+    - water
     slot_uri: MIXS:0000590
     multivalued: true
     range: string
   watering_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliliter, liter
+      Preferred_unit: milliliter, liter
     description: Information about treatment involving an exposure to watering frequencies,
       treatment regimen including how many times the treatment was repeated, how long
       each treatment lasted, and the start and end time of the entire treatment; can
       include multiple regimens
     title: watering regimen
     examples:
-      - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-      - regimen
-      - water
+    - regimen
+    - water
     slot_uri: MIXS:0000591
     multivalued: true
     range: string
@@ -15253,49 +14337,43 @@ slots:
     description: The day of the week when sampling occurred
     title: weekday
     examples:
-      - value: Sunday
+    - value: Sunday
     slot_uri: MIXS:0000848
     range: WeekdayEnum
   weight_loss_3_month:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: weight loss specification;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Expected_value: weight loss specification;measurement value
+      Preferred_unit: kilogram, gram
     description: Specification of weight loss in the last three months, if yes should
       be further specified to include amount of weight loss
     title: weight loss in last three months
     examples:
-      - value: yes;5 kilogram
+    - value: yes;5 kilogram
     keywords:
-      - months
-      - weight
+    - months
+    - weight
     string_serialization: '{boolean};{float} {unit}'
     slot_uri: MIXS:0000295
   wga_amp_appr:
     description: Method used to amplify genomic DNA in preparation for sequencing
     title: WGA amplification approach
     examples:
-      - value: mda based
+    - value: mda based
     in_subset:
-      - sequencing
+    - sequencing
     slot_uri: MIXS:0000055
     range: WgaAmpApprEnum
   wga_amp_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: kit name
+      Expected_value: kit name
     description: Kit used to amplify genomic DNA in preparation for sequencing
     title: WGA amplification kit
     examples:
-      - value: qiagen repli-g
+    - value: qiagen repli-g
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - kit
+    - kit
     string_serialization: '{text}'
     slot_uri: MIXS:0000006
   win:
@@ -15305,29 +14383,27 @@ slots:
       systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)'
     title: well identification number
     keywords:
-      - identifier
-      - number
+    - identifier
+    - number
     slot_uri: MIXS:0000297
     range: string
     recommended: true
   wind_direction:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degrees or cardinal direction
+      Preferred_unit: degrees or cardinal direction
     description: Wind direction is the direction from which a wind originates
     title: wind direction
     keywords:
-      - direction
-      - wind
+    - direction
+    - wind
     slot_uri: MIXS:0000757
     range: string
   wind_speed:
     description: speed of wind measured at the time of sampling
     title: wind speed
     keywords:
-      - speed
-      - wind
+    - speed
+    - wind
     slot_uri: MIXS:0000118
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -15340,70 +14416,66 @@ slots:
     description: The physical condition of the window at the time of sampling
     title: window condition
     examples:
-      - value: rupture
+    - value: rupture
     keywords:
-      - condition
-      - window
+    - condition
+    - window
     slot_uri: MIXS:0000849
     range: DamagedRupturedEnum
   window_cover:
     description: The type of window covering
     title: window covering
     examples:
-      - value: curtains
+    - value: curtains
     keywords:
-      - window
+    - window
     slot_uri: MIXS:0000850
     range: WindowCoverEnum
   window_horiz_pos:
     description: The horizontal position of the window on the wall
     title: window horizontal position
     examples:
-      - value: middle
+    - value: middle
     keywords:
-      - window
+    - window
     slot_uri: MIXS:0000851
     range: WindowHorizPosEnum
   window_loc:
     description: The relative location of the window within the room
     title: window location
     examples:
-      - value: west
+    - value: west
     keywords:
-      - location
-      - window
+    - location
+    - window
     slot_uri: MIXS:0000852
     range: CompassDirections8Enum
   window_mat:
     description: The type of material used to finish a window
     title: window material
     examples:
-      - value: wood
+    - value: wood
     keywords:
-      - material
-      - window
+    - material
+    - window
     slot_uri: MIXS:0000853
     range: WindowMatEnum
   window_open_freq:
     description: The number of times windows are opened per week
     title: window open frequency
     keywords:
-      - frequency
-      - window
+    - frequency
+    - window
     slot_uri: MIXS:0000246
     range: integer
   window_size:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: inch, meter
+      Expected_value: measurement value
+      Preferred_unit: inch, meter
     description: The window's length and width
     title: window area/size
     keywords:
-      - window
+    - window
     string_serialization: '{float} {unit} x {float} {unit}'
     slot_uri: MIXS:0000224
   window_status:
@@ -15411,61 +14483,61 @@ slots:
       testing
     title: window status
     examples:
-      - value: open
+    - value: open
     keywords:
-      - status
-      - window
+    - status
+    - window
     slot_uri: MIXS:0000855
     range: WindowStatusEnum
   window_type:
     description: The type of windows
     title: window type
     examples:
-      - value: fixed window
+    - value: fixed window
     keywords:
-      - type
-      - window
+    - type
+    - window
     slot_uri: MIXS:0000856
     range: WindowTypeEnum
   window_vert_pos:
     description: The vertical position of the window on the wall
     title: window vertical position
     examples:
-      - value: middle
+    - value: middle
     keywords:
-      - window
+    - window
     slot_uri: MIXS:0000857
     range: WindowVertPosEnum
   window_water_mold:
     description: Signs of the presence of mold or mildew on the window
     title: window signs of water/mold
     examples:
-      - value: no presence of mold visible
+    - value: no presence of mold visible
     keywords:
-      - window
+    - window
     slot_uri: MIXS:0000854
     range: MoldVisibilityEnum
   x16s_recover:
     description: Can a 16S gene be recovered from the submitted SAG or MAG?
     title: 16S recovered
     examples:
-      - value: 'yes'
+    - value: 'yes'
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - recover
+    - recover
     slot_uri: MIXS:0000065
     range: boolean
   x16s_recover_software:
     description: Tools used for 16S rRNA gene extraction
     title: 16S recovery software
     examples:
-      - value: rambl;v2;default parameters
+    - value: rambl;v2;default parameters
     in_subset:
-      - sequencing
+    - sequencing
     keywords:
-      - recover
-      - software
+    - recover
+    - software
     slot_uri: MIXS:0000066
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -15475,9 +14547,7 @@ slots:
       partial_match: true
   xylene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of xylene in the sample
     title: xylene
     slot_uri: MIXS:0000156
@@ -15494,69 +14564,69 @@ classes:
     description: 'Minimal Information about a Genome Sequence: cultured bacteria/archaea'
     title: MIGS bacteria
     aliases:
-      - migs_ba
+    - migs_ba
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - assembly_name
-      - temp
-      - compl_score
-      - nucl_acid_ext
-      - samp_size
-      - isol_growth_condt
-      - alt
-      - source_mat_id
-      - extrachrom_elements
-      - estimated_size
-      - samp_vol_we_dna_ext
-      - pathogenicity
-      - lib_reads_seqd
-      - rel_to_oxygen
-      - encoded_traits
-      - samp_collect_device
-      - number_contig
-      - biotic_relationship
-      - num_replicons
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - host_spec_range
-      - neg_cont_type
-      - adapters
-      - assembly_software
-      - tax_ident
-      - annot
-      - trophic_level
-      - pos_cont_type
-      - subspecf_gen_lin
-      - feat_pred
-      - env_local_scale
-      - compl_software
-      - samp_mat_process
-      - sim_search_meth
-      - host_disease_stat
-      - depth
-      - samp_collect_method
-      - specific_host
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - assembly_name
+    - temp
+    - compl_score
+    - nucl_acid_ext
+    - samp_size
+    - isol_growth_condt
+    - alt
+    - source_mat_id
+    - extrachrom_elements
+    - estimated_size
+    - samp_vol_we_dna_ext
+    - pathogenicity
+    - lib_reads_seqd
+    - rel_to_oxygen
+    - encoded_traits
+    - samp_collect_device
+    - number_contig
+    - biotic_relationship
+    - num_replicons
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - host_spec_range
+    - neg_cont_type
+    - adapters
+    - assembly_software
+    - tax_ident
+    - annot
+    - trophic_level
+    - pos_cont_type
+    - subspecf_gen_lin
+    - feat_pred
+    - env_local_scale
+    - compl_software
+    - samp_mat_process
+    - sim_search_meth
+    - host_disease_stat
+    - depth
+    - samp_collect_method
+    - specific_host
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15572,32 +14642,20 @@ classes:
         required: true
       biotic_relationship:
         recommended: true
-      compl_score:
-      compl_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
-      encoded_traits:
-      estimated_size:
-      experimental_factor:
       extrachrom_elements:
         recommended: true
-      feat_pred:
       host_disease_stat:
         examples:
-          - value: rabies [DOID:11260]
+        - value: rabies [DOID:11260]
         recommended: true
-      host_spec_range:
       isol_growth_condt:
         required: true
-      lib_layout:
-      lib_reads_seqd:
-      lib_screen:
-      lib_size:
-      lib_vector:
       nucl_acid_amp:
         recommended: true
       nucl_acid_ext:
@@ -15610,19 +14668,14 @@ classes:
         recommended: true
       ref_biomaterial:
         required: true
-      ref_db:
       rel_to_oxygen:
         recommended: true
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: swabbing
-      samp_mat_process:
-      samp_size:
-      samp_vol_we_dna_ext:
-      sim_search_meth:
+        - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -15631,7 +14684,6 @@ classes:
         recommended: true
       subspecf_gen_lin:
         recommended: true
-      tax_class:
       tax_ident:
         recommended: true
       temp:
@@ -15643,69 +14695,69 @@ classes:
     description: 'Minimal Information about a Genome Sequence: eukaryote'
     title: MIGS eukaryote
     aliases:
-      - migs_eu
+    - migs_eu
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - assembly_name
-      - temp
-      - compl_score
-      - nucl_acid_ext
-      - samp_size
-      - isol_growth_condt
-      - alt
-      - estimated_size
-      - extrachrom_elements
-      - source_mat_id
-      - samp_vol_we_dna_ext
-      - ploidy
-      - pathogenicity
-      - lib_reads_seqd
-      - propagation
-      - samp_collect_device
-      - number_contig
-      - biotic_relationship
-      - num_replicons
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - host_spec_range
-      - neg_cont_type
-      - adapters
-      - assembly_software
-      - tax_ident
-      - annot
-      - trophic_level
-      - pos_cont_type
-      - subspecf_gen_lin
-      - feat_pred
-      - env_local_scale
-      - compl_software
-      - samp_mat_process
-      - sim_search_meth
-      - host_disease_stat
-      - depth
-      - samp_collect_method
-      - specific_host
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - assembly_name
+    - temp
+    - compl_score
+    - nucl_acid_ext
+    - samp_size
+    - isol_growth_condt
+    - alt
+    - estimated_size
+    - extrachrom_elements
+    - source_mat_id
+    - samp_vol_we_dna_ext
+    - ploidy
+    - pathogenicity
+    - lib_reads_seqd
+    - propagation
+    - samp_collect_device
+    - number_contig
+    - biotic_relationship
+    - num_replicons
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - host_spec_range
+    - neg_cont_type
+    - adapters
+    - assembly_software
+    - tax_ident
+    - annot
+    - trophic_level
+    - pos_cont_type
+    - subspecf_gen_lin
+    - feat_pred
+    - env_local_scale
+    - compl_software
+    - samp_mat_process
+    - sim_search_meth
+    - host_disease_stat
+    - depth
+    - samp_collect_method
+    - specific_host
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15719,62 +14771,39 @@ classes:
         required: true
       assembly_software:
         required: true
-      biotic_relationship:
-      compl_score:
-      compl_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
-      estimated_size:
-      experimental_factor:
-      extrachrom_elements:
-      feat_pred:
       host_disease_stat:
         examples:
-          - value: rabies [DOID:11260]
-      host_spec_range:
+        - value: rabies [DOID:11260]
       isol_growth_condt:
         required: true
-      lib_layout:
-      lib_reads_seqd:
-      lib_screen:
-      lib_size:
-      lib_vector:
       nucl_acid_amp:
         recommended: true
       nucl_acid_ext:
         recommended: true
-      num_replicons:
       number_contig:
         required: true
       pathogenicity:
         recommended: true
-      ploidy:
       propagation:
         recommended: true
-      ref_biomaterial:
-      ref_db:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: swabbing
-      samp_mat_process:
-      samp_size:
-      samp_vol_we_dna_ext:
-      sim_search_meth:
+        - value: swabbing
       sop:
         recommended: true
       source_mat_id:
         recommended: true
-      specific_host:
       subspecf_gen_lin:
         recommended: true
-      tax_class:
       tax_ident:
         recommended: true
       temp:
@@ -15786,60 +14815,60 @@ classes:
     description: 'Minimal Information about a Genome Sequence: organelle'
     title: MIGS org
     aliases:
-      - migs_org
+    - migs_org
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - assembly_name
-      - temp
-      - compl_score
-      - nucl_acid_ext
-      - samp_size
-      - isol_growth_condt
-      - alt
-      - source_mat_id
-      - extrachrom_elements
-      - estimated_size
-      - samp_vol_we_dna_ext
-      - lib_reads_seqd
-      - samp_collect_device
-      - number_contig
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - adapters
-      - neg_cont_type
-      - assembly_software
-      - tax_ident
-      - annot
-      - pos_cont_type
-      - subspecf_gen_lin
-      - feat_pred
-      - env_local_scale
-      - compl_software
-      - samp_mat_process
-      - sim_search_meth
-      - depth
-      - samp_collect_method
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - assembly_name
+    - temp
+    - compl_score
+    - nucl_acid_ext
+    - samp_size
+    - isol_growth_condt
+    - alt
+    - source_mat_id
+    - extrachrom_elements
+    - estimated_size
+    - samp_vol_we_dna_ext
+    - lib_reads_seqd
+    - samp_collect_device
+    - number_contig
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - adapters
+    - neg_cont_type
+    - assembly_software
+    - tax_ident
+    - annot
+    - pos_cont_type
+    - subspecf_gen_lin
+    - feat_pred
+    - env_local_scale
+    - compl_software
+    - samp_mat_process
+    - sim_search_meth
+    - depth
+    - samp_collect_method
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15849,53 +14878,34 @@ classes:
         recommended: true
       assembly_name:
         recommended: true
-      assembly_qual:
       assembly_software:
         required: true
-      compl_score:
-      compl_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
-      estimated_size:
-      experimental_factor:
       extrachrom_elements:
         recommended: true
-      feat_pred:
       isol_growth_condt:
         required: true
-      lib_layout:
-      lib_reads_seqd:
-      lib_screen:
-      lib_size:
-      lib_vector:
       nucl_acid_amp:
         recommended: true
       nucl_acid_ext:
         recommended: true
-      number_contig:
-      ref_biomaterial:
-      ref_db:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: swabbing
-      samp_mat_process:
-      samp_size:
-      samp_vol_we_dna_ext:
-      sim_search_meth:
+        - value: swabbing
       sop:
         recommended: true
       source_mat_id:
         recommended: true
       subspecf_gen_lin:
         recommended: true
-      tax_class:
       tax_ident:
         recommended: true
       temp:
@@ -15905,63 +14915,63 @@ classes:
     description: 'Minimal Information about a Genome Sequence: plasmid'
     title: MIGS pl
     aliases:
-      - migs_pl
+    - migs_pl
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - assembly_name
-      - temp
-      - compl_score
-      - nucl_acid_ext
-      - samp_size
-      - isol_growth_condt
-      - alt
-      - source_mat_id
-      - estimated_size
-      - samp_vol_we_dna_ext
-      - lib_reads_seqd
-      - encoded_traits
-      - propagation
-      - samp_collect_device
-      - number_contig
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - host_spec_range
-      - neg_cont_type
-      - adapters
-      - assembly_software
-      - tax_ident
-      - annot
-      - pos_cont_type
-      - subspecf_gen_lin
-      - feat_pred
-      - env_local_scale
-      - compl_software
-      - samp_mat_process
-      - sim_search_meth
-      - depth
-      - samp_collect_method
-      - specific_host
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - assembly_name
+    - temp
+    - compl_score
+    - nucl_acid_ext
+    - samp_size
+    - isol_growth_condt
+    - alt
+    - source_mat_id
+    - estimated_size
+    - samp_vol_we_dna_ext
+    - lib_reads_seqd
+    - encoded_traits
+    - propagation
+    - samp_collect_device
+    - number_contig
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - host_spec_range
+    - neg_cont_type
+    - adapters
+    - assembly_software
+    - tax_ident
+    - annot
+    - pos_cont_type
+    - subspecf_gen_lin
+    - feat_pred
+    - env_local_scale
+    - compl_software
+    - samp_mat_process
+    - sim_search_meth
+    - depth
+    - samp_collect_method
+    - specific_host
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15971,49 +14981,30 @@ classes:
         recommended: true
       assembly_name:
         recommended: true
-      assembly_qual:
       assembly_software:
         required: true
-      compl_score:
-      compl_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
       encoded_traits:
         recommended: true
-      estimated_size:
-      experimental_factor:
-      feat_pred:
-      host_spec_range:
       isol_growth_condt:
         required: true
-      lib_layout:
-      lib_reads_seqd:
-      lib_screen:
-      lib_size:
-      lib_vector:
       nucl_acid_amp:
         recommended: true
       nucl_acid_ext:
         recommended: true
-      number_contig:
       propagation:
         required: true
-      ref_biomaterial:
-      ref_db:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: swabbing
-      samp_mat_process:
-      samp_size:
-      samp_vol_we_dna_ext:
-      sim_search_meth:
+        - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -16022,7 +15013,6 @@ classes:
         recommended: true
       subspecf_gen_lin:
         recommended: true
-      tax_class:
       tax_ident:
         recommended: true
       temp:
@@ -16032,68 +15022,68 @@ classes:
     description: 'Minimal Information about a Genome Sequence: virus'
     title: MIGS virus
     aliases:
-      - migs_vi
+    - migs_vi
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - assembly_name
-      - temp
-      - compl_score
-      - nucl_acid_ext
-      - samp_size
-      - isol_growth_condt
-      - alt
-      - source_mat_id
-      - estimated_size
-      - samp_vol_we_dna_ext
-      - pathogenicity
-      - lib_reads_seqd
-      - encoded_traits
-      - propagation
-      - samp_collect_device
-      - number_contig
-      - biotic_relationship
-      - num_replicons
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - host_spec_range
-      - neg_cont_type
-      - virus_enrich_appr
-      - adapters
-      - assembly_software
-      - tax_ident
-      - annot
-      - pos_cont_type
-      - subspecf_gen_lin
-      - feat_pred
-      - env_local_scale
-      - compl_software
-      - samp_mat_process
-      - sim_search_meth
-      - host_disease_stat
-      - depth
-      - samp_collect_method
-      - specific_host
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - assembly_name
+    - temp
+    - compl_score
+    - nucl_acid_ext
+    - samp_size
+    - isol_growth_condt
+    - alt
+    - source_mat_id
+    - estimated_size
+    - samp_vol_we_dna_ext
+    - pathogenicity
+    - lib_reads_seqd
+    - encoded_traits
+    - propagation
+    - samp_collect_device
+    - number_contig
+    - biotic_relationship
+    - num_replicons
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - host_spec_range
+    - neg_cont_type
+    - virus_enrich_appr
+    - adapters
+    - assembly_software
+    - tax_ident
+    - annot
+    - pos_cont_type
+    - subspecf_gen_lin
+    - feat_pred
+    - env_local_scale
+    - compl_software
+    - samp_mat_process
+    - sim_search_meth
+    - host_disease_stat
+    - depth
+    - samp_collect_method
+    - specific_host
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -16103,59 +15093,40 @@ classes:
         recommended: true
       assembly_name:
         recommended: true
-      assembly_qual:
       assembly_software:
         required: true
-      biotic_relationship:
-      compl_score:
-      compl_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
       encoded_traits:
         recommended: true
-      estimated_size:
-      experimental_factor:
-      feat_pred:
       host_disease_stat:
         examples:
-          - value: rabies [DOID:11260]
+        - value: rabies [DOID:11260]
         recommended: true
       host_spec_range:
         recommended: true
       isol_growth_condt:
         required: true
-      lib_layout:
-      lib_reads_seqd:
-      lib_screen:
-      lib_size:
-      lib_vector:
       nucl_acid_amp:
         recommended: true
       nucl_acid_ext:
         recommended: true
       num_replicons:
         recommended: true
-      number_contig:
       pathogenicity:
         recommended: true
       propagation:
         required: true
-      ref_biomaterial:
-      ref_db:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: swabbing
-      samp_mat_process:
-      samp_size:
-      samp_vol_we_dna_ext:
-      sim_search_meth:
+        - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -16164,7 +15135,6 @@ classes:
         recommended: true
       subspecf_gen_lin:
         recommended: true
-      tax_class:
       tax_ident:
         recommended: true
       temp:
@@ -16176,78 +15146,77 @@ classes:
     description: Minimum Information About a Metagenome-Assembled Genome
     title: MIMAG
     aliases:
-      - mimag
+    - mimag
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - size_frac
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - contam_screen_input
-      - mid
-      - assembly_name
-      - temp
-      - compl_score
-      - trnas
-      - mag_cov_software
-      - nucl_acid_ext
-      - samp_size
-      - alt
-      - bin_param
-      - bin_software
-      - source_mat_id
-      - samp_vol_we_dna_ext
-      - lib_reads_seqd
-      - rel_to_oxygen
-      - reassembly_bin
-      - decontam_software
-      - samp_collect_device
-      - number_contig
-      - trna_ext_software
-      - lib_layout
-      - contam_screen_param
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - adapters
-      - neg_cont_type
-      - assembly_software
-      - tax_ident
-      - contam_score
-      - annot
-      - x16s_recover_software
-      - x16s_recover
-      - pos_cont_type
-      - feat_pred
-      - compl_software
-      - env_local_scale
-      - samp_mat_process
-      - sim_search_meth
-      - depth
-      - samp_collect_method
-      - compl_appr
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - size_frac
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - contam_screen_input
+    - mid
+    - assembly_name
+    - temp
+    - compl_score
+    - trnas
+    - mag_cov_software
+    - nucl_acid_ext
+    - samp_size
+    - alt
+    - bin_param
+    - bin_software
+    - source_mat_id
+    - samp_vol_we_dna_ext
+    - lib_reads_seqd
+    - rel_to_oxygen
+    - reassembly_bin
+    - decontam_software
+    - samp_collect_device
+    - number_contig
+    - trna_ext_software
+    - lib_layout
+    - contam_screen_param
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - adapters
+    - neg_cont_type
+    - assembly_software
+    - tax_ident
+    - contam_score
+    - annot
+    - x16s_recover_software
+    - x16s_recover
+    - pos_cont_type
+    - feat_pred
+    - compl_software
+    - env_local_scale
+    - samp_mat_process
+    - sim_search_meth
+    - depth
+    - samp_collect_method
+    - compl_appr
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
       alt:
         recommended: true
-      annot:
       assembly_name:
         recommended: true
       assembly_qual:
@@ -16258,25 +15227,20 @@ classes:
         required: true
       bin_software:
         required: true
-      compl_appr:
       compl_score:
         required: true
       compl_software:
         required: true
       contam_score:
         required: true
-      contam_screen_input:
-      contam_screen_param:
-      decontam_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
       experimental_factor:
         recommended: true
-      feat_pred:
       lib_layout:
         recommended: true
       lib_reads_seqd:
@@ -16287,98 +15251,84 @@ classes:
         recommended: true
       lib_vector:
         recommended: true
-      mag_cov_software:
       mid:
         recommended: true
       nucl_acid_amp:
         recommended: true
       nucl_acid_ext:
         recommended: true
-      number_contig:
-      reassembly_bin:
-      ref_biomaterial:
-      ref_db:
-      rel_to_oxygen:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-          - value: swabbing
+        - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
       samp_size:
         recommended: true
-      samp_vol_we_dna_ext:
-      sim_search_meth:
-      size_frac:
       sop:
         recommended: true
       source_mat_id:
         recommended: true
-      tax_class:
       tax_ident:
         required: true
       temp:
         recommended: true
-      trna_ext_software:
-      trnas:
-      x16s_recover:
-      x16s_recover_software:
     class_uri: MIXS:0010011
   MimarksC:
     description: 'Minimal Information about a Marker Specimen: specimen'
     title: MIMARKS specimen
     comments:
-      - for marker gene sequences from cultured or voucher-identifiable specimens
+    - for marker gene sequences from cultured or voucher-identifiable specimens
     aliases:
-      - mimarks_c
-      - MIMARKS-SU
-      - MIMARKS-specimen
+    - mimarks_c
+    - MIMARKS-SU
+    - MIMARKS-specimen
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - pcr_primers
-      - nucl_acid_amp
-      - target_subfragment
-      - temp
-      - pcr_cond
-      - nucl_acid_ext
-      - samp_size
-      - isol_growth_condt
-      - alt
-      - source_mat_id
-      - extrachrom_elements
-      - samp_vol_we_dna_ext
-      - rel_to_oxygen
-      - samp_collect_device
-      - biotic_relationship
-      - seq_quality_check
-      - project_name
-      - neg_cont_type
-      - chimera_check
-      - trophic_level
-      - pos_cont_type
-      - subspecf_gen_lin
-      - env_local_scale
-      - samp_mat_process
-      - depth
-      - samp_collect_method
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - experimental_factor
-      - target_gene
-      - associated_resource
-      - sop
+    - samp_name
+    - pcr_primers
+    - nucl_acid_amp
+    - target_subfragment
+    - temp
+    - pcr_cond
+    - nucl_acid_ext
+    - samp_size
+    - isol_growth_condt
+    - alt
+    - source_mat_id
+    - extrachrom_elements
+    - samp_vol_we_dna_ext
+    - rel_to_oxygen
+    - samp_collect_device
+    - biotic_relationship
+    - seq_quality_check
+    - project_name
+    - neg_cont_type
+    - chimera_check
+    - trophic_level
+    - pos_cont_type
+    - subspecf_gen_lin
+    - env_local_scale
+    - samp_mat_process
+    - depth
+    - samp_collect_method
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - experimental_factor
+    - target_gene
+    - associated_resource
+    - sop
     slot_usage:
       alt:
         recommended: true
@@ -16388,12 +15338,10 @@ classes:
         recommended: true
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
-      experimental_factor:
-      extrachrom_elements:
       isol_growth_condt:
         required: true
       nucl_acid_amp:
@@ -16408,14 +15356,12 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: swabbing
+        - value: swabbing
       samp_mat_process:
         recommended: true
-      samp_size:
-      samp_vol_we_dna_ext:
       seq_quality_check:
         recommended: true
       sop:
@@ -16437,57 +15383,57 @@ classes:
     description: 'Minimal Information about a Marker Specimen: survey'
     title: MIMARKS survey
     comments:
-      - for marker gene sequences obtained directly from the environment
+    - for marker gene sequences obtained directly from the environment
     aliases:
-      - mimarks_s
-      - MIMARKS-SP
-      - MIMARKS-survey
+    - mimarks_s
+    - MIMARKS-SP
+    - MIMARKS-survey
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - pcr_primers
-      - size_frac
-      - lib_screen
-      - nucl_acid_amp
-      - lib_size
-      - target_subfragment
-      - mid
-      - temp
-      - nucl_acid_ext
-      - samp_size
-      - alt
-      - source_mat_id
-      - samp_vol_we_dna_ext
-      - lib_reads_seqd
-      - rel_to_oxygen
-      - samp_collect_device
-      - seq_quality_check
-      - lib_layout
-      - env_broad_scale
-      - project_name
-      - lib_vector
-      - adapters
-      - neg_cont_type
-      - assembly_software
-      - chimera_check
-      - pos_cont_type
-      - env_local_scale
-      - samp_mat_process
-      - depth
-      - samp_collect_method
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - pcr_cond
-      - experimental_factor
-      - target_gene
-      - associated_resource
-      - sop
+    - samp_name
+    - pcr_primers
+    - size_frac
+    - lib_screen
+    - nucl_acid_amp
+    - lib_size
+    - target_subfragment
+    - mid
+    - temp
+    - nucl_acid_ext
+    - samp_size
+    - alt
+    - source_mat_id
+    - samp_vol_we_dna_ext
+    - lib_reads_seqd
+    - rel_to_oxygen
+    - samp_collect_device
+    - seq_quality_check
+    - lib_layout
+    - env_broad_scale
+    - project_name
+    - lib_vector
+    - adapters
+    - neg_cont_type
+    - assembly_software
+    - chimera_check
+    - pos_cont_type
+    - env_local_scale
+    - samp_mat_process
+    - depth
+    - samp_collect_method
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - pcr_cond
+    - experimental_factor
+    - target_gene
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -16499,7 +15445,7 @@ classes:
         recommended: true
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -16525,23 +15471,20 @@ classes:
         recommended: true
       pcr_primers:
         recommended: true
-      rel_to_oxygen:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-          - value: swabbing
+        - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
       samp_size:
         recommended: true
-      samp_vol_we_dna_ext:
       seq_quality_check:
         recommended: true
-      size_frac:
       sop:
         recommended: true
       source_mat_id:
@@ -16557,56 +15500,56 @@ classes:
     description: Metagenome or Environmental
     title: MIMS
     aliases:
-      - mims
+    - mims
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - size_frac
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - mid
-      - assembly_name
-      - temp
-      - nucl_acid_ext
-      - samp_size
-      - alt
-      - source_mat_id
-      - samp_vol_we_dna_ext
-      - lib_reads_seqd
-      - rel_to_oxygen
-      - samp_collect_device
-      - number_contig
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - adapters
-      - neg_cont_type
-      - assembly_software
-      - annot
-      - pos_cont_type
-      - feat_pred
-      - env_local_scale
-      - samp_mat_process
-      - sim_search_meth
-      - depth
-      - samp_collect_method
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - size_frac
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - mid
+    - assembly_name
+    - temp
+    - nucl_acid_ext
+    - samp_size
+    - alt
+    - source_mat_id
+    - samp_vol_we_dna_ext
+    - lib_reads_seqd
+    - rel_to_oxygen
+    - samp_collect_device
+    - number_contig
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - adapters
+    - neg_cont_type
+    - assembly_software
+    - annot
+    - pos_cont_type
+    - feat_pred
+    - env_local_scale
+    - samp_mat_process
+    - sim_search_meth
+    - depth
+    - samp_collect_method
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
@@ -16622,13 +15565,12 @@ classes:
         recommended: true
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
       experimental_factor:
         recommended: true
-      feat_pred:
       lib_layout:
         recommended: true
       lib_reads_seqd:
@@ -16647,29 +15589,22 @@ classes:
         recommended: true
       number_contig:
         recommended: true
-      ref_biomaterial:
-      ref_db:
-      rel_to_oxygen:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-          - value: swabbing
+        - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
       samp_size:
         recommended: true
-      samp_vol_we_dna_ext:
-      sim_search_meth:
-      size_frac:
       sop:
         recommended: true
       source_mat_id:
         recommended: true
-      tax_class:
       temp:
         recommended: true
     class_uri: MIXS:0010007
@@ -16677,104 +15612,98 @@ classes:
     description: Minimum Information About a Single Amplified Genome
     title: Minimum Information About a Single Amplified Genome
     aliases:
-      - misag
+    - misag
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - size_frac
-      - lib_screen
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - contam_screen_input
-      - mid
-      - assembly_name
-      - temp
-      - compl_score
-      - trnas
-      - nucl_acid_ext
-      - samp_size
-      - alt
-      - source_mat_id
-      - samp_vol_we_dna_ext
-      - lib_reads_seqd
-      - rel_to_oxygen
-      - wga_amp_kit
-      - decontam_software
-      - samp_collect_device
-      - number_contig
-      - trna_ext_software
-      - sc_lysis_method
-      - lib_layout
-      - contam_screen_param
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - adapters
-      - neg_cont_type
-      - assembly_software
-      - tax_ident
-      - contam_score
-      - annot
-      - x16s_recover_software
-      - x16s_recover
-      - pos_cont_type
-      - feat_pred
-      - compl_software
-      - env_local_scale
-      - sort_tech
-      - samp_mat_process
-      - sim_search_meth
-      - depth
-      - samp_collect_method
-      - wga_amp_appr
-      - compl_appr
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - sc_lysis_approach
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - associated_resource
-      - sop
+    - samp_name
+    - size_frac
+    - lib_screen
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - contam_screen_input
+    - mid
+    - assembly_name
+    - temp
+    - compl_score
+    - trnas
+    - nucl_acid_ext
+    - samp_size
+    - alt
+    - source_mat_id
+    - samp_vol_we_dna_ext
+    - lib_reads_seqd
+    - rel_to_oxygen
+    - wga_amp_kit
+    - decontam_software
+    - samp_collect_device
+    - number_contig
+    - trna_ext_software
+    - sc_lysis_method
+    - lib_layout
+    - contam_screen_param
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - adapters
+    - neg_cont_type
+    - assembly_software
+    - tax_ident
+    - contam_score
+    - annot
+    - x16s_recover_software
+    - x16s_recover
+    - pos_cont_type
+    - feat_pred
+    - compl_software
+    - env_local_scale
+    - sort_tech
+    - samp_mat_process
+    - sim_search_meth
+    - depth
+    - samp_collect_method
+    - wga_amp_appr
+    - compl_appr
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - sc_lysis_approach
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
       alt:
         recommended: true
-      annot:
       assembly_name:
         recommended: true
       assembly_qual:
         required: true
       assembly_software:
         required: true
-      compl_appr:
       compl_score:
         required: true
       compl_software:
         required: true
       contam_score:
         required: true
-      contam_screen_input:
-      contam_screen_param:
-      decontam_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
       experimental_factor:
         recommended: true
-      feat_pred:
       lib_layout:
         recommended: true
       lib_reads_seqd:
@@ -16791,138 +15720,123 @@ classes:
         recommended: true
       nucl_acid_ext:
         recommended: true
-      number_contig:
-      ref_biomaterial:
-      ref_db:
-      rel_to_oxygen:
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-          - value: swabbing
+        - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
       samp_size:
         recommended: true
-      samp_vol_we_dna_ext:
       sc_lysis_approach:
         required: true
-      sc_lysis_method:
-      sim_search_meth:
-      size_frac:
       sop:
         recommended: true
       sort_tech:
         required: true
       source_mat_id:
         recommended: true
-      tax_class:
       tax_ident:
         required: true
       temp:
         recommended: true
-      trna_ext_software:
-      trnas:
       wga_amp_appr:
         required: true
-      wga_amp_kit:
-      x16s_recover:
-      x16s_recover_software:
     class_uri: MIXS:0010010
   Miuvig:
     description: Minimum Information About an Uncultivated Virus Genome
     title: Minimum Information About an Uncultivated Virus Genome
     aliases:
-      - miuvig
+    - miuvig
     is_a: Checklist
     mixin: true
     slots:
-      - samp_name
-      - size_frac
-      - lib_screen
-      - source_uvig
-      - ref_db
-      - nucl_acid_amp
-      - lib_size
-      - mid
-      - assembly_name
-      - temp
-      - compl_score
-      - trnas
-      - nucl_acid_ext
-      - samp_size
-      - alt
-      - estimated_size
-      - source_mat_id
-      - samp_vol_we_dna_ext
-      - pathogenicity
-      - lib_reads_seqd
-      - samp_collect_device
-      - number_contig
-      - biotic_relationship
-      - trna_ext_software
-      - lib_layout
-      - assembly_qual
-      - ref_biomaterial
-      - project_name
-      - lib_vector
-      - host_spec_range
-      - neg_cont_type
-      - virus_enrich_appr
-      - adapters
-      - assembly_software
-      - tax_ident
-      - annot
-      - pos_cont_type
-      - feat_pred
-      - compl_software
-      - env_local_scale
-      - samp_mat_process
-      - sim_search_meth
-      - host_disease_stat
-      - depth
-      - samp_collect_method
-      - compl_appr
-      - specific_host
-      - env_medium
-      - samp_taxon_id
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - lat_lon
-      - elev
-      - env_broad_scale
-      - tax_class
-      - experimental_factor
-      - sort_tech
-      - sc_lysis_approach
-      - sc_lysis_method
-      - wga_amp_appr
-      - wga_amp_kit
-      - bin_param
-      - bin_software
-      - reassembly_bin
-      - mag_cov_software
-      - vir_ident_software
-      - pred_genome_type
-      - pred_genome_struc
-      - detec_type
-      - otu_class_appr
-      - otu_seq_comp_appr
-      - otu_db
-      - host_pred_appr
-      - host_pred_est_acc
-      - associated_resource
-      - sop
+    - samp_name
+    - size_frac
+    - lib_screen
+    - source_uvig
+    - ref_db
+    - nucl_acid_amp
+    - lib_size
+    - mid
+    - assembly_name
+    - temp
+    - compl_score
+    - trnas
+    - nucl_acid_ext
+    - samp_size
+    - alt
+    - estimated_size
+    - source_mat_id
+    - samp_vol_we_dna_ext
+    - pathogenicity
+    - lib_reads_seqd
+    - samp_collect_device
+    - number_contig
+    - biotic_relationship
+    - trna_ext_software
+    - lib_layout
+    - assembly_qual
+    - ref_biomaterial
+    - project_name
+    - lib_vector
+    - host_spec_range
+    - neg_cont_type
+    - virus_enrich_appr
+    - adapters
+    - assembly_software
+    - tax_ident
+    - annot
+    - pos_cont_type
+    - feat_pred
+    - compl_software
+    - env_local_scale
+    - samp_mat_process
+    - sim_search_meth
+    - host_disease_stat
+    - depth
+    - samp_collect_method
+    - compl_appr
+    - specific_host
+    - env_medium
+    - samp_taxon_id
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - lat_lon
+    - elev
+    - env_broad_scale
+    - tax_class
+    - experimental_factor
+    - sort_tech
+    - sc_lysis_approach
+    - sc_lysis_method
+    - wga_amp_appr
+    - wga_amp_kit
+    - bin_param
+    - bin_software
+    - reassembly_bin
+    - mag_cov_software
+    - vir_ident_software
+    - pred_genome_type
+    - pred_genome_struc
+    - detec_type
+    - otu_class_appr
+    - otu_seq_comp_appr
+    - otu_db
+    - host_pred_appr
+    - host_pred_est_acc
+    - associated_resource
+    - sop
     slot_usage:
       adapters:
         recommended: true
       alt:
         recommended: true
-      annot:
       assembly_name:
         recommended: true
       assembly_qual:
@@ -16933,34 +15847,30 @@ classes:
         recommended: true
       bin_software:
         recommended: true
-      biotic_relationship:
       compl_appr:
         recommended: true
       compl_score:
         recommended: true
-      compl_software:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       detec_type:
         required: true
       elev:
         recommended: true
-      estimated_size:
       experimental_factor:
         recommended: true
       feat_pred:
         recommended: true
       host_disease_stat:
         examples:
-          - value: rabies [DOID:11260]
+        - value: rabies [DOID:11260]
         recommended: true
       host_pred_appr:
         recommended: true
       host_pred_est_acc:
         recommended: true
-      host_spec_range:
       lib_layout:
         recommended: true
       lib_reads_seqd:
@@ -16971,7 +15881,6 @@ classes:
         recommended: true
       lib_vector:
         recommended: true
-      mag_cov_software:
       mid:
         recommended: true
       nucl_acid_amp:
@@ -16986,29 +15895,26 @@ classes:
         recommended: true
       otu_seq_comp_appr:
         recommended: true
-      pathogenicity:
       pred_genome_struc:
         required: true
       pred_genome_type:
         required: true
       reassembly_bin:
         recommended: true
-      ref_biomaterial:
       ref_db:
         recommended: true
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-          - value: swabbing
+        - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
       samp_size:
         recommended: true
-      samp_vol_we_dna_ext:
       sc_lysis_approach:
         recommended: true
       sc_lysis_method:
@@ -17025,14 +15931,10 @@ classes:
         recommended: true
       source_uvig:
         required: true
-      specific_host:
       tax_class:
         recommended: true
-      tax_ident:
       temp:
         recommended: true
-      trna_ext_software:
-      trnas:
       vir_ident_software:
         required: true
       virus_enrich_appr:
@@ -17047,166 +15949,166 @@ classes:
     title: agriculture
     is_a: Extension
     slots:
-      - plant_growth_med
-      - photosynt_activ
-      - photosynt_activ_meth
-      - samp_collect_method
-      - enrichment_protocol
-      - library_prep_kit
-      - sequencing_location
-      - soil_temp
-      - soil_pH
-      - soil_conductivity
-      - rel_location
-      - soil_cover
-      - porosity
-      - soil_texture
-      - soil_texture_meth
-      - host_symbiont
-      - host_disease_stat
-      - pres_animal_insect
-      - plant_water_method
-      - anim_water_method
-      - farm_water_source
-      - water_source_shared
-      - water_pH
-      - elev
-      - season
-      - solar_irradiance
-      - crop_yield
-      - season_humidity
-      - humidity
-      - adjacent_environment
-      - chem_administration
-      - food_prod
-      - lot_number
-      - fertilizer_admin
-      - samp_store_temp
-      - food_trav_mode
-      - food_trav_vehic
-      - farm_equip_san
-      - farm_equip
-      - farm_equip_shared
-      - food_harvest_proc
-      - plant_struc
-      - host_dry_mass
-      - ances_data
-      - genetic_mod
-      - food_product_type
-      - food_source
-      - spikein_strain
-      - organism_count
-      - size_frac_low
-      - size_frac_up
-      - cult_isol_date
-      - samp_pooling
-      - root_med_macronutr
-      - root_med_carbon
-      - root_med_ph
-      - depth
-      - specific_host
-      - pathogenicity
-      - biotic_relationship
-      - water_temp_regm
-      - watering_regm
-      - standing_water_regm
-      - gaseous_environment
-      - fungicide_regm
-      - climate_environment
-      - herbicide_regm
-      - non_min_nutr_regm
-      - pesticide_regm
-      - ph_regm
-      - salt_regm
-      - season_environment
-      - temp
-      - perturbation
-      - isol_growth_condt
-      - samp_store_dur
-      - samp_store_loc
-      - samp_collect_device
-      - samp_mat_process
-      - host_age
-      - host_common_name
-      - host_genotype
-      - host_height
-      - host_subspecf_genlin
-      - host_length
-      - host_life_stage
-      - host_phenotype
-      - host_taxid
-      - host_tot_mass
-      - host_spec_range
-      - trophic_level
-      - plant_product
-      - samp_size
-      - oxy_stat_samp
-      - seq_meth
-      - samp_vol_we_dna_ext
-      - pcr_primers
-      - nucl_acid_ext
-      - nucl_acid_amp
-      - lib_size
-      - lib_reads_seqd
-      - lib_layout
-      - lib_vector
-      - lib_screen
-      - target_gene
-      - target_subfragment
-      - mid
-      - adapters
-      - pcr_cond
-      - seq_quality_check
-      - chimera_check
-      - assembly_name
-      - assembly_qual
-      - assembly_software
-      - annot
-      - associated_resource
-      - sop
-      - source_mat_id
-      - fao_class
-      - local_class
-      - local_class_meth
-      - soil_type
-      - soil_type_meth
-      - soil_horizon
-      - horizon_meth
-      - link_class_info
-      - previous_land_use
-      - prev_land_use_meth
-      - crop_rotation
-      - agrochem_addition
-      - tillage
-      - fire
-      - flooding
-      - extreme_event
-      - link_climate_info
-      - annual_temp
-      - season_temp
-      - annual_precpt
-      - season_precpt
-      - cur_land_use
-      - slope_gradient
-      - slope_aspect
-      - profile_position
-      - drainage_class
-      - store_cond
-      - ph_meth
-      - cur_vegetation
-      - cur_vegetation_meth
-      - tot_org_carb
-      - tot_org_c_meth
-      - tot_nitro_content
-      - tot_nitro_cont_meth
-      - microbial_biomass
-      - micro_biomass_meth
-      - heavy_metals_meth
-      - tot_carb
-      - tot_phosphate
-      - sieving
-      - pool_dna_extracts
-      - misc_param
+    - plant_growth_med
+    - photosynt_activ
+    - photosynt_activ_meth
+    - samp_collect_method
+    - enrichment_protocol
+    - library_prep_kit
+    - sequencing_location
+    - soil_temp
+    - soil_pH
+    - soil_conductivity
+    - rel_location
+    - soil_cover
+    - porosity
+    - soil_texture
+    - soil_texture_meth
+    - host_symbiont
+    - host_disease_stat
+    - pres_animal_insect
+    - plant_water_method
+    - anim_water_method
+    - farm_water_source
+    - water_source_shared
+    - water_pH
+    - elev
+    - season
+    - solar_irradiance
+    - crop_yield
+    - season_humidity
+    - humidity
+    - adjacent_environment
+    - chem_administration
+    - food_prod
+    - lot_number
+    - fertilizer_admin
+    - samp_store_temp
+    - food_trav_mode
+    - food_trav_vehic
+    - farm_equip_san
+    - farm_equip
+    - farm_equip_shared
+    - food_harvest_proc
+    - plant_struc
+    - host_dry_mass
+    - ances_data
+    - genetic_mod
+    - food_product_type
+    - food_source
+    - spikein_strain
+    - organism_count
+    - size_frac_low
+    - size_frac_up
+    - cult_isol_date
+    - samp_pooling
+    - root_med_macronutr
+    - root_med_carbon
+    - root_med_ph
+    - depth
+    - specific_host
+    - pathogenicity
+    - biotic_relationship
+    - water_temp_regm
+    - watering_regm
+    - standing_water_regm
+    - gaseous_environment
+    - fungicide_regm
+    - climate_environment
+    - herbicide_regm
+    - non_min_nutr_regm
+    - pesticide_regm
+    - ph_regm
+    - salt_regm
+    - season_environment
+    - temp
+    - perturbation
+    - isol_growth_condt
+    - samp_store_dur
+    - samp_store_loc
+    - samp_collect_device
+    - samp_mat_process
+    - host_age
+    - host_common_name
+    - host_genotype
+    - host_height
+    - host_subspecf_genlin
+    - host_length
+    - host_life_stage
+    - host_phenotype
+    - host_taxid
+    - host_tot_mass
+    - host_spec_range
+    - trophic_level
+    - plant_product
+    - samp_size
+    - oxy_stat_samp
+    - seq_meth
+    - samp_vol_we_dna_ext
+    - pcr_primers
+    - nucl_acid_ext
+    - nucl_acid_amp
+    - lib_size
+    - lib_reads_seqd
+    - lib_layout
+    - lib_vector
+    - lib_screen
+    - target_gene
+    - target_subfragment
+    - mid
+    - adapters
+    - pcr_cond
+    - seq_quality_check
+    - chimera_check
+    - assembly_name
+    - assembly_qual
+    - assembly_software
+    - annot
+    - associated_resource
+    - sop
+    - source_mat_id
+    - fao_class
+    - local_class
+    - local_class_meth
+    - soil_type
+    - soil_type_meth
+    - soil_horizon
+    - horizon_meth
+    - link_class_info
+    - previous_land_use
+    - prev_land_use_meth
+    - crop_rotation
+    - agrochem_addition
+    - tillage
+    - fire
+    - flooding
+    - extreme_event
+    - link_climate_info
+    - annual_temp
+    - season_temp
+    - annual_precpt
+    - season_precpt
+    - cur_land_use
+    - slope_gradient
+    - slope_aspect
+    - profile_position
+    - drainage_class
+    - store_cond
+    - ph_meth
+    - cur_vegetation
+    - cur_vegetation_meth
+    - tot_org_carb
+    - tot_org_c_meth
+    - tot_nitro_content
+    - tot_nitro_cont_meth
+    - microbial_biomass
+    - micro_biomass_meth
+    - heavy_metals_meth
+    - tot_carb
+    - tot_phosphate
+    - sieving
+    - pool_dna_extracts
+    - misc_param
     slot_usage:
       adapters:
         required: true
@@ -17214,8 +16116,6 @@ classes:
         recommended: true
       assembly_name:
         required: true
-      assembly_qual:
-      assembly_software:
       biotic_relationship:
         recommended: true
       chem_administration:
@@ -17234,11 +16134,10 @@ classes:
         recommended: true
       depth:
         examples:
-          - value: 5 cm
+        - value: 5 cm
         recommended: true
       drainage_class:
         recommended: true
-      elev:
       enrichment_protocol:
         recommended: true
       extreme_event:
@@ -17249,13 +16148,12 @@ classes:
         recommended: true
       flooding:
         recommended: true
-      food_prod:
       food_product_type:
         examples:
-          - value: delicatessen salad; FOODON:03316276
+        - value: delicatessen salad; FOODON:03316276
       food_source:
         examples:
-          - value: red swamp crayfish; FOODON:03412231
+        - value: red swamp crayfish; FOODON:03412231
         required: true
       fungicide_regm:
         string_serialization: '{text};{float} {unit};{period};{interval};{period}'
@@ -17277,7 +16175,7 @@ classes:
         required: true
       host_disease_stat:
         examples:
-          - value: downy mildew
+        - value: downy mildew
         recommended: true
       host_genotype:
         required: true
@@ -17293,31 +16191,29 @@ classes:
         required: true
       host_symbiont:
         examples:
-          - value: Paragordius varius
+        - value: Paragordius varius
       host_taxid:
         examples:
-          - value: '9606'
+        - value: '9606'
         string_serialization: '{integer}'
         required: true
       host_tot_mass:
         required: true
       humidity:
         examples:
-          - value: 30% relative humidity
+        - value: 30% relative humidity
         recommended: true
-      isol_growth_condt:
       lib_layout:
         recommended: true
       lib_reads_seqd:
         required: true
       lib_screen:
         required: true
-      lib_size:
       lib_vector:
         required: true
       library_prep_kit:
         examples:
-          - value: llumina DNA Prep, (M) Tagmentation
+        - value: llumina DNA Prep, (M) Tagmentation
       local_class:
         recommended: true
       local_class_meth:
@@ -17337,7 +16233,7 @@ classes:
         required: true
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         recommended: true
       oxy_stat_samp:
         recommended: true
@@ -17359,7 +16255,7 @@ classes:
         recommended: true
       plant_growth_med:
         examples:
-          - value: hydroponic plant culture media [EO:0007067]
+        - value: hydroponic plant culture media [EO:0007067]
       plant_product:
         recommended: true
       plant_struc:
@@ -17380,11 +16276,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-          - value: biopsy, niskin bottle, push core
+        - value: biopsy, niskin bottle, push core
         required: true
       samp_collect_method:
         examples:
-          - value: environmental swab sampling
+        - value: environmental swab sampling
       samp_mat_process:
         required: true
       samp_pooling:
@@ -17400,8 +16296,6 @@ classes:
       season_environment:
         string_serialization: '{text};{period};{interval};{period}'
         recommended: true
-      season_precpt:
-      seq_quality_check:
       sieving:
         required: true
       slope_aspect:
@@ -17416,14 +16310,11 @@ classes:
         recommended: true
       soil_pH:
         description: pH of some soil.
-      soil_temp:
       soil_type:
         string_serialization: '{text}'
         required: true
       soil_type_meth:
         required: true
-      sop:
-      source_mat_id:
       specific_host:
         required: true
       standing_water_regm:
@@ -17468,241 +16359,231 @@ classes:
     title: air
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - alt
-      - elev
-      - barometric_press
-      - carb_dioxide
-      - carb_monoxide
-      - chem_administration
-      - humidity
-      - methane
-      - organism_count
-      - oxygen
-      - oxy_stat_samp
-      - perturbation
-      - pollutants
-      - air_PM_concen
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - solar_irradiance
-      - temp
-      - ventilation_rate
-      - ventilation_type
-      - volatile_org_comp
-      - wind_direction
-      - wind_speed
-      - misc_param
+    - samp_name
+    - project_name
+    - alt
+    - elev
+    - barometric_press
+    - carb_dioxide
+    - carb_monoxide
+    - chem_administration
+    - humidity
+    - methane
+    - organism_count
+    - oxygen
+    - oxy_stat_samp
+    - perturbation
+    - pollutants
+    - air_PM_concen
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - solar_irradiance
+    - temp
+    - ventilation_rate
+    - ventilation_type
+    - volatile_org_comp
+    - wind_direction
+    - wind_speed
+    - misc_param
     slot_usage:
-      air_PM_concen:
       alt:
         required: true
-      carb_dioxide:
-      chem_administration:
       elev:
         recommended: true
       humidity:
         examples:
-          - value: 25 gram per cubic meter
+        - value: 25 gram per cubic meter
       methane:
         examples:
-          - value: 1800 parts per billion
+        - value: 1800 parts per billion
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
-      ventilation_type:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       wind_direction:
         examples:
-          - value: Northwest
+        - value: Northwest
       wind_speed:
         examples:
-          - value: 21 kilometer per hour
+        - value: 21 kilometer per hour
     class_uri: MIXS:0016000
   BuiltEnvironment:
     description: built environment extension
     title: built environment
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - surf_material
-      - surf_air_cont
-      - rel_air_humidity
-      - abs_air_humidity
-      - surf_humidity
-      - air_temp
-      - surf_temp
-      - surf_moisture_ph
-      - build_occup_type
-      - surf_moisture
-      - dew_point
-      - carb_dioxide
-      - ventilation_type
-      - organism_count
-      - indoor_space
-      - indoor_surf
-      - filter_type
-      - heat_cool_type
-      - substructure_type
-      - building_setting
-      - light_type
-      - samp_sort_meth
-      - space_typ_state
-      - typ_occup_density
-      - occup_samp
-      - occup_density_samp
-      - address
-      - adj_room
-      - aero_struc
-      - amount_light
-      - arch_struc
-      - avg_occup
-      - avg_dew_point
-      - avg_temp
-      - bathroom_count
-      - bedroom_count
-      - built_struc_age
-      - built_struc_set
-      - built_struc_type
-      - ceil_area
-      - ceil_cond
-      - ceil_finish_mat
-      - ceil_water_mold
-      - ceil_struc
-      - ceil_texture
-      - ceil_thermal_mass
-      - ceil_type
-      - cool_syst_id
-      - date_last_rain
-      - build_docs
-      - door_size
-      - door_cond
-      - door_direct
-      - door_loc
-      - door_mat
-      - door_move
-      - door_water_mold
-      - door_type
-      - door_comp_type
-      - door_type_metal
-      - door_type_wood
-      - drawings
-      - elevator
-      - escalator
-      - exp_duct
-      - exp_pipe
-      - ext_door
-      - fireplace_type
-      - floor_age
-      - floor_area
-      - floor_cond
-      - floor_count
-      - floor_finish_mat
-      - floor_water_mold
-      - floor_struc
-      - floor_thermal_mass
-      - freq_clean
-      - freq_cook
-      - furniture
-      - gender_restroom
-      - hall_count
-      - handidness
-      - heat_deliv_loc
-      - heat_sys_deliv_meth
-      - heat_system_id
-      - height_carper_fiber
-      - inside_lux
-      - int_wall_cond
-      - last_clean
-      - max_occup
-      - mech_struc
-      - number_plants
-      - number_pets
-      - number_resident
-      - occup_document
-      - ext_wall_orient
-      - ext_window_orient
-      - rel_humidity_out
-      - pres_animal_insect
-      - quad_pos
-      - rel_samp_loc
-      - room_air_exch_rate
-      - room_architec_elem
-      - room_condt
-      - room_count
-      - room_dim
-      - room_door_dist
-      - room_loc
-      - room_moist_dam_hist
-      - room_net_area
-      - room_occup
-      - room_samp_pos
-      - room_type
-      - room_vol
-      - room_window_count
-      - room_connected
-      - room_hallway
-      - room_door_share
-      - room_wall_share
-      - samp_weather
-      - samp_floor
-      - samp_room_id
-      - samp_time_out
-      - season
-      - season_use
-      - shading_device_cond
-      - shading_device_loc
-      - shading_device_mat
-      - shad_dev_water_mold
-      - shading_device_type
-      - specific_humidity
-      - specific
-      - temp_out
-      - train_line
-      - train_stat_loc
-      - train_stop_loc
-      - vis_media
-      - wall_area
-      - wall_const_type
-      - wall_finish_mat
-      - wall_height
-      - wall_loc
-      - wall_water_mold
-      - wall_surf_treatment
-      - wall_texture
-      - wall_thermal_mass
-      - water_feat_size
-      - water_feat_type
-      - weekday
-      - window_size
-      - window_cond
-      - window_cover
-      - window_horiz_pos
-      - window_loc
-      - window_mat
-      - window_open_freq
-      - window_water_mold
-      - window_status
-      - window_type
-      - window_vert_pos
+    - samp_name
+    - project_name
+    - surf_material
+    - surf_air_cont
+    - rel_air_humidity
+    - abs_air_humidity
+    - surf_humidity
+    - air_temp
+    - surf_temp
+    - surf_moisture_ph
+    - build_occup_type
+    - surf_moisture
+    - dew_point
+    - carb_dioxide
+    - ventilation_type
+    - organism_count
+    - indoor_space
+    - indoor_surf
+    - filter_type
+    - heat_cool_type
+    - substructure_type
+    - building_setting
+    - light_type
+    - samp_sort_meth
+    - space_typ_state
+    - typ_occup_density
+    - occup_samp
+    - occup_density_samp
+    - address
+    - adj_room
+    - aero_struc
+    - amount_light
+    - arch_struc
+    - avg_occup
+    - avg_dew_point
+    - avg_temp
+    - bathroom_count
+    - bedroom_count
+    - built_struc_age
+    - built_struc_set
+    - built_struc_type
+    - ceil_area
+    - ceil_cond
+    - ceil_finish_mat
+    - ceil_water_mold
+    - ceil_struc
+    - ceil_texture
+    - ceil_thermal_mass
+    - ceil_type
+    - cool_syst_id
+    - date_last_rain
+    - build_docs
+    - door_size
+    - door_cond
+    - door_direct
+    - door_loc
+    - door_mat
+    - door_move
+    - door_water_mold
+    - door_type
+    - door_comp_type
+    - door_type_metal
+    - door_type_wood
+    - drawings
+    - elevator
+    - escalator
+    - exp_duct
+    - exp_pipe
+    - ext_door
+    - fireplace_type
+    - floor_age
+    - floor_area
+    - floor_cond
+    - floor_count
+    - floor_finish_mat
+    - floor_water_mold
+    - floor_struc
+    - floor_thermal_mass
+    - freq_clean
+    - freq_cook
+    - furniture
+    - gender_restroom
+    - hall_count
+    - handidness
+    - heat_deliv_loc
+    - heat_sys_deliv_meth
+    - heat_system_id
+    - height_carper_fiber
+    - inside_lux
+    - int_wall_cond
+    - last_clean
+    - max_occup
+    - mech_struc
+    - number_plants
+    - number_pets
+    - number_resident
+    - occup_document
+    - ext_wall_orient
+    - ext_window_orient
+    - rel_humidity_out
+    - pres_animal_insect
+    - quad_pos
+    - rel_samp_loc
+    - room_air_exch_rate
+    - room_architec_elem
+    - room_condt
+    - room_count
+    - room_dim
+    - room_door_dist
+    - room_loc
+    - room_moist_dam_hist
+    - room_net_area
+    - room_occup
+    - room_samp_pos
+    - room_type
+    - room_vol
+    - room_window_count
+    - room_connected
+    - room_hallway
+    - room_door_share
+    - room_wall_share
+    - samp_weather
+    - samp_floor
+    - samp_room_id
+    - samp_time_out
+    - season
+    - season_use
+    - shading_device_cond
+    - shading_device_loc
+    - shading_device_mat
+    - shad_dev_water_mold
+    - shading_device_type
+    - specific_humidity
+    - specific
+    - temp_out
+    - train_line
+    - train_stat_loc
+    - train_stop_loc
+    - vis_media
+    - wall_area
+    - wall_const_type
+    - wall_finish_mat
+    - wall_height
+    - wall_loc
+    - wall_water_mold
+    - wall_surf_treatment
+    - wall_texture
+    - wall_thermal_mass
+    - water_feat_size
+    - water_feat_type
+    - weekday
+    - window_size
+    - window_cond
+    - window_cover
+    - window_horiz_pos
+    - window_loc
+    - window_mat
+    - window_open_freq
+    - window_water_mold
+    - window_status
+    - window_type
+    - window_vert_pos
     slot_usage:
       air_temp:
         examples:
-          - value: 20 degree Celsius
+        - value: 20 degree Celsius
         required: true
       avg_occup:
         examples:
-          - value: '2'
+        - value: '2'
       carb_dioxide:
         required: true
       freq_clean:
@@ -17712,7 +16593,7 @@ classes:
         recommended: true
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         required: true
       surf_material:
         required: true
@@ -17725,303 +16606,287 @@ classes:
     title: food-animal and animal feed
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - lat_lon
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - samp_size
-      - samp_collect_device
-      - experimental_factor
-      - nucl_acid_ext
-      - organism_count
-      - spikein_count
-      - samp_store_temp
-      - samp_store_dur
-      - samp_vol_we_dna_ext
-      - pool_dna_extracts
-      - temp
-      - samp_store_loc
-      - samp_transport_cont
-      - perturbation
-      - coll_site_geo_feat
-      - food_origin
-      - food_prod
-      - food_product_type
-      - food_source
-      - IFSAC_category
-      - intended_consumer
-      - samp_purpose
-      - animal_am
-      - animal_am_dur
-      - animal_am_freq
-      - animal_am_route
-      - animal_am_use
-      - animal_body_cond
-      - animal_diet
-      - animal_feed_equip
-      - animal_group_size
-      - animal_housing
-      - animal_sex
-      - bacterial_density
-      - cons_food_stor_dur
-      - cons_food_stor_temp
-      - cons_purch_date
-      - cons_qty_purchased
-      - cult_isol_date
-      - cult_result
-      - cult_result_org
-      - cult_target
-      - enrichment_protocol
-      - food_additive
-      - food_contact_surf
-      - food_contain_wrap
-      - food_cooking_proc
-      - food_dis_point
-      - food_dis_point_city
-      - food_ingredient
-      - food_pack_capacity
-      - food_pack_integrity
-      - food_pack_medium
-      - food_preserv_proc
-      - food_prior_contact
-      - food_prod_synonym
-      - food_product_qual
-      - food_quality_date
-      - food_source_age
-      - food_trace_list
-      - food_trav_mode
-      - food_trav_vehic
-      - food_treat_proc
-      - HACCP_term
-      - library_prep_kit
-      - lot_number
-      - microb_cult_med
-      - part_plant_animal
-      - repository_name
-      - samp_collect_method
-      - samp_pooling
-      - samp_rep_biol
-      - samp_rep_tech
-      - samp_source_mat_cat
-      - samp_stor_device
-      - samp_stor_media
-      - samp_transport_dur
-      - samp_transport_temp
-      - sequencing_kit
-      - sequencing_location
-      - serovar_or_serotype
-      - spikein_AMR
-      - spikein_antibiotic
-      - spikein_growth_med
-      - spikein_metal
-      - spikein_org
-      - spikein_serovar
-      - spikein_strain
-      - study_design
-      - study_inc_dur
-      - study_inc_temp
-      - study_timecourse
-      - study_tmnt
-      - timepoint
-      - misc_param
+    - samp_name
+    - project_name
+    - lat_lon
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - samp_size
+    - samp_collect_device
+    - experimental_factor
+    - nucl_acid_ext
+    - organism_count
+    - spikein_count
+    - samp_store_temp
+    - samp_store_dur
+    - samp_vol_we_dna_ext
+    - pool_dna_extracts
+    - temp
+    - samp_store_loc
+    - samp_transport_cont
+    - perturbation
+    - coll_site_geo_feat
+    - food_origin
+    - food_prod
+    - food_product_type
+    - food_source
+    - IFSAC_category
+    - intended_consumer
+    - samp_purpose
+    - animal_am
+    - animal_am_dur
+    - animal_am_freq
+    - animal_am_route
+    - animal_am_use
+    - animal_body_cond
+    - animal_diet
+    - animal_feed_equip
+    - animal_group_size
+    - animal_housing
+    - animal_sex
+    - bacterial_density
+    - cons_food_stor_dur
+    - cons_food_stor_temp
+    - cons_purch_date
+    - cons_qty_purchased
+    - cult_isol_date
+    - cult_result
+    - cult_result_org
+    - cult_target
+    - enrichment_protocol
+    - food_additive
+    - food_contact_surf
+    - food_contain_wrap
+    - food_cooking_proc
+    - food_dis_point
+    - food_dis_point_city
+    - food_ingredient
+    - food_pack_capacity
+    - food_pack_integrity
+    - food_pack_medium
+    - food_preserv_proc
+    - food_prior_contact
+    - food_prod_synonym
+    - food_product_qual
+    - food_quality_date
+    - food_source_age
+    - food_trace_list
+    - food_trav_mode
+    - food_trav_vehic
+    - food_treat_proc
+    - HACCP_term
+    - library_prep_kit
+    - lot_number
+    - microb_cult_med
+    - part_plant_animal
+    - repository_name
+    - samp_collect_method
+    - samp_pooling
+    - samp_rep_biol
+    - samp_rep_tech
+    - samp_source_mat_cat
+    - samp_stor_device
+    - samp_stor_media
+    - samp_transport_dur
+    - samp_transport_temp
+    - sequencing_kit
+    - sequencing_location
+    - serovar_or_serotype
+    - spikein_AMR
+    - spikein_antibiotic
+    - spikein_growth_med
+    - spikein_metal
+    - spikein_org
+    - spikein_serovar
+    - spikein_strain
+    - study_design
+    - study_inc_dur
+    - study_inc_temp
+    - study_timecourse
+    - study_tmnt
+    - timepoint
+    - misc_param
     slot_usage:
-      enrichment_protocol:
-      experimental_factor:
-      food_contact_surf:
       food_origin:
         required: true
       food_pack_medium:
         examples:
-          - value: packed in fruit juice [FOODON:03480039]
+        - value: packed in fruit juice [FOODON:03480039]
       food_prod:
         required: true
-      food_product_qual:
       food_product_type:
         examples:
-          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-          - value: giant tiger prawn [FOODON:03412612]
+        - value: giant tiger prawn [FOODON:03412612]
       intended_consumer:
         required: true
       library_prep_kit:
         examples:
-          - value: Illumina DNA Prep
-      nucl_acid_ext:
+        - value: Illumina DNA Prep
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
-      perturbation:
+        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       pool_dna_extracts:
         string_serialization: '{boolean},{integer}'
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: environmental swab sampling
-      samp_pooling:
+        - value: environmental swab sampling
       samp_purpose:
         required: true
-      samp_size:
-      samp_source_mat_cat:
-      samp_stor_device:
-      samp_stor_media:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
     class_uri: MIXS:0016019
   FoodFarmEnvironment:
     description: food-farm environment extension
     title: food-farm environment
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - lat_lon
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - samp_size
-      - samp_collect_device
-      - nucl_acid_ext
-      - humidity
-      - organism_count
-      - spikein_count
-      - samp_store_temp
-      - solar_irradiance
-      - ventilation_rate
-      - samp_store_dur
-      - wind_speed
-      - salinity
-      - samp_vol_we_dna_ext
-      - previous_land_use
-      - crop_rotation
-      - soil_type_meth
-      - tot_org_c_meth
-      - tot_nitro_cont_meth
-      - host_age
-      - host_dry_mass
-      - host_height
-      - host_length
-      - host_tot_mass
-      - root_med_carbon
-      - root_med_macronutr
-      - root_med_micronutr
-      - depth
-      - season_temp
-      - season_precpt
-      - tot_org_carb
-      - tot_nitro_content
-      - conduc
-      - turbidity
-      - size_frac_low
-      - size_frac_up
-      - temp
-      - ventilation_type
-      - wind_direction
-      - genetic_mod
-      - host_phenotype
-      - ph
-      - ances_data
-      - biotic_regm
-      - chem_administration
-      - growth_habit
-      - host_disease_stat
-      - host_genotype
-      - host_taxid
-      - mechanical_damage
-      - perturbation
-      - root_cond
-      - root_med_ph
-      - tillage
-      - ph_meth
-      - growth_medium
-      - season
-      - food_product_type
-      - samp_type
-      - farm_water_source
-      - plant_water_method
-      - air_PM_concen
-      - animal_feed_equip
-      - animal_intrusion
-      - anim_water_method
-      - crop_yield
-      - cult_result
-      - cult_result_org
-      - cult_target
-      - plant_part_maturity
-      - adjacent_environment
-      - water_source_adjac
-      - farm_equip_shared
-      - farm_equip_san
-      - farm_equip_san_freq
-      - farm_equip
-      - fertilizer_admin
-      - fertilizer_date
-      - animal_group_size
-      - animal_diet
-      - food_contact_surf
-      - food_contain_wrap
-      - food_harvest_proc
-      - food_pack_medium
-      - food_preserv_proc
-      - food_prod_char
-      - prod_label_claims
-      - food_trav_mode
-      - food_trav_vehic
-      - food_source
-      - food_treat_proc
-      - extr_weather_event
-      - date_extr_weath
-      - host_subspecf_genlin
-      - intended_consumer
-      - library_prep_kit
-      - air_flow_impede
-      - lot_number
-      - season_humidity
-      - part_plant_animal
-      - plant_growth_med
-      - plant_reprod_crop
-      - samp_purpose
-      - repository_name
-      - samp_pooling
-      - samp_source_mat_cat
-      - sequencing_kit
-      - sequencing_location
-      - serovar_or_serotype
-      - soil_conductivity
-      - soil_cover
-      - soil_pH
-      - rel_location
-      - soil_porosity
-      - soil_temp
-      - soil_texture_class
-      - soil_texture_meth
-      - soil_type
-      - spikein_org
-      - spikein_serovar
-      - spikein_growth_med
-      - spikein_strain
-      - spikein_antibiotic
-      - spikein_metal
-      - timepoint
-      - water_frequency
-      - water_pH
-      - water_source_shared
-      - enrichment_protocol
-      - food_quality_date
-      - IFSAC_category
-      - animal_housing
-      - cult_isol_date
-      - food_clean_proc
-      - misc_param
+    - samp_name
+    - project_name
+    - lat_lon
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - samp_size
+    - samp_collect_device
+    - nucl_acid_ext
+    - humidity
+    - organism_count
+    - spikein_count
+    - samp_store_temp
+    - solar_irradiance
+    - ventilation_rate
+    - samp_store_dur
+    - wind_speed
+    - salinity
+    - samp_vol_we_dna_ext
+    - previous_land_use
+    - crop_rotation
+    - soil_type_meth
+    - tot_org_c_meth
+    - tot_nitro_cont_meth
+    - host_age
+    - host_dry_mass
+    - host_height
+    - host_length
+    - host_tot_mass
+    - root_med_carbon
+    - root_med_macronutr
+    - root_med_micronutr
+    - depth
+    - season_temp
+    - season_precpt
+    - tot_org_carb
+    - tot_nitro_content
+    - conduc
+    - turbidity
+    - size_frac_low
+    - size_frac_up
+    - temp
+    - ventilation_type
+    - wind_direction
+    - genetic_mod
+    - host_phenotype
+    - ph
+    - ances_data
+    - biotic_regm
+    - chem_administration
+    - growth_habit
+    - host_disease_stat
+    - host_genotype
+    - host_taxid
+    - mechanical_damage
+    - perturbation
+    - root_cond
+    - root_med_ph
+    - tillage
+    - ph_meth
+    - growth_medium
+    - season
+    - food_product_type
+    - samp_type
+    - farm_water_source
+    - plant_water_method
+    - air_PM_concen
+    - animal_feed_equip
+    - animal_intrusion
+    - anim_water_method
+    - crop_yield
+    - cult_result
+    - cult_result_org
+    - cult_target
+    - plant_part_maturity
+    - adjacent_environment
+    - water_source_adjac
+    - farm_equip_shared
+    - farm_equip_san
+    - farm_equip_san_freq
+    - farm_equip
+    - fertilizer_admin
+    - fertilizer_date
+    - animal_group_size
+    - animal_diet
+    - food_contact_surf
+    - food_contain_wrap
+    - food_harvest_proc
+    - food_pack_medium
+    - food_preserv_proc
+    - food_prod_char
+    - prod_label_claims
+    - food_trav_mode
+    - food_trav_vehic
+    - food_source
+    - food_treat_proc
+    - extr_weather_event
+    - date_extr_weath
+    - host_subspecf_genlin
+    - intended_consumer
+    - library_prep_kit
+    - air_flow_impede
+    - lot_number
+    - season_humidity
+    - part_plant_animal
+    - plant_growth_med
+    - plant_reprod_crop
+    - samp_purpose
+    - repository_name
+    - samp_pooling
+    - samp_source_mat_cat
+    - sequencing_kit
+    - sequencing_location
+    - serovar_or_serotype
+    - soil_conductivity
+    - soil_cover
+    - soil_pH
+    - rel_location
+    - soil_porosity
+    - soil_temp
+    - soil_texture_class
+    - soil_texture_meth
+    - soil_type
+    - spikein_org
+    - spikein_serovar
+    - spikein_growth_med
+    - spikein_strain
+    - spikein_antibiotic
+    - spikein_metal
+    - timepoint
+    - water_frequency
+    - water_pH
+    - water_source_shared
+    - enrichment_protocol
+    - food_quality_date
+    - IFSAC_category
+    - animal_housing
+    - cult_isol_date
+    - food_clean_proc
+    - misc_param
     slot_usage:
-      air_PM_concen:
       biotic_regm:
         required: true
       chem_administration:
@@ -18030,1140 +16895,1029 @@ classes:
         string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         required: true
-      enrichment_protocol:
-      food_contact_surf:
       food_pack_medium:
         examples:
-          - value: vacuum-packed [FOODON:03480027]
+        - value: vacuum-packed [FOODON:03480027]
       food_product_type:
         examples:
-          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-          - value: giant tiger prawn [FOODON:03412612]
+        - value: giant tiger prawn [FOODON:03412612]
       host_age:
         examples:
-          - value: 10 days
+        - value: 10 days
       host_disease_stat:
         examples:
-          - value: downy mildew
+        - value: downy mildew
         recommended: true
       host_genotype:
         examples:
-          - value: Ts
+        - value: Ts
       host_height:
         examples:
-          - value: 1 meter
-      host_length:
+        - value: 1 meter
       host_phenotype:
         examples:
-          - value: seed pod; green [PATO:0000320]
+        - value: seed pod; green [PATO:0000320]
       host_taxid:
         examples:
-          - value: '4530'
+        - value: '4530'
         string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
-          - value: 2500 gram
+        - value: 2500 gram
       humidity:
         examples:
-          - value: 30% relative humidity
-      intended_consumer:
+        - value: 30% relative humidity
       library_prep_kit:
         examples:
-          - value: Illumina DNA Prep
-      nucl_acid_ext:
+        - value: Illumina DNA Prep
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
-      perturbation:
-      ph:
-      ph_meth:
+        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       plant_growth_med:
         examples:
-          - value: soil
-      previous_land_use:
-      rel_location:
+        - value: soil
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
-      samp_pooling:
-      samp_purpose:
-      samp_size:
-      samp_source_mat_cat:
-      samp_store_dur:
-      samp_vol_we_dna_ext:
-      season_precpt:
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       soil_conductivity:
         description: Conductivity of soil at time of sampling.
-      soil_cover:
       soil_pH:
         description: The pH of soil at time of sampling.
-      soil_temp:
       soil_type:
         string_serialization: '{termLabel} [{termID}]'
-      soil_type_meth:
-      temp:
-      tillage:
-      tot_nitro_cont_meth:
-      tot_nitro_content:
-      tot_org_c_meth:
-      tot_org_carb:
-      turbidity:
-      ventilation_type:
       water_pH:
         description: pH measurement of the sample, or liquid portion of sample, or
           aqueous phase of the fluid.
       wind_direction:
         examples:
-          - value: 0 degrees; Northwest
+        - value: 0 degrees; Northwest
       wind_speed:
         examples:
-          - value: 1.6 kilometers per hour
+        - value: 1.6 kilometers per hour
     class_uri: MIXS:0016020
   FoodFoodProductionFacility:
     description: food-food production facility extension
     title: food-food production facility
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - lat_lon
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - samp_size
-      - samp_collect_device
-      - experimental_factor
-      - nucl_acid_ext
-      - organism_count
-      - samp_store_temp
-      - samp_store_dur
-      - air_temp
-      - room_dim
-      - freq_clean
-      - samp_room_id
-      - samp_vol_we_dna_ext
-      - pool_dna_extracts
-      - samp_store_loc
-      - surf_material
-      - indoor_surf
-      - avg_occup
-      - samp_floor
-      - genetic_mod
-      - coll_site_geo_feat
-      - samp_source_mat_cat
-      - samp_type
-      - samp_stor_media
-      - samp_stor_device
-      - food_product_type
-      - IFSAC_category
-      - food_product_qual
-      - food_contact_surf
-      - facility_type
-      - food_trav_mode
-      - food_trav_vehic
-      - samp_transport_dur
-      - samp_transport_temp
-      - samp_collect_method
-      - num_samp_collect
-      - lot_number
-      - hygienic_area
-      - env_monitoring_zone
-      - area_samp_size
-      - samp_surf_moisture
-      - samp_loc_condition
-      - biocide_used
-      - ster_meth_samp_room
-      - enrichment_protocol
-      - cult_target
-      - microb_cult_med
-      - timepoint
-      - bacterial_density
-      - cult_isol_date
-      - cult_result
-      - cult_result_org
-      - subspecf_gen_lin
-      - samp_pooling
-      - samp_purpose
-      - samp_rep_tech
-      - samp_rep_biol
-      - samp_transport_cont
-      - study_design
-      - nucl_acid_ext_kit
-      - library_prep_kit
-      - sequencing_kit
-      - sequencing_location
-      - study_inc_temp
-      - study_inc_dur
-      - study_timecourse
-      - study_tmnt
-      - food_source
-      - food_dis_point
-      - food_dis_point_city
-      - food_origin
-      - food_prod_synonym
-      - food_additive
-      - food_trace_list
-      - part_plant_animal
-      - food_ingredient
-      - spec_intended_cons
-      - HACCP_term
-      - dietary_claim_use
-      - food_allergen_label
-      - food_prod_char
-      - prod_label_claims
-      - food_name_status
-      - food_preserv_proc
-      - food_cooking_proc
-      - food_treat_proc
-      - food_contain_wrap
-      - food_pack_capacity
-      - food_pack_medium
-      - food_prior_contact
-      - food_prod
-      - food_quality_date
-      - repository_name
-      - intended_consumer
-      - food_pack_integrity
-      - misc_param
+    - samp_name
+    - project_name
+    - lat_lon
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - samp_size
+    - samp_collect_device
+    - experimental_factor
+    - nucl_acid_ext
+    - organism_count
+    - samp_store_temp
+    - samp_store_dur
+    - air_temp
+    - room_dim
+    - freq_clean
+    - samp_room_id
+    - samp_vol_we_dna_ext
+    - pool_dna_extracts
+    - samp_store_loc
+    - surf_material
+    - indoor_surf
+    - avg_occup
+    - samp_floor
+    - genetic_mod
+    - coll_site_geo_feat
+    - samp_source_mat_cat
+    - samp_type
+    - samp_stor_media
+    - samp_stor_device
+    - food_product_type
+    - IFSAC_category
+    - food_product_qual
+    - food_contact_surf
+    - facility_type
+    - food_trav_mode
+    - food_trav_vehic
+    - samp_transport_dur
+    - samp_transport_temp
+    - samp_collect_method
+    - num_samp_collect
+    - lot_number
+    - hygienic_area
+    - env_monitoring_zone
+    - area_samp_size
+    - samp_surf_moisture
+    - samp_loc_condition
+    - biocide_used
+    - ster_meth_samp_room
+    - enrichment_protocol
+    - cult_target
+    - microb_cult_med
+    - timepoint
+    - bacterial_density
+    - cult_isol_date
+    - cult_result
+    - cult_result_org
+    - subspecf_gen_lin
+    - samp_pooling
+    - samp_purpose
+    - samp_rep_tech
+    - samp_rep_biol
+    - samp_transport_cont
+    - study_design
+    - nucl_acid_ext_kit
+    - library_prep_kit
+    - sequencing_kit
+    - sequencing_location
+    - study_inc_temp
+    - study_inc_dur
+    - study_timecourse
+    - study_tmnt
+    - food_source
+    - food_dis_point
+    - food_dis_point_city
+    - food_origin
+    - food_prod_synonym
+    - food_additive
+    - food_trace_list
+    - part_plant_animal
+    - food_ingredient
+    - spec_intended_cons
+    - HACCP_term
+    - dietary_claim_use
+    - food_allergen_label
+    - food_prod_char
+    - prod_label_claims
+    - food_name_status
+    - food_preserv_proc
+    - food_cooking_proc
+    - food_treat_proc
+    - food_contain_wrap
+    - food_pack_capacity
+    - food_pack_medium
+    - food_prior_contact
+    - food_prod
+    - food_quality_date
+    - repository_name
+    - intended_consumer
+    - food_pack_integrity
+    - misc_param
     slot_usage:
       air_temp:
         examples:
-          - value: 4 degree Celsius
+        - value: 4 degree Celsius
       avg_occup:
         examples:
-          - value: '6'
-      enrichment_protocol:
-      experimental_factor:
+        - value: '6'
       food_contact_surf:
         required: true
-      food_origin:
       food_pack_medium:
         examples:
-          - value: vacuum-packed [FOODON:03480027]
-      food_prod:
+        - value: vacuum-packed [FOODON:03480027]
       food_product_qual:
         required: true
       food_product_type:
         examples:
-          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-          - value: giant tiger prawn [FOODON:03412612]
+        - value: giant tiger prawn [FOODON:03412612]
       freq_clean:
         string_serialization: '{text}'
-      indoor_surf:
-      intended_consumer:
       library_prep_kit:
         examples:
-          - value: Illumina DNA Prep
-      nucl_acid_ext:
+        - value: Illumina DNA Prep
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       pool_dna_extracts:
         string_serialization: '{boolean},{integer}'
       samp_collect_device:
         examples:
-          - value: biopsy, niskin bottle, push core
+        - value: biopsy, niskin bottle, push core
       samp_collect_method:
         examples:
-          - value: environmental swab sampling
-      samp_pooling:
-      samp_purpose:
-      samp_size:
+        - value: environmental swab sampling
       samp_source_mat_cat:
         required: true
       samp_stor_device:
         required: true
       samp_stor_media:
         required: true
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      subspecf_gen_lin:
-      surf_material:
     class_uri: MIXS:0016021
   FoodHumanFoods:
     description: food-human foods extension
     title: food-human foods
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - lat_lon
-      - geo_loc_name
-      - collection_date
-      - seq_meth
-      - samp_size
-      - samp_collect_device
-      - experimental_factor
-      - nucl_acid_ext
-      - organism_count
-      - spikein_count
-      - samp_store_temp
-      - samp_store_dur
-      - samp_vol_we_dna_ext
-      - pool_dna_extracts
-      - temp
-      - samp_store_loc
-      - genetic_mod
-      - perturbation
-      - coll_site_geo_feat
-      - food_product_type
-      - IFSAC_category
-      - ferm_chem_add
-      - ferm_chem_add_perc
-      - ferm_headspace_oxy
-      - ferm_medium
-      - ferm_pH
-      - ferm_rel_humidity
-      - ferm_temp
-      - ferm_time
-      - ferm_vessel
-      - bacterial_density
-      - cons_food_stor_dur
-      - cons_food_stor_temp
-      - cons_purch_date
-      - cons_qty_purchased
-      - cult_isol_date
-      - cult_result
-      - cult_result_org
-      - cult_target
-      - dietary_claim_use
-      - enrichment_protocol
-      - food_additive
-      - food_allergen_label
-      - food_contact_surf
-      - food_contain_wrap
-      - food_cooking_proc
-      - food_dis_point
-      - food_ingredient
-      - food_name_status
-      - food_origin
-      - food_pack_capacity
-      - food_pack_integrity
-      - food_pack_medium
-      - food_preserv_proc
-      - food_prior_contact
-      - food_prod
-      - food_prod_synonym
-      - food_product_qual
-      - food_quality_date
-      - food_source
-      - food_trace_list
-      - food_trav_mode
-      - food_trav_vehic
-      - food_treat_proc
-      - HACCP_term
-      - intended_consumer
-      - library_prep_kit
-      - lot_number
-      - microb_cult_med
-      - microb_start
-      - microb_start_count
-      - microb_start_inoc
-      - microb_start_prep
-      - microb_start_source
-      - microb_start_taxID
-      - nucl_acid_ext_kit
-      - num_samp_collect
-      - part_plant_animal
-      - repository_name
-      - samp_collect_method
-      - samp_pooling
-      - samp_rep_biol
-      - samp_rep_tech
-      - samp_source_mat_cat
-      - samp_stor_device
-      - samp_stor_media
-      - samp_transport_cont
-      - samp_transport_dur
-      - samp_transport_temp
-      - samp_purpose
-      - sequencing_kit
-      - sequencing_location
-      - serovar_or_serotype
-      - spikein_AMR
-      - spikein_antibiotic
-      - spikein_growth_med
-      - spikein_metal
-      - spikein_org
-      - spikein_serovar
-      - spikein_strain
-      - study_design
-      - study_inc_dur
-      - study_inc_temp
-      - study_timecourse
-      - study_tmnt
-      - timepoint
-      - misc_param
+    - samp_name
+    - project_name
+    - lat_lon
+    - geo_loc_name
+    - collection_date
+    - seq_meth
+    - samp_size
+    - samp_collect_device
+    - experimental_factor
+    - nucl_acid_ext
+    - organism_count
+    - spikein_count
+    - samp_store_temp
+    - samp_store_dur
+    - samp_vol_we_dna_ext
+    - pool_dna_extracts
+    - temp
+    - samp_store_loc
+    - genetic_mod
+    - perturbation
+    - coll_site_geo_feat
+    - food_product_type
+    - IFSAC_category
+    - ferm_chem_add
+    - ferm_chem_add_perc
+    - ferm_headspace_oxy
+    - ferm_medium
+    - ferm_pH
+    - ferm_rel_humidity
+    - ferm_temp
+    - ferm_time
+    - ferm_vessel
+    - bacterial_density
+    - cons_food_stor_dur
+    - cons_food_stor_temp
+    - cons_purch_date
+    - cons_qty_purchased
+    - cult_isol_date
+    - cult_result
+    - cult_result_org
+    - cult_target
+    - dietary_claim_use
+    - enrichment_protocol
+    - food_additive
+    - food_allergen_label
+    - food_contact_surf
+    - food_contain_wrap
+    - food_cooking_proc
+    - food_dis_point
+    - food_ingredient
+    - food_name_status
+    - food_origin
+    - food_pack_capacity
+    - food_pack_integrity
+    - food_pack_medium
+    - food_preserv_proc
+    - food_prior_contact
+    - food_prod
+    - food_prod_synonym
+    - food_product_qual
+    - food_quality_date
+    - food_source
+    - food_trace_list
+    - food_trav_mode
+    - food_trav_vehic
+    - food_treat_proc
+    - HACCP_term
+    - intended_consumer
+    - library_prep_kit
+    - lot_number
+    - microb_cult_med
+    - microb_start
+    - microb_start_count
+    - microb_start_inoc
+    - microb_start_prep
+    - microb_start_source
+    - microb_start_taxID
+    - nucl_acid_ext_kit
+    - num_samp_collect
+    - part_plant_animal
+    - repository_name
+    - samp_collect_method
+    - samp_pooling
+    - samp_rep_biol
+    - samp_rep_tech
+    - samp_source_mat_cat
+    - samp_stor_device
+    - samp_stor_media
+    - samp_transport_cont
+    - samp_transport_dur
+    - samp_transport_temp
+    - samp_purpose
+    - sequencing_kit
+    - sequencing_location
+    - serovar_or_serotype
+    - spikein_AMR
+    - spikein_antibiotic
+    - spikein_growth_med
+    - spikein_metal
+    - spikein_org
+    - spikein_serovar
+    - spikein_strain
+    - study_design
+    - study_inc_dur
+    - study_inc_temp
+    - study_timecourse
+    - study_tmnt
+    - timepoint
+    - misc_param
     slot_usage:
-      enrichment_protocol:
-      experimental_factor:
-      food_contact_surf:
-      food_origin:
       food_pack_medium:
         examples:
-          - value: vacuum-packed[FOODON:03480027]
-      food_prod:
-      food_product_qual:
+        - value: vacuum-packed[FOODON:03480027]
       food_product_type:
         examples:
-          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-          - value: giant tiger prawn [FOODON:03412612]
-      intended_consumer:
+        - value: giant tiger prawn [FOODON:03412612]
       library_prep_kit:
         examples:
-          - value: Illumina DNA Prep
-      nucl_acid_ext:
+        - value: Illumina DNA Prep
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
-      perturbation:
+        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       pool_dna_extracts:
         string_serialization: '{boolean},{integer}'
       samp_collect_device:
         examples:
-          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-          - value: environmental swab sampling
-      samp_pooling:
-      samp_purpose:
-      samp_size:
-      samp_source_mat_cat:
-      samp_stor_device:
-      samp_stor_media:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: environmental swab sampling
     class_uri: MIXS:0016022
   HostAssociated:
     description: host-associated extension
     title: host-associated
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - alt
-      - depth
-      - elev
-      - ances_data
-      - biol_stat
-      - genetic_mod
-      - host_common_name
-      - samp_capt_status
-      - samp_dis_stage
-      - host_taxid
-      - host_subject_id
-      - host_age
-      - host_life_stage
-      - host_sex
-      - host_disease_stat
-      - chem_administration
-      - host_body_habitat
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_length
-      - host_diet
-      - host_last_meal
-      - host_growth_cond
-      - host_substrate
-      - host_fam_rel
-      - host_subspecf_genlin
-      - host_genotype
-      - host_phenotype
-      - host_body_temp
-      - host_dry_mass
-      - blood_press_diast
-      - blood_press_syst
-      - host_color
-      - host_shape
-      - gravidity
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_vol_we_dna_ext
-      - samp_store_temp
-      - samp_store_dur
-      - samp_store_loc
-      - host_symbiont
-      - misc_param
+    - samp_name
+    - project_name
+    - alt
+    - depth
+    - elev
+    - ances_data
+    - biol_stat
+    - genetic_mod
+    - host_common_name
+    - samp_capt_status
+    - samp_dis_stage
+    - host_taxid
+    - host_subject_id
+    - host_age
+    - host_life_stage
+    - host_sex
+    - host_disease_stat
+    - chem_administration
+    - host_body_habitat
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_length
+    - host_diet
+    - host_last_meal
+    - host_growth_cond
+    - host_substrate
+    - host_fam_rel
+    - host_subspecf_genlin
+    - host_genotype
+    - host_phenotype
+    - host_body_temp
+    - host_dry_mass
+    - blood_press_diast
+    - blood_press_syst
+    - host_color
+    - host_shape
+    - gravidity
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_vol_we_dna_ext
+    - samp_store_temp
+    - samp_store_dur
+    - samp_store_loc
+    - host_symbiont
+    - misc_param
     slot_usage:
       alt:
         recommended: true
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
-      gravidity:
       host_age:
         examples:
-          - value: 10 days
+        - value: 10 days
       host_body_habitat:
         examples:
-          - value: nasopharynx
+        - value: nasopharynx
       host_body_site:
         examples:
-          - value: gill [UBERON:0002535]
+        - value: gill [UBERON:0002535]
       host_body_temp:
         examples:
-          - value: 15 degree Celsius
-      host_color:
+        - value: 15 degree Celsius
       host_common_name:
         examples:
-          - value: human
+        - value: human
       host_diet:
         examples:
-          - value: herbivore
+        - value: herbivore
       host_disease_stat:
         examples:
-          - value: rabies [DOID:11260]
+        - value: rabies [DOID:11260]
       host_fam_rel:
         examples:
-          - value: offspring;Mussel25
+        - value: offspring;Mussel25
       host_genotype:
         examples:
-          - value: C57BL/6
-      host_growth_cond:
+        - value: C57BL/6
       host_height:
         examples:
-          - value: 0.1 meter
+        - value: 0.1 meter
       host_last_meal:
         examples:
-          - value: corn feed;P2H
-      host_length:
+        - value: corn feed;P2H
       host_life_stage:
         examples:
-          - value: adult
+        - value: adult
       host_phenotype:
         examples:
-          - value: elongated [PATO:0001154]
-      host_shape:
+        - value: elongated [PATO:0001154]
       host_subject_id:
         examples:
-          - value: MPI123
-      host_substrate:
+        - value: MPI123
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_taxid:
         examples:
-          - value: '7955'
+        - value: '7955'
         string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
-          - value: 2500 gram
+        - value: 2500 gram
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016002
   HumanAssociated:
     description: human-associated extension
     title: human-associated
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - host_subject_id
-      - host_age
-      - host_sex
-      - host_disease_stat
-      - ihmc_medication_code
-      - chem_administration
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_diet
-      - host_last_meal
-      - host_fam_rel
-      - host_genotype
-      - host_phenotype
-      - host_body_temp
-      - smoker
-      - host_hiv_stat
-      - drug_usage
-      - host_body_mass_index
-      - diet_last_six_month
-      - weight_loss_3_month
-      - ethnicity
-      - host_occupation
-      - pet_farm_animal
-      - travel_out_six_month
-      - twin_sibling
-      - medic_hist_perform
-      - study_complt_stat
-      - pulmonary_disord
-      - nose_throat_disord
-      - blood_blood_disord
-      - host_pulse
-      - gestation_state
-      - maternal_health_stat
-      - foetal_health_stat
-      - amniotic_fluid_color
-      - kidney_disord
-      - urogenit_tract_disor
-      - urine_collect_meth
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_vol_we_dna_ext
-      - samp_store_temp
-      - samp_store_dur
-      - host_symbiont
-      - samp_store_loc
-      - misc_param
+    - samp_name
+    - project_name
+    - host_subject_id
+    - host_age
+    - host_sex
+    - host_disease_stat
+    - ihmc_medication_code
+    - chem_administration
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_diet
+    - host_last_meal
+    - host_fam_rel
+    - host_genotype
+    - host_phenotype
+    - host_body_temp
+    - smoker
+    - host_hiv_stat
+    - drug_usage
+    - host_body_mass_index
+    - diet_last_six_month
+    - weight_loss_3_month
+    - ethnicity
+    - host_occupation
+    - pet_farm_animal
+    - travel_out_six_month
+    - twin_sibling
+    - medic_hist_perform
+    - study_complt_stat
+    - pulmonary_disord
+    - nose_throat_disord
+    - blood_blood_disord
+    - host_pulse
+    - gestation_state
+    - maternal_health_stat
+    - foetal_health_stat
+    - amniotic_fluid_color
+    - kidney_disord
+    - urogenit_tract_disor
+    - urine_collect_meth
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_vol_we_dna_ext
+    - samp_store_temp
+    - samp_store_dur
+    - host_symbiont
+    - samp_store_loc
+    - misc_param
     slot_usage:
-      chem_administration:
       host_age:
         examples:
-          - value: 30 years
+        - value: 30 years
       host_body_site:
         examples:
-          - value: Lung parenchyma [fma27360]
+        - value: Lung parenchyma [fma27360]
       host_body_temp:
         examples:
-          - value: 36.5 degree Celsius
+        - value: 36.5 degree Celsius
       host_diet:
         examples:
-          - value: high-fat
+        - value: high-fat
       host_disease_stat:
         examples:
-          - value: measles [DOID:8622]
+        - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-          - value: mother;ID298
+        - value: mother;ID298
       host_genotype:
         examples:
-          - value: ST1
+        - value: ST1
       host_height:
         examples:
-          - value: 1.75 meter
+        - value: 1.75 meter
       host_last_meal:
         examples:
-          - value: french fries;P5H30M
+        - value: french fries;P5H30M
       host_phenotype:
         examples:
-          - value: Tinnitus [HP:0000360]
+        - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-          - value: MPI123
+        - value: MPI123
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_tot_mass:
         examples:
-          - value: 65 kilogram
+        - value: 65 kilogram
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016003
   HumanGut:
     description: human-gut extension
     title: human-gut
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - gastrointest_disord
-      - liver_disord
-      - special_diet
-      - host_subject_id
-      - host_age
-      - host_sex
-      - host_disease_stat
-      - ihmc_medication_code
-      - chem_administration
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_diet
-      - host_last_meal
-      - host_fam_rel
-      - host_genotype
-      - host_phenotype
-      - host_body_temp
-      - host_body_mass_index
-      - ethnicity
-      - host_occupation
-      - medic_hist_perform
-      - host_pulse
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - samp_store_dur
-      - host_symbiont
-      - samp_store_loc
-      - misc_param
+    - samp_name
+    - project_name
+    - gastrointest_disord
+    - liver_disord
+    - special_diet
+    - host_subject_id
+    - host_age
+    - host_sex
+    - host_disease_stat
+    - ihmc_medication_code
+    - chem_administration
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_diet
+    - host_last_meal
+    - host_fam_rel
+    - host_genotype
+    - host_phenotype
+    - host_body_temp
+    - host_body_mass_index
+    - ethnicity
+    - host_occupation
+    - medic_hist_perform
+    - host_pulse
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - samp_store_dur
+    - host_symbiont
+    - samp_store_loc
+    - misc_param
     slot_usage:
-      chem_administration:
       host_age:
         examples:
-          - value: 30 years
+        - value: 30 years
       host_body_site:
         examples:
-          - value: Wall of gut [fma45653]
+        - value: Wall of gut [fma45653]
       host_body_temp:
         examples:
-          - value: 36.5 degree Celsius
+        - value: 36.5 degree Celsius
       host_diet:
         examples:
-          - value: high-fat
+        - value: high-fat
       host_disease_stat:
         examples:
-          - value: measles [DOID:8622]
+        - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-          - value: mother;ID298
+        - value: mother;ID298
       host_genotype:
         examples:
-          - value: ST1
+        - value: ST1
       host_height:
         examples:
-          - value: 1.75 meter
+        - value: 1.75 meter
       host_last_meal:
         examples:
-          - value: french fries;P5H30M
+        - value: french fries;P5H30M
       host_phenotype:
         examples:
-          - value: Tinnitus [HP:0000360]
+        - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-          - value: MPI123
+        - value: MPI123
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_tot_mass:
         examples:
-          - value: 65 kilogram
+        - value: 65 kilogram
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016004
   HumanOral:
     description: human-oral extension
     title: human-oral
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - nose_mouth_teeth_throat_disord
-      - time_last_toothbrush
-      - host_subject_id
-      - host_age
-      - host_sex
-      - host_disease_stat
-      - ihmc_medication_code
-      - chem_administration
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_diet
-      - host_last_meal
-      - host_fam_rel
-      - host_genotype
-      - host_phenotype
-      - host_body_temp
-      - host_body_mass_index
-      - ethnicity
-      - host_occupation
-      - medic_hist_perform
-      - host_pulse
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_vol_we_dna_ext
-      - samp_store_temp
-      - samp_store_dur
-      - host_symbiont
-      - samp_store_loc
-      - misc_param
+    - samp_name
+    - project_name
+    - nose_mouth_teeth_throat_disord
+    - time_last_toothbrush
+    - host_subject_id
+    - host_age
+    - host_sex
+    - host_disease_stat
+    - ihmc_medication_code
+    - chem_administration
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_diet
+    - host_last_meal
+    - host_fam_rel
+    - host_genotype
+    - host_phenotype
+    - host_body_temp
+    - host_body_mass_index
+    - ethnicity
+    - host_occupation
+    - medic_hist_perform
+    - host_pulse
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_vol_we_dna_ext
+    - samp_store_temp
+    - samp_store_dur
+    - host_symbiont
+    - samp_store_loc
+    - misc_param
     slot_usage:
-      chem_administration:
       host_age:
         examples:
-          - value: 30 years
+        - value: 30 years
       host_body_site:
         examples:
-          - value: Epithelium of tongue [fma284658]
+        - value: Epithelium of tongue [fma284658]
       host_body_temp:
         examples:
-          - value: 36.5 degree Celsius
+        - value: 36.5 degree Celsius
       host_diet:
         examples:
-          - value: high-fat
+        - value: high-fat
       host_disease_stat:
         examples:
-          - value: measles [DOID:8622]
+        - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-          - value: mother;ID298
+        - value: mother;ID298
       host_genotype:
         examples:
-          - value: ST1
+        - value: ST1
       host_height:
         examples:
-          - value: 1.75 meter
+        - value: 1.75 meter
       host_last_meal:
         examples:
-          - value: french fries;P5H30M
+        - value: french fries;P5H30M
       host_phenotype:
         examples:
-          - value: Tinnitus [HP:0000360]
+        - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-          - value: MPI123
+        - value: MPI123
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_tot_mass:
         examples:
-          - value: 65 kilogram
+        - value: 65 kilogram
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016005
   HumanSkin:
     description: human-skin extension
     title: human-skin
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - dermatology_disord
-      - time_since_last_wash
-      - dominant_hand
-      - host_subject_id
-      - host_age
-      - host_sex
-      - host_disease_stat
-      - ihmc_medication_code
-      - chem_administration
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_diet
-      - host_last_meal
-      - host_fam_rel
-      - host_genotype
-      - host_phenotype
-      - host_body_temp
-      - host_body_mass_index
-      - ethnicity
-      - host_occupation
-      - medic_hist_perform
-      - host_pulse
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_vol_we_dna_ext
-      - samp_store_temp
-      - samp_store_dur
-      - samp_store_loc
-      - host_symbiont
-      - misc_param
+    - samp_name
+    - project_name
+    - dermatology_disord
+    - time_since_last_wash
+    - dominant_hand
+    - host_subject_id
+    - host_age
+    - host_sex
+    - host_disease_stat
+    - ihmc_medication_code
+    - chem_administration
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_diet
+    - host_last_meal
+    - host_fam_rel
+    - host_genotype
+    - host_phenotype
+    - host_body_temp
+    - host_body_mass_index
+    - ethnicity
+    - host_occupation
+    - medic_hist_perform
+    - host_pulse
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_vol_we_dna_ext
+    - samp_store_temp
+    - samp_store_dur
+    - samp_store_loc
+    - host_symbiont
+    - misc_param
     slot_usage:
-      chem_administration:
       host_age:
         examples:
-          - value: 30 years
+        - value: 30 years
       host_body_site:
         examples:
-          - value: Skin of palm of left hand [fma38303]
+        - value: Skin of palm of left hand [fma38303]
       host_body_temp:
         examples:
-          - value: 36.5 degree Celsius
+        - value: 36.5 degree Celsius
       host_diet:
         examples:
-          - value: high-fat
+        - value: high-fat
       host_disease_stat:
         examples:
-          - value: measles [DOID:8622]
+        - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-          - value: mother;ID298
+        - value: mother;ID298
       host_genotype:
         examples:
-          - value: ST1
+        - value: ST1
       host_height:
         examples:
-          - value: 1.75 meter
+        - value: 1.75 meter
       host_last_meal:
         examples:
-          - value: french fries;P5H30M
+        - value: french fries;P5H30M
       host_phenotype:
         examples:
-          - value: Tinnitus [HP:0000360]
+        - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-          - value: MPI123
+        - value: MPI123
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_tot_mass:
         examples:
-          - value: 65 kilogram
+        - value: 65 kilogram
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016006
   HumanVaginal:
     description: human-vaginal extension
     title: human-vaginal
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - menarche
-      - sexual_act
-      - pregnancy
-      - douche
-      - birth_control
-      - menopause
-      - hrt
-      - hysterectomy
-      - gynecologic_disord
-      - urogenit_disord
-      - host_subject_id
-      - host_age
-      - host_sex
-      - host_disease_stat
-      - ihmc_medication_code
-      - chem_administration
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_diet
-      - host_last_meal
-      - host_fam_rel
-      - host_genotype
-      - host_phenotype
-      - host_body_temp
-      - host_body_mass_index
-      - ethnicity
-      - host_occupation
-      - medic_hist_perform
-      - host_pulse
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_vol_we_dna_ext
-      - samp_store_temp
-      - samp_store_loc
-      - samp_store_dur
-      - host_symbiont
-      - misc_param
+    - samp_name
+    - project_name
+    - menarche
+    - sexual_act
+    - pregnancy
+    - douche
+    - birth_control
+    - menopause
+    - hrt
+    - hysterectomy
+    - gynecologic_disord
+    - urogenit_disord
+    - host_subject_id
+    - host_age
+    - host_sex
+    - host_disease_stat
+    - ihmc_medication_code
+    - chem_administration
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_diet
+    - host_last_meal
+    - host_fam_rel
+    - host_genotype
+    - host_phenotype
+    - host_body_temp
+    - host_body_mass_index
+    - ethnicity
+    - host_occupation
+    - medic_hist_perform
+    - host_pulse
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_vol_we_dna_ext
+    - samp_store_temp
+    - samp_store_loc
+    - samp_store_dur
+    - host_symbiont
+    - misc_param
     slot_usage:
-      chem_administration:
       host_age:
         examples:
-          - value: 30 years
+        - value: 30 years
       host_body_site:
         examples:
-          - value: Ectocervix [fma86484]
+        - value: Ectocervix [fma86484]
       host_body_temp:
         examples:
-          - value: 36.5 degree Celsius
+        - value: 36.5 degree Celsius
       host_diet:
         examples:
-          - value: high-fat
+        - value: high-fat
       host_disease_stat:
         examples:
-          - value: measles [DOID:8622]
+        - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-          - value: mother;ID298
+        - value: mother;ID298
       host_genotype:
         examples:
-          - value: ST1
+        - value: ST1
       host_height:
         examples:
-          - value: 1.75 meter
+        - value: 1.75 meter
       host_last_meal:
         examples:
-          - value: french fries;P5H30M
+        - value: french fries;P5H30M
       host_phenotype:
         examples:
-          - value: Tinnitus [HP:0000360]
+        - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-          - value: MPI123
+        - value: MPI123
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_tot_mass:
         examples:
-          - value: 65 kilogram
+        - value: 65 kilogram
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016007
   HydrocarbonResourcesCores:
     description: hydrocarbon resources-cores extension
     title: hydrocarbon resources-cores
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - hcr
-      - hc_produced
-      - basin
-      - field
-      - reservoir
-      - hcr_temp
-      - tvdss_of_hcr_temp
-      - hcr_pressure
-      - tvdss_of_hcr_press
-      - permeability
-      - porosity
-      - lithology
-      - depos_env
-      - hcr_geol_age
-      - owc_tvdss
-      - hcr_fw_salinity
-      - sulfate_fw
-      - vfa_fw
-      - sr_kerog_type
-      - sr_lithology
-      - sr_dep_env
-      - sr_geol_age
-      - samp_well_name
-      - win
-      - samp_type
-      - samp_subtype
-      - temp
-      - pressure
-      - samp_tvdss
-      - samp_md
-      - elev
-      - oxy_stat_samp
-      - samp_transport_cond
-      - samp_store_temp
-      - samp_store_dur
-      - samp_store_loc
-      - samp_vol_we_dna_ext
-      - organism_count
-      - org_count_qpcr_info
-      - ph
-      - salinity
-      - alkalinity
-      - alkalinity_method
-      - sulfate
-      - sulfide
-      - tot_sulfur
-      - nitrate
-      - nitrite
-      - ammonium
-      - tot_nitro
-      - diss_iron
-      - sodium
-      - chloride
-      - potassium
-      - magnesium
-      - calcium
-      - tot_iron
-      - diss_org_carb
-      - diss_inorg_carb
-      - diss_inorg_phosp
-      - tot_phosp
-      - suspend_solids
-      - density
-      - diss_carb_dioxide
-      - diss_oxygen_fluid
-      - vfa
-      - benzene
-      - toluene
-      - ethylbenzene
-      - xylene
-      - api
-      - tan
-      - viscosity
-      - pour_point
-      - saturates_pc
-      - aromatics_pc
-      - resins_pc
-      - asphaltenes_pc
-      - misc_param
-      - additional_info
+    - samp_name
+    - project_name
+    - hcr
+    - hc_produced
+    - basin
+    - field
+    - reservoir
+    - hcr_temp
+    - tvdss_of_hcr_temp
+    - hcr_pressure
+    - tvdss_of_hcr_press
+    - permeability
+    - porosity
+    - lithology
+    - depos_env
+    - hcr_geol_age
+    - owc_tvdss
+    - hcr_fw_salinity
+    - sulfate_fw
+    - vfa_fw
+    - sr_kerog_type
+    - sr_lithology
+    - sr_dep_env
+    - sr_geol_age
+    - samp_well_name
+    - win
+    - samp_type
+    - samp_subtype
+    - temp
+    - pressure
+    - samp_tvdss
+    - samp_md
+    - elev
+    - oxy_stat_samp
+    - samp_transport_cond
+    - samp_store_temp
+    - samp_store_dur
+    - samp_store_loc
+    - samp_vol_we_dna_ext
+    - organism_count
+    - org_count_qpcr_info
+    - ph
+    - salinity
+    - alkalinity
+    - alkalinity_method
+    - sulfate
+    - sulfide
+    - tot_sulfur
+    - nitrate
+    - nitrite
+    - ammonium
+    - tot_nitro
+    - diss_iron
+    - sodium
+    - chloride
+    - potassium
+    - magnesium
+    - calcium
+    - tot_iron
+    - diss_org_carb
+    - diss_inorg_carb
+    - diss_inorg_phosp
+    - tot_phosp
+    - suspend_solids
+    - density
+    - diss_carb_dioxide
+    - diss_oxygen_fluid
+    - vfa
+    - benzene
+    - toluene
+    - ethylbenzene
+    - xylene
+    - api
+    - tan
+    - viscosity
+    - pour_point
+    - saturates_pc
+    - aromatics_pc
+    - resins_pc
+    - asphaltenes_pc
+    - misc_param
+    - additional_info
     slot_usage:
       ammonium:
         recommended: true
       depos_env:
         examples:
-          - value: Continental - Alluvial
+        - value: Continental - Alluvial
       diss_inorg_phosp:
         recommended: true
-      elev:
       hcr_temp:
         required: true
       nitrate:
@@ -19172,13 +17926,10 @@ classes:
         recommended: true
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         recommended: true
-      oxy_stat_samp:
       ph:
         recommended: true
-      samp_store_dur:
-      samp_store_loc:
       samp_vol_we_dna_ext:
         recommended: true
       sulfate:
@@ -19197,98 +17948,98 @@ classes:
     title: hydrocarbon resources-fluids/swabs
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - hcr
-      - hc_produced
-      - basin
-      - field
-      - reservoir
-      - hcr_temp
-      - tvdss_of_hcr_temp
-      - hcr_pressure
-      - tvdss_of_hcr_press
-      - lithology
-      - depos_env
-      - hcr_geol_age
-      - hcr_fw_salinity
-      - sulfate_fw
-      - vfa_fw
-      - prod_start_date
-      - prod_rate
-      - water_prod_rate
-      - water_cut
-      - iwf
-      - add_recov_method
-      - iw_bt_date_well
-      - biocide
-      - biocide_admin_method
-      - chem_treatment
-      - chem_treat_method
-      - samp_loc_corr_rate
-      - samp_well_name
-      - win
-      - samp_type
-      - samp_subtype
-      - samp_collect_point
-      - temp
-      - pressure
-      - oxy_stat_samp
-      - samp_preserv
-      - samp_transport_cond
-      - samp_store_temp
-      - samp_store_dur
-      - samp_store_loc
-      - samp_vol_we_dna_ext
-      - organism_count
-      - org_count_qpcr_info
-      - ph
-      - salinity
-      - alkalinity
-      - alkalinity_method
-      - sulfate
-      - sulfide
-      - tot_sulfur
-      - nitrate
-      - nitrite
-      - ammonium
-      - tot_nitro
-      - diss_iron
-      - sodium
-      - chloride
-      - potassium
-      - magnesium
-      - calcium
-      - tot_iron
-      - diss_org_carb
-      - diss_inorg_carb
-      - diss_inorg_phosp
-      - tot_phosp
-      - suspend_solids
-      - density
-      - diss_carb_dioxide
-      - diss_oxygen_fluid
-      - vfa
-      - benzene
-      - toluene
-      - ethylbenzene
-      - xylene
-      - api
-      - tan
-      - viscosity
-      - pour_point
-      - saturates_pc
-      - aromatics_pc
-      - resins_pc
-      - asphaltenes_pc
-      - misc_param
-      - additional_info
+    - samp_name
+    - project_name
+    - hcr
+    - hc_produced
+    - basin
+    - field
+    - reservoir
+    - hcr_temp
+    - tvdss_of_hcr_temp
+    - hcr_pressure
+    - tvdss_of_hcr_press
+    - lithology
+    - depos_env
+    - hcr_geol_age
+    - hcr_fw_salinity
+    - sulfate_fw
+    - vfa_fw
+    - prod_start_date
+    - prod_rate
+    - water_prod_rate
+    - water_cut
+    - iwf
+    - add_recov_method
+    - iw_bt_date_well
+    - biocide
+    - biocide_admin_method
+    - chem_treatment
+    - chem_treat_method
+    - samp_loc_corr_rate
+    - samp_well_name
+    - win
+    - samp_type
+    - samp_subtype
+    - samp_collect_point
+    - temp
+    - pressure
+    - oxy_stat_samp
+    - samp_preserv
+    - samp_transport_cond
+    - samp_store_temp
+    - samp_store_dur
+    - samp_store_loc
+    - samp_vol_we_dna_ext
+    - organism_count
+    - org_count_qpcr_info
+    - ph
+    - salinity
+    - alkalinity
+    - alkalinity_method
+    - sulfate
+    - sulfide
+    - tot_sulfur
+    - nitrate
+    - nitrite
+    - ammonium
+    - tot_nitro
+    - diss_iron
+    - sodium
+    - chloride
+    - potassium
+    - magnesium
+    - calcium
+    - tot_iron
+    - diss_org_carb
+    - diss_inorg_carb
+    - diss_inorg_phosp
+    - tot_phosp
+    - suspend_solids
+    - density
+    - diss_carb_dioxide
+    - diss_oxygen_fluid
+    - vfa
+    - benzene
+    - toluene
+    - ethylbenzene
+    - xylene
+    - api
+    - tan
+    - viscosity
+    - pour_point
+    - saturates_pc
+    - aromatics_pc
+    - resins_pc
+    - asphaltenes_pc
+    - misc_param
+    - additional_info
     slot_usage:
       ammonium:
         recommended: true
       depos_env:
         examples:
-          - value: Marine - Reef
+        - value: Marine - Reef
       diss_inorg_phosp:
         recommended: true
       hcr_temp:
@@ -19299,13 +18050,10 @@ classes:
         recommended: true
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         recommended: true
-      oxy_stat_samp:
       ph:
         recommended: true
-      samp_store_dur:
-      samp_store_loc:
       samp_vol_we_dna_ext:
         recommended: true
       sulfate:
@@ -19324,108 +18072,83 @@ classes:
     title: microbial mat/biofilm
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - depth
-      - elev
-      - alkalinity
-      - alkyl_diethers
-      - aminopept_act
-      - ammonium
-      - bacteria_carb_prod
-      - biomass
-      - bishomohopanol
-      - bromide
-      - calcium
-      - carb_nitro_ratio
-      - chem_administration
-      - chloride
-      - chlorophyll
-      - diether_lipids
-      - diss_carb_dioxide
-      - diss_hydrogen
-      - diss_inorg_carb
-      - diss_org_carb
-      - diss_org_nitro
-      - diss_oxygen
-      - glucosidase_act
-      - magnesium
-      - mean_frict_vel
-      - mean_peak_frict_vel
-      - methane
-      - misc_param
-      - n_alkanes
-      - nitrate
-      - nitrite
-      - nitro
-      - org_carb
-      - org_matter
-      - org_nitro
-      - organism_count
-      - oxy_stat_samp
-      - ph
-      - part_org_carb
-      - perturbation
-      - petroleum_hydrocarb
-      - phaeopigments
-      - phosphate
-      - phosplipid_fatt_acid
-      - potassium
-      - pressure
-      - redox_potential
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - silicate
-      - sodium
-      - sulfate
-      - sulfide
-      - temp
-      - tot_carb
-      - tot_nitro_content
-      - tot_org_carb
-      - turbidity
-      - water_content
+    - samp_name
+    - project_name
+    - depth
+    - elev
+    - alkalinity
+    - alkyl_diethers
+    - aminopept_act
+    - ammonium
+    - bacteria_carb_prod
+    - biomass
+    - bishomohopanol
+    - bromide
+    - calcium
+    - carb_nitro_ratio
+    - chem_administration
+    - chloride
+    - chlorophyll
+    - diether_lipids
+    - diss_carb_dioxide
+    - diss_hydrogen
+    - diss_inorg_carb
+    - diss_org_carb
+    - diss_org_nitro
+    - diss_oxygen
+    - glucosidase_act
+    - magnesium
+    - mean_frict_vel
+    - mean_peak_frict_vel
+    - methane
+    - misc_param
+    - n_alkanes
+    - nitrate
+    - nitrite
+    - nitro
+    - org_carb
+    - org_matter
+    - org_nitro
+    - organism_count
+    - oxy_stat_samp
+    - ph
+    - part_org_carb
+    - perturbation
+    - petroleum_hydrocarb
+    - phaeopigments
+    - phosphate
+    - phosplipid_fatt_acid
+    - potassium
+    - pressure
+    - redox_potential
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - silicate
+    - sodium
+    - sulfate
+    - sulfide
+    - temp
+    - tot_carb
+    - tot_nitro_content
+    - tot_org_carb
+    - turbidity
+    - water_content
     slot_usage:
-      alkyl_diethers:
-      ammonium:
-      bacteria_carb_prod:
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
-      diss_org_nitro:
       elev:
         recommended: true
       methane:
         examples:
-          - value: 0.15 micromole per liter
-      n_alkanes:
-      nitrate:
-      nitrite:
-      org_carb:
-      org_nitro:
+        - value: 0.15 micromole per liter
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      part_org_carb:
-      perturbation:
-      ph:
-      phosplipid_fatt_acid:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      sulfate:
-      sulfide:
-      temp:
-      tot_carb:
-      tot_nitro_content:
-      tot_org_carb:
-      turbidity:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016008
@@ -19434,170 +18157,151 @@ classes:
     title: miscellaneous natural or artificial environment
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - alt
-      - depth
-      - elev
-      - alkalinity
-      - ammonium
-      - biomass
-      - bromide
-      - calcium
-      - chem_administration
-      - chloride
-      - chlorophyll
-      - density
-      - diether_lipids
-      - diss_carb_dioxide
-      - diss_hydrogen
-      - diss_inorg_carb
-      - diss_org_nitro
-      - diss_oxygen
-      - misc_param
-      - nitrate
-      - nitrite
-      - nitro
-      - org_carb
-      - org_matter
-      - org_nitro
-      - organism_count
-      - oxy_stat_samp
-      - ph
-      - perturbation
-      - phosphate
-      - phosplipid_fatt_acid
-      - potassium
-      - pressure
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - silicate
-      - sodium
-      - sulfate
-      - sulfide
-      - temp
-      - water_current
+    - samp_name
+    - project_name
+    - alt
+    - depth
+    - elev
+    - alkalinity
+    - ammonium
+    - biomass
+    - bromide
+    - calcium
+    - chem_administration
+    - chloride
+    - chlorophyll
+    - density
+    - diether_lipids
+    - diss_carb_dioxide
+    - diss_hydrogen
+    - diss_inorg_carb
+    - diss_org_nitro
+    - diss_oxygen
+    - misc_param
+    - nitrate
+    - nitrite
+    - nitro
+    - org_carb
+    - org_matter
+    - org_nitro
+    - organism_count
+    - oxy_stat_samp
+    - ph
+    - perturbation
+    - phosphate
+    - phosplipid_fatt_acid
+    - potassium
+    - pressure
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - silicate
+    - sodium
+    - sulfate
+    - sulfide
+    - temp
+    - water_current
     slot_usage:
       alt:
         recommended: true
-      ammonium:
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
-      diss_org_nitro:
       elev:
         recommended: true
-      nitrate:
-      nitrite:
-      org_carb:
-      org_nitro:
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      ph:
-      phosplipid_fatt_acid:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      sulfate:
-      sulfide:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016009
   PlantAssociated:
     description: plant-associated extension
     title: plant-associated
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - depth
-      - elev
-      - air_temp_regm
-      - ances_data
-      - antibiotic_regm
-      - biol_stat
-      - biotic_regm
-      - chem_administration
-      - chem_mutagen
-      - climate_environment
-      - cult_root_med
-      - fertilizer_regm
-      - fungicide_regm
-      - gaseous_environment
-      - genetic_mod
-      - gravity
-      - growth_facil
-      - growth_habit
-      - growth_hormone_regm
-      - herbicide_regm
-      - host_age
-      - host_common_name
-      - host_disease_stat
-      - host_dry_mass
-      - host_genotype
-      - host_height
-      - host_subspecf_genlin
-      - host_length
-      - host_life_stage
-      - host_phenotype
-      - host_taxid
-      - host_tot_mass
-      - host_wet_mass
-      - humidity_regm
-      - light_regm
-      - mechanical_damage
-      - mineral_nutr_regm
-      - misc_param
-      - non_min_nutr_regm
-      - organism_count
-      - oxy_stat_samp
-      - ph_regm
-      - perturbation
-      - pesticide_regm
-      - plant_growth_med
-      - plant_product
-      - plant_sex
-      - plant_struc
-      - radiation_regm
-      - rainfall_regm
-      - root_cond
-      - root_med_carbon
-      - root_med_macronutr
-      - root_med_micronutr
-      - root_med_suppl
-      - root_med_ph
-      - root_med_regl
-      - root_med_solid
-      - salt_regm
-      - samp_capt_status
-      - samp_dis_stage
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - season_environment
-      - standing_water_regm
-      - temp
-      - tiss_cult_growth_med
-      - water_temp_regm
-      - watering_regm
-      - host_symbiont
+    - samp_name
+    - project_name
+    - depth
+    - elev
+    - air_temp_regm
+    - ances_data
+    - antibiotic_regm
+    - biol_stat
+    - biotic_regm
+    - chem_administration
+    - chem_mutagen
+    - climate_environment
+    - cult_root_med
+    - fertilizer_regm
+    - fungicide_regm
+    - gaseous_environment
+    - genetic_mod
+    - gravity
+    - growth_facil
+    - growth_habit
+    - growth_hormone_regm
+    - herbicide_regm
+    - host_age
+    - host_common_name
+    - host_disease_stat
+    - host_dry_mass
+    - host_genotype
+    - host_height
+    - host_subspecf_genlin
+    - host_length
+    - host_life_stage
+    - host_phenotype
+    - host_taxid
+    - host_tot_mass
+    - host_wet_mass
+    - humidity_regm
+    - light_regm
+    - mechanical_damage
+    - mineral_nutr_regm
+    - misc_param
+    - non_min_nutr_regm
+    - organism_count
+    - oxy_stat_samp
+    - ph_regm
+    - perturbation
+    - pesticide_regm
+    - plant_growth_med
+    - plant_product
+    - plant_sex
+    - plant_struc
+    - radiation_regm
+    - rainfall_regm
+    - root_cond
+    - root_med_carbon
+    - root_med_macronutr
+    - root_med_micronutr
+    - root_med_suppl
+    - root_med_ph
+    - root_med_regl
+    - root_med_solid
+    - salt_regm
+    - samp_capt_status
+    - samp_dis_stage
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - season_environment
+    - standing_water_regm
+    - temp
+    - tiss_cult_growth_med
+    - water_temp_regm
+    - watering_regm
+    - host_symbiont
     slot_usage:
-      biotic_regm:
-      chem_administration:
       climate_environment:
         string_serialization: '{text};{Rn/start_time/end_time/duration}'
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -19609,62 +18313,53 @@ classes:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       host_age:
         examples:
-          - value: 10 days
+        - value: 10 days
       host_common_name:
         examples:
-          - value: rice
+        - value: rice
       host_disease_stat:
         examples:
-          - value: downy mildew
+        - value: downy mildew
       host_genotype:
         examples:
-          - value: Ts
+        - value: Ts
       host_height:
         examples:
-          - value: 1 meter
-      host_length:
+        - value: 1 meter
       host_life_stage:
         examples:
-          - value: adult
+        - value: adult
       host_phenotype:
         examples:
-          - value: seed pod; green [PATO:0000320]
+        - value: seed pod; green [PATO:0000320]
       host_symbiont:
         examples:
-          - value: flukeworms
+        - value: flukeworms
       host_taxid:
         examples:
-          - value: '4530'
+        - value: '4530'
         string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
-          - value: 2500 gram
+        - value: 2500 gram
       non_min_nutr_regm:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       pesticide_regm:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       ph_regm:
         string_serialization: '{float};{Rn/start_time/end_time/duration}'
       plant_growth_med:
         examples:
-          - value: hydroponic plant culture media [EO:0007067]
-      plant_product:
-      plant_struc:
+        - value: hydroponic plant culture media [EO:0007067]
       salt_regm:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
       season_environment:
         string_serialization: '{text};{Rn/start_time/end_time/duration}'
       standing_water_regm:
         string_serialization: '{text};{Rn/start_time/end_time/duration}'
-      temp:
       water_temp_regm:
         string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
       watering_regm:
@@ -19675,114 +18370,89 @@ classes:
     title: sediment
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - depth
-      - elev
-      - alkalinity
-      - alkyl_diethers
-      - aminopept_act
-      - ammonium
-      - bacteria_carb_prod
-      - biomass
-      - bishomohopanol
-      - bromide
-      - calcium
-      - carb_nitro_ratio
-      - chem_administration
-      - chloride
-      - chlorophyll
-      - density
-      - diether_lipids
-      - diss_carb_dioxide
-      - diss_hydrogen
-      - diss_inorg_carb
-      - diss_org_carb
-      - diss_org_nitro
-      - diss_oxygen
-      - glucosidase_act
-      - magnesium
-      - mean_frict_vel
-      - mean_peak_frict_vel
-      - methane
-      - misc_param
-      - n_alkanes
-      - nitrate
-      - nitrite
-      - nitro
-      - org_carb
-      - org_matter
-      - org_nitro
-      - organism_count
-      - oxy_stat_samp
-      - ph
-      - particle_class
-      - part_org_carb
-      - perturbation
-      - petroleum_hydrocarb
-      - phaeopigments
-      - phosphate
-      - phosplipid_fatt_acid
-      - porosity
-      - potassium
-      - pressure
-      - redox_potential
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - sediment_type
-      - silicate
-      - sodium
-      - sulfate
-      - sulfide
-      - temp
-      - tidal_stage
-      - tot_carb
-      - tot_depth_water_col
-      - tot_nitro_content
-      - tot_org_carb
-      - turbidity
-      - water_content
+    - samp_name
+    - project_name
+    - depth
+    - elev
+    - alkalinity
+    - alkyl_diethers
+    - aminopept_act
+    - ammonium
+    - bacteria_carb_prod
+    - biomass
+    - bishomohopanol
+    - bromide
+    - calcium
+    - carb_nitro_ratio
+    - chem_administration
+    - chloride
+    - chlorophyll
+    - density
+    - diether_lipids
+    - diss_carb_dioxide
+    - diss_hydrogen
+    - diss_inorg_carb
+    - diss_org_carb
+    - diss_org_nitro
+    - diss_oxygen
+    - glucosidase_act
+    - magnesium
+    - mean_frict_vel
+    - mean_peak_frict_vel
+    - methane
+    - misc_param
+    - n_alkanes
+    - nitrate
+    - nitrite
+    - nitro
+    - org_carb
+    - org_matter
+    - org_nitro
+    - organism_count
+    - oxy_stat_samp
+    - ph
+    - particle_class
+    - part_org_carb
+    - perturbation
+    - petroleum_hydrocarb
+    - phaeopigments
+    - phosphate
+    - phosplipid_fatt_acid
+    - porosity
+    - potassium
+    - pressure
+    - redox_potential
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - sediment_type
+    - silicate
+    - sodium
+    - sulfate
+    - sulfide
+    - temp
+    - tidal_stage
+    - tot_carb
+    - tot_depth_water_col
+    - tot_nitro_content
+    - tot_org_carb
+    - turbidity
+    - water_content
     slot_usage:
-      alkyl_diethers:
-      ammonium:
-      bacteria_carb_prod:
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         required: true
-      diss_org_nitro:
       elev:
         recommended: true
       methane:
         examples:
-          - value: 0.15 micromole per liter
-      n_alkanes:
-      nitrate:
-      nitrite:
-      org_carb:
-      org_nitro:
+        - value: 0.15 micromole per liter
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      part_org_carb:
-      perturbation:
-      ph:
-      phosplipid_fatt_acid:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      sulfate:
-      sulfide:
-      temp:
-      tot_carb:
-      tot_nitro_content:
-      tot_org_carb:
-      turbidity:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016011
@@ -19791,112 +18461,80 @@ classes:
     title: soil
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - depth
-      - elev
-      - cur_land_use
-      - cur_vegetation
-      - cur_vegetation_meth
-      - previous_land_use
-      - prev_land_use_meth
-      - crop_rotation
-      - agrochem_addition
-      - tillage
-      - fire
-      - flooding
-      - extreme_event
-      - soil_horizon
-      - horizon_meth
-      - sieving
-      - water_content
-      - water_cont_soil_meth
-      - samp_vol_we_dna_ext
-      - pool_dna_extracts
-      - store_cond
-      - link_climate_info
-      - annual_temp
-      - season_temp
-      - annual_precpt
-      - season_precpt
-      - link_class_info
-      - fao_class
-      - local_class
-      - local_class_meth
-      - org_nitro
-      - temp
-      - soil_type
-      - soil_type_meth
-      - slope_gradient
-      - slope_aspect
-      - profile_position
-      - drainage_class
-      - soil_texture
-      - soil_texture_meth
-      - ph
-      - ph_meth
-      - org_matter
-      - tot_org_carb
-      - tot_org_c_meth
-      - tot_nitro_content
-      - tot_nitro_cont_meth
-      - microbial_biomass
-      - micro_biomass_meth
-      - link_addit_analys
-      - heavy_metals
-      - heavy_metals_meth
-      - al_sat
-      - al_sat_meth
-      - misc_param
+    - samp_name
+    - project_name
+    - depth
+    - elev
+    - cur_land_use
+    - cur_vegetation
+    - cur_vegetation_meth
+    - previous_land_use
+    - prev_land_use_meth
+    - crop_rotation
+    - agrochem_addition
+    - tillage
+    - fire
+    - flooding
+    - extreme_event
+    - soil_horizon
+    - horizon_meth
+    - sieving
+    - water_content
+    - water_cont_soil_meth
+    - samp_vol_we_dna_ext
+    - pool_dna_extracts
+    - store_cond
+    - link_climate_info
+    - annual_temp
+    - season_temp
+    - annual_precpt
+    - season_precpt
+    - link_class_info
+    - fao_class
+    - local_class
+    - local_class_meth
+    - org_nitro
+    - temp
+    - soil_type
+    - soil_type_meth
+    - slope_gradient
+    - slope_aspect
+    - profile_position
+    - drainage_class
+    - soil_texture
+    - soil_texture_meth
+    - ph
+    - ph_meth
+    - org_matter
+    - tot_org_carb
+    - tot_org_c_meth
+    - tot_nitro_content
+    - tot_nitro_cont_meth
+    - microbial_biomass
+    - micro_biomass_meth
+    - link_addit_analys
+    - heavy_metals
+    - heavy_metals_meth
+    - al_sat
+    - al_sat_meth
+    - misc_param
     slot_usage:
       crop_rotation:
         string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
-      cur_vegetation:
-      cur_vegetation_meth:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         required: true
-      drainage_class:
       elev:
         required: true
-      extreme_event:
-      fao_class:
-      fire:
-      flooding:
       heavy_metals_meth:
         string_serialization: '{PMID}|{DOI}|{URL}'
-      horizon_meth:
-      local_class:
-      local_class_meth:
-      micro_biomass_meth:
-      microbial_biomass:
-      org_nitro:
-      ph:
-      ph_meth:
       pool_dna_extracts:
         string_serialization: '{boolean};{integer}'
-      prev_land_use_meth:
-      previous_land_use:
-      profile_position:
-      samp_vol_we_dna_ext:
-      season_precpt:
-      sieving:
-      slope_aspect:
-      slope_gradient:
-      soil_horizon:
       soil_type:
         string_serialization: '{termLabel} [{termID}]
 
           '
-      soil_type_meth:
-      store_cond:
-      temp:
-      tillage:
-      tot_nitro_cont_meth:
-      tot_nitro_content:
-      tot_org_c_meth:
-      tot_org_carb:
       water_content:
         string_serialization: '{float}'
     class_uri: MIXS:0016012
@@ -19905,322 +18543,271 @@ classes:
     title: symbiont-associated
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - lat_lon
-      - geo_loc_name
-      - collection_date
-      - alt
-      - depth
-      - elev
-      - host_subject_id
-      - host_common_name
-      - host_taxid
-      - source_mat_id
-      - host_dependence
-      - type_of_symbiosis
-      - sym_life_cycle_type
-      - host_life_stage
-      - host_age
-      - urobiom_sex
-      - mode_transmission
-      - route_transmission
-      - host_body_habitat
-      - host_body_site
-      - host_body_product
-      - host_tot_mass
-      - host_height
-      - host_length
-      - host_growth_cond
-      - host_substrate
-      - host_fam_rel
-      - host_infra_spec_name
-      - host_infra_spec_rank
-      - host_genotype
-      - host_phenotype
-      - host_dry_mass
-      - host_color
-      - host_shape
-      - gravidity
-      - host_number
-      - host_symbiont
-      - host_specificity
-      - symbiont_host_role
-      - host_cellular_loc
-      - association_duration
-      - host_of_host_coinf
-      - host_of_host_name
-      - host_of_host_env_loc
-      - host_of_host_env_med
-      - host_of_host_taxid
-      - host_of_host_sub_id
-      - host_of_host_disease
-      - host_of_host_fam_rel
-      - host_of_host_infname
-      - host_of_host_infrank
-      - host_of_host_geno
-      - host_of_host_pheno
-      - host_of_host_gravid
-      - host_of_host_totmass
-      - chem_administration
-      - perturbation
-      - salinity
-      - oxy_stat_samp
-      - temp
-      - organism_count
-      - samp_vol_we_dna_ext
-      - samp_store_temp
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_sol
-      - misc_param
+    - samp_name
+    - project_name
+    - lat_lon
+    - geo_loc_name
+    - collection_date
+    - alt
+    - depth
+    - elev
+    - host_subject_id
+    - host_common_name
+    - host_taxid
+    - source_mat_id
+    - host_dependence
+    - type_of_symbiosis
+    - sym_life_cycle_type
+    - host_life_stage
+    - host_age
+    - urobiom_sex
+    - mode_transmission
+    - route_transmission
+    - host_body_habitat
+    - host_body_site
+    - host_body_product
+    - host_tot_mass
+    - host_height
+    - host_length
+    - host_growth_cond
+    - host_substrate
+    - host_fam_rel
+    - host_infra_spec_name
+    - host_infra_spec_rank
+    - host_genotype
+    - host_phenotype
+    - host_dry_mass
+    - host_color
+    - host_shape
+    - gravidity
+    - host_number
+    - host_symbiont
+    - host_specificity
+    - symbiont_host_role
+    - host_cellular_loc
+    - association_duration
+    - host_of_host_coinf
+    - host_of_host_name
+    - host_of_host_env_loc
+    - host_of_host_env_med
+    - host_of_host_taxid
+    - host_of_host_sub_id
+    - host_of_host_disease
+    - host_of_host_fam_rel
+    - host_of_host_infname
+    - host_of_host_infrank
+    - host_of_host_geno
+    - host_of_host_pheno
+    - host_of_host_gravid
+    - host_of_host_totmass
+    - chem_administration
+    - perturbation
+    - salinity
+    - oxy_stat_samp
+    - temp
+    - organism_count
+    - samp_vol_we_dna_ext
+    - samp_store_temp
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_sol
+    - misc_param
     slot_usage:
       alt:
         recommended: true
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
       elev:
         recommended: true
-      gravidity:
-      host_age:
       host_body_habitat:
         examples:
-          - value: anterior end of a tapeworm
+        - value: anterior end of a tapeworm
       host_body_site:
         examples:
-          - value: scolex [UBERON:0015119]
-      host_color:
+        - value: scolex [UBERON:0015119]
       host_common_name:
         examples:
-          - value: trematode
+        - value: trematode
       host_fam_rel:
         examples:
-          - value: clone;P15
-      host_genotype:
-      host_growth_cond:
-      host_height:
-      host_length:
+        - value: clone;P15
       host_life_stage:
         examples:
-          - value: redia
+        - value: redia
         required: true
       host_phenotype:
         examples:
-          - value: soldier
-      host_shape:
+        - value: soldier
       host_subject_id:
         examples:
-          - value: P14
-      host_substrate:
+        - value: P14
       host_symbiont:
         examples:
-          - value: Paragordius varius
+        - value: Paragordius varius
       host_taxid:
         examples:
-          - value: '395013'
+        - value: '395013'
         string_serialization: '{integer}'
-      host_tot_mass:
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      source_mat_id:
-      temp:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016023
   WastewaterSludge:
     description: wastewater/sludge extension
     title: wastewater/sludge
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - depth
-      - alkalinity
-      - biochem_oxygen_dem
-      - chem_administration
-      - chem_oxygen_dem
-      - efficiency_percent
-      - emulsions
-      - gaseous_substances
-      - indust_eff_percent
-      - inorg_particles
-      - misc_param
-      - nitrate
-      - org_particles
-      - organism_count
-      - oxy_stat_samp
-      - ph
-      - perturbation
-      - phosphate
-      - pre_treatment
-      - primary_treatment
-      - reactor_type
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - secondary_treatment
-      - sewage_type
-      - sludge_retent_time
-      - sodium
-      - soluble_inorg_mat
-      - soluble_org_mat
-      - suspend_solids
-      - temp
-      - tertiary_treatment
-      - tot_nitro
-      - tot_phosphate
-      - wastewater_type
+    - samp_name
+    - project_name
+    - depth
+    - alkalinity
+    - biochem_oxygen_dem
+    - chem_administration
+    - chem_oxygen_dem
+    - efficiency_percent
+    - emulsions
+    - gaseous_substances
+    - indust_eff_percent
+    - inorg_particles
+    - misc_param
+    - nitrate
+    - org_particles
+    - organism_count
+    - oxy_stat_samp
+    - ph
+    - perturbation
+    - phosphate
+    - pre_treatment
+    - primary_treatment
+    - reactor_type
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - secondary_treatment
+    - sewage_type
+    - sludge_retent_time
+    - sodium
+    - soluble_inorg_mat
+    - soluble_org_mat
+    - suspend_solids
+    - temp
+    - tertiary_treatment
+    - tot_nitro
+    - tot_phosphate
+    - wastewater_type
     slot_usage:
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         recommended: true
-      nitrate:
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      perturbation:
-      ph:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      temp:
-      tot_phosphate:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016013
   Water:
     description: water extension
     title: water
     is_a: Extension
     slots:
-      - samp_name
-      - project_name
-      - depth
-      - elev
-      - alkalinity
-      - alkalinity_method
-      - alkyl_diethers
-      - aminopept_act
-      - ammonium
-      - atmospheric_data
-      - bacteria_carb_prod
-      - bac_prod
-      - bac_resp
-      - biomass
-      - bishomohopanol
-      - bromide
-      - calcium
-      - carb_nitro_ratio
-      - chem_administration
-      - chloride
-      - chlorophyll
-      - conduc
-      - density
-      - diether_lipids
-      - diss_carb_dioxide
-      - diss_hydrogen
-      - diss_inorg_carb
-      - diss_inorg_nitro
-      - diss_inorg_phosp
-      - diss_org_carb
-      - diss_org_nitro
-      - diss_oxygen
-      - down_par
-      - fluor
-      - glucosidase_act
-      - light_intensity
-      - magnesium
-      - mean_frict_vel
-      - mean_peak_frict_vel
-      - misc_param
-      - n_alkanes
-      - nitrate
-      - nitrite
-      - nitro
-      - org_carb
-      - org_matter
-      - org_nitro
-      - organism_count
-      - oxy_stat_samp
-      - ph
-      - part_org_carb
-      - part_org_nitro
-      - perturbation
-      - petroleum_hydrocarb
-      - phaeopigments
-      - phosphate
-      - phosplipid_fatt_acid
-      - photon_flux
-      - potassium
-      - pressure
-      - primary_prod
-      - redox_potential
-      - salinity
-      - samp_store_dur
-      - samp_store_loc
-      - samp_store_temp
-      - samp_vol_we_dna_ext
-      - silicate
-      - size_frac_low
-      - size_frac_up
-      - sodium
-      - soluble_react_phosp
-      - sulfate
-      - sulfide
-      - suspend_part_matter
-      - temp
-      - tidal_stage
-      - tot_depth_water_col
-      - tot_diss_nitro
-      - tot_inorg_nitro
-      - tot_nitro
-      - tot_part_carb
-      - tot_phosp
-      - turbidity
-      - water_current
+    - samp_name
+    - project_name
+    - depth
+    - elev
+    - alkalinity
+    - alkalinity_method
+    - alkyl_diethers
+    - aminopept_act
+    - ammonium
+    - atmospheric_data
+    - bacteria_carb_prod
+    - bac_prod
+    - bac_resp
+    - biomass
+    - bishomohopanol
+    - bromide
+    - calcium
+    - carb_nitro_ratio
+    - chem_administration
+    - chloride
+    - chlorophyll
+    - conduc
+    - density
+    - diether_lipids
+    - diss_carb_dioxide
+    - diss_hydrogen
+    - diss_inorg_carb
+    - diss_inorg_nitro
+    - diss_inorg_phosp
+    - diss_org_carb
+    - diss_org_nitro
+    - diss_oxygen
+    - down_par
+    - fluor
+    - glucosidase_act
+    - light_intensity
+    - magnesium
+    - mean_frict_vel
+    - mean_peak_frict_vel
+    - misc_param
+    - n_alkanes
+    - nitrate
+    - nitrite
+    - nitro
+    - org_carb
+    - org_matter
+    - org_nitro
+    - organism_count
+    - oxy_stat_samp
+    - ph
+    - part_org_carb
+    - part_org_nitro
+    - perturbation
+    - petroleum_hydrocarb
+    - phaeopigments
+    - phosphate
+    - phosplipid_fatt_acid
+    - photon_flux
+    - potassium
+    - pressure
+    - primary_prod
+    - redox_potential
+    - salinity
+    - samp_store_dur
+    - samp_store_loc
+    - samp_store_temp
+    - samp_vol_we_dna_ext
+    - silicate
+    - size_frac_low
+    - size_frac_up
+    - sodium
+    - soluble_react_phosp
+    - sulfate
+    - sulfide
+    - suspend_part_matter
+    - temp
+    - tidal_stage
+    - tot_depth_water_col
+    - tot_diss_nitro
+    - tot_inorg_nitro
+    - tot_nitro
+    - tot_part_carb
+    - tot_phosp
+    - turbidity
+    - water_current
     slot_usage:
-      alkyl_diethers:
-      ammonium:
-      bacteria_carb_prod:
-      chem_administration:
       depth:
         examples:
-          - value: 10 meter
+        - value: 10 meter
         required: true
-      diss_inorg_phosp:
-      diss_org_nitro:
       elev:
         recommended: true
-      n_alkanes:
-      nitrate:
-      nitrite:
-      org_carb:
-      org_nitro:
       organism_count:
         examples:
-          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-      oxy_stat_samp:
-      part_org_carb:
-      perturbation:
-      ph:
-      phosplipid_fatt_acid:
-      samp_store_dur:
-      samp_store_loc:
-      samp_vol_we_dna_ext:
-      sulfate:
-      sulfide:
-      temp:
-      turbidity:
+        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016014
   Checklist:
     description: A collection of metadata terms (slots) to minimally describe the
@@ -20229,2801 +18816,2788 @@ classes:
     description: A collection of recommended metadata terms (slots) developed by community
       experts, describing the specific context under which a sample was collected.
     aliases:
-      - EnvironmentalPackage
+    - EnvironmentalPackage
   MixsCompliantData:
     description: A collection of Data that comply with some combination of a MIxS
       checklist and environmental extension
     title: MIxS compliant data
     slots:
-      - migs_ba_data
-      - agriculture_data
-      - migs_ba_agriculture_data
-      - air_data
-      - migs_ba_air_data
-      - built_environment_data
-      - migs_ba_built_environment_data
-      - food_animal_and_animal_feed_data
-      - migs_ba_food_animal_and_animal_feed_data
-      - food_farm_environment_data
-      - migs_ba_food_farm_environment_data
-      - food_food_production_facility_data
-      - migs_ba_food_food_production_facility_data
-      - food_human_foods_data
-      - migs_ba_food_human_foods_data
-      - host_associated_data
-      - migs_ba_host_associated_data
-      - human_associated_data
-      - migs_ba_human_associated_data
-      - human_gut_data
-      - migs_ba_human_gut_data
-      - human_oral_data
-      - migs_ba_human_oral_data
-      - human_skin_data
-      - migs_ba_human_skin_data
-      - human_vaginal_data
-      - migs_ba_human_vaginal_data
-      - hydrocarbon_resources_cores_data
-      - migs_ba_hydrocarbon_resources_cores_data
-      - hydrocarbon_resources_fluids_swabs_data
-      - migs_ba_hydrocarbon_resources_fluids_swabs_data
-      - microbial_mat_biofilm_data
-      - migs_ba_microbial_mat_biofilm_data
-      - miscellaneous_natural_or_artificial_environment_data
-      - migs_ba_miscellaneous_natural_or_artificial_environment_data
-      - plant_associated_data
-      - migs_ba_plant_associated_data
-      - sediment_data
-      - migs_ba_sediment_data
-      - soil_data
-      - migs_ba_soil_data
-      - symbiont_associated_data
-      - migs_ba_symbiont_associated_data
-      - wastewater_sludge_data
-      - migs_ba_wastewater_sludge_data
-      - water_data
-      - migs_ba_water_data
-      - migs_eu_data
-      - migs_eu_agriculture_data
-      - migs_eu_air_data
-      - migs_eu_built_environment_data
-      - migs_eu_food_animal_and_animal_feed_data
-      - migs_eu_food_farm_environment_data
-      - migs_eu_food_food_production_facility_data
-      - migs_eu_food_human_foods_data
-      - migs_eu_host_associated_data
-      - migs_eu_human_associated_data
-      - migs_eu_human_gut_data
-      - migs_eu_human_oral_data
-      - migs_eu_human_skin_data
-      - migs_eu_human_vaginal_data
-      - migs_eu_hydrocarbon_resources_cores_data
-      - migs_eu_hydrocarbon_resources_fluids_swabs_data
-      - migs_eu_microbial_mat_biofilm_data
-      - migs_eu_miscellaneous_natural_or_artificial_environment_data
-      - migs_eu_plant_associated_data
-      - migs_eu_sediment_data
-      - migs_eu_soil_data
-      - migs_eu_symbiont_associated_data
-      - migs_eu_wastewater_sludge_data
-      - migs_eu_water_data
-      - migs_org_data
-      - migs_org_agriculture_data
-      - migs_org_air_data
-      - migs_org_built_environment_data
-      - migs_org_food_animal_and_animal_feed_data
-      - migs_org_food_farm_environment_data
-      - migs_org_food_food_production_facility_data
-      - migs_org_food_human_foods_data
-      - migs_org_host_associated_data
-      - migs_org_human_associated_data
-      - migs_org_human_gut_data
-      - migs_org_human_oral_data
-      - migs_org_human_skin_data
-      - migs_org_human_vaginal_data
-      - migs_org_hydrocarbon_resources_cores_data
-      - migs_org_hydrocarbon_resources_fluids_swabs_data
-      - migs_org_microbial_mat_biofilm_data
-      - migs_org_miscellaneous_natural_or_artificial_environment_data
-      - migs_org_plant_associated_data
-      - migs_org_sediment_data
-      - migs_org_soil_data
-      - migs_org_symbiont_associated_data
-      - migs_org_wastewater_sludge_data
-      - migs_org_water_data
-      - migs_pl_data
-      - migs_pl_agriculture_data
-      - migs_pl_air_data
-      - migs_pl_built_environment_data
-      - migs_pl_food_animal_and_animal_feed_data
-      - migs_pl_food_farm_environment_data
-      - migs_pl_food_food_production_facility_data
-      - migs_pl_food_human_foods_data
-      - migs_pl_host_associated_data
-      - migs_pl_human_associated_data
-      - migs_pl_human_gut_data
-      - migs_pl_human_oral_data
-      - migs_pl_human_skin_data
-      - migs_pl_human_vaginal_data
-      - migs_pl_hydrocarbon_resources_cores_data
-      - migs_pl_hydrocarbon_resources_fluids_swabs_data
-      - migs_pl_microbial_mat_biofilm_data
-      - migs_pl_miscellaneous_natural_or_artificial_environment_data
-      - migs_pl_plant_associated_data
-      - migs_pl_sediment_data
-      - migs_pl_soil_data
-      - migs_pl_symbiont_associated_data
-      - migs_pl_wastewater_sludge_data
-      - migs_pl_water_data
-      - migs_vi_data
-      - migs_vi_agriculture_data
-      - migs_vi_air_data
-      - migs_vi_built_environment_data
-      - migs_vi_food_animal_and_animal_feed_data
-      - migs_vi_food_farm_environment_data
-      - migs_vi_food_food_production_facility_data
-      - migs_vi_food_human_foods_data
-      - migs_vi_host_associated_data
-      - migs_vi_human_associated_data
-      - migs_vi_human_gut_data
-      - migs_vi_human_oral_data
-      - migs_vi_human_skin_data
-      - migs_vi_human_vaginal_data
-      - migs_vi_hydrocarbon_resources_cores_data
-      - migs_vi_hydrocarbon_resources_fluids_swabs_data
-      - migs_vi_microbial_mat_biofilm_data
-      - migs_vi_miscellaneous_natural_or_artificial_environment_data
-      - migs_vi_plant_associated_data
-      - migs_vi_sediment_data
-      - migs_vi_soil_data
-      - migs_vi_symbiont_associated_data
-      - migs_vi_wastewater_sludge_data
-      - migs_vi_water_data
-      - mimag_data
-      - mimag_agriculture_data
-      - mimag_air_data
-      - mimag_built_environment_data
-      - mimag_food_animal_and_animal_feed_data
-      - mimag_food_farm_environment_data
-      - mimag_food_food_production_facility_data
-      - mimag_food_human_foods_data
-      - mimag_host_associated_data
-      - mimag_human_associated_data
-      - mimag_human_gut_data
-      - mimag_human_oral_data
-      - mimag_human_skin_data
-      - mimag_human_vaginal_data
-      - mimag_hydrocarbon_resources_cores_data
-      - mimag_hydrocarbon_resources_fluids_swabs_data
-      - mimag_microbial_mat_biofilm_data
-      - mimag_miscellaneous_natural_or_artificial_environment_data
-      - mimag_plant_associated_data
-      - mimag_sediment_data
-      - mimag_soil_data
-      - mimag_symbiont_associated_data
-      - mimag_wastewater_sludge_data
-      - mimag_water_data
-      - mimarks_c_data
-      - mimarks_c_agriculture_data
-      - mimarks_c_air_data
-      - mimarks_c_built_environment_data
-      - mimarks_c_food_animal_and_animal_feed_data
-      - mimarks_c_food_farm_environment_data
-      - mimarks_c_food_food_production_facility_data
-      - mimarks_c_food_human_foods_data
-      - mimarks_c_host_associated_data
-      - mimarks_c_human_associated_data
-      - mimarks_c_human_gut_data
-      - mimarks_c_human_oral_data
-      - mimarks_c_human_skin_data
-      - mimarks_c_human_vaginal_data
-      - mimarks_c_hydrocarbon_resources_cores_data
-      - mimarks_c_hydrocarbon_resources_fluids_swabs_data
-      - mimarks_c_microbial_mat_biofilm_data
-      - mimarks_c_miscellaneous_natural_or_artificial_environment_data
-      - mimarks_c_plant_associated_data
-      - mimarks_c_sediment_data
-      - mimarks_c_soil_data
-      - mimarks_c_symbiont_associated_data
-      - mimarks_c_wastewater_sludge_data
-      - mimarks_c_water_data
-      - mimarks_s_data
-      - mimarks_s_agriculture_data
-      - mimarks_s_air_data
-      - mimarks_s_built_environment_data
-      - mimarks_s_food_animal_and_animal_feed_data
-      - mimarks_s_food_farm_environment_data
-      - mimarks_s_food_food_production_facility_data
-      - mimarks_s_food_human_foods_data
-      - mimarks_s_host_associated_data
-      - mimarks_s_human_associated_data
-      - mimarks_s_human_gut_data
-      - mimarks_s_human_oral_data
-      - mimarks_s_human_skin_data
-      - mimarks_s_human_vaginal_data
-      - mimarks_s_hydrocarbon_resources_cores_data
-      - mimarks_s_hydrocarbon_resources_fluids_swabs_data
-      - mimarks_s_microbial_mat_biofilm_data
-      - mimarks_s_miscellaneous_natural_or_artificial_environment_data
-      - mimarks_s_plant_associated_data
-      - mimarks_s_sediment_data
-      - mimarks_s_soil_data
-      - mimarks_s_symbiont_associated_data
-      - mimarks_s_wastewater_sludge_data
-      - mimarks_s_water_data
-      - mims_data
-      - mims_agriculture_data
-      - mims_air_data
-      - mims_built_environment_data
-      - mims_food_animal_and_animal_feed_data
-      - mims_food_farm_environment_data
-      - mims_food_food_production_facility_data
-      - mims_food_human_foods_data
-      - mims_host_associated_data
-      - mims_human_associated_data
-      - mims_human_gut_data
-      - mims_human_oral_data
-      - mims_human_skin_data
-      - mims_human_vaginal_data
-      - mims_hydrocarbon_resources_cores_data
-      - mims_hydrocarbon_resources_fluids_swabs_data
-      - mims_microbial_mat_biofilm_data
-      - mims_miscellaneous_natural_or_artificial_environment_data
-      - mims_plant_associated_data
-      - mims_sediment_data
-      - mims_soil_data
-      - mims_symbiont_associated_data
-      - mims_wastewater_sludge_data
-      - mims_water_data
-      - misag_data
-      - misag_agriculture_data
-      - misag_air_data
-      - misag_built_environment_data
-      - misag_food_animal_and_animal_feed_data
-      - misag_food_farm_environment_data
-      - misag_food_food_production_facility_data
-      - misag_food_human_foods_data
-      - misag_host_associated_data
-      - misag_human_associated_data
-      - misag_human_gut_data
-      - misag_human_oral_data
-      - misag_human_skin_data
-      - misag_human_vaginal_data
-      - misag_hydrocarbon_resources_cores_data
-      - misag_hydrocarbon_resources_fluids_swabs_data
-      - misag_microbial_mat_biofilm_data
-      - misag_miscellaneous_natural_or_artificial_environment_data
-      - misag_plant_associated_data
-      - misag_sediment_data
-      - misag_soil_data
-      - misag_symbiont_associated_data
-      - misag_wastewater_sludge_data
-      - misag_water_data
-      - miuvig_data
-      - miuvig_agriculture_data
-      - miuvig_air_data
-      - miuvig_built_environment_data
-      - miuvig_food_animal_and_animal_feed_data
-      - miuvig_food_farm_environment_data
-      - miuvig_food_food_production_facility_data
-      - miuvig_food_human_foods_data
-      - miuvig_host_associated_data
-      - miuvig_human_associated_data
-      - miuvig_human_gut_data
-      - miuvig_human_oral_data
-      - miuvig_human_skin_data
-      - miuvig_human_vaginal_data
-      - miuvig_hydrocarbon_resources_cores_data
-      - miuvig_hydrocarbon_resources_fluids_swabs_data
-      - miuvig_microbial_mat_biofilm_data
-      - miuvig_miscellaneous_natural_or_artificial_environment_data
-      - miuvig_plant_associated_data
-      - miuvig_sediment_data
-      - miuvig_soil_data
-      - miuvig_symbiont_associated_data
-      - miuvig_wastewater_sludge_data
-      - miuvig_water_data
+    - migs_ba_data
+    - agriculture_data
+    - migs_ba_agriculture_data
+    - air_data
+    - migs_ba_air_data
+    - built_environment_data
+    - migs_ba_built_environment_data
+    - food_animal_and_animal_feed_data
+    - migs_ba_food_animal_and_animal_feed_data
+    - food_farm_environment_data
+    - migs_ba_food_farm_environment_data
+    - food_food_production_facility_data
+    - migs_ba_food_food_production_facility_data
+    - food_human_foods_data
+    - migs_ba_food_human_foods_data
+    - host_associated_data
+    - migs_ba_host_associated_data
+    - human_associated_data
+    - migs_ba_human_associated_data
+    - human_gut_data
+    - migs_ba_human_gut_data
+    - human_oral_data
+    - migs_ba_human_oral_data
+    - human_skin_data
+    - migs_ba_human_skin_data
+    - human_vaginal_data
+    - migs_ba_human_vaginal_data
+    - hydrocarbon_resources_cores_data
+    - migs_ba_hydrocarbon_resources_cores_data
+    - hydrocarbon_resources_fluids_swabs_data
+    - migs_ba_hydrocarbon_resources_fluids_swabs_data
+    - microbial_mat_biofilm_data
+    - migs_ba_microbial_mat_biofilm_data
+    - miscellaneous_natural_or_artificial_environment_data
+    - migs_ba_miscellaneous_natural_or_artificial_environment_data
+    - plant_associated_data
+    - migs_ba_plant_associated_data
+    - sediment_data
+    - migs_ba_sediment_data
+    - soil_data
+    - migs_ba_soil_data
+    - symbiont_associated_data
+    - migs_ba_symbiont_associated_data
+    - wastewater_sludge_data
+    - migs_ba_wastewater_sludge_data
+    - water_data
+    - migs_ba_water_data
+    - migs_eu_data
+    - migs_eu_agriculture_data
+    - migs_eu_air_data
+    - migs_eu_built_environment_data
+    - migs_eu_food_animal_and_animal_feed_data
+    - migs_eu_food_farm_environment_data
+    - migs_eu_food_food_production_facility_data
+    - migs_eu_food_human_foods_data
+    - migs_eu_host_associated_data
+    - migs_eu_human_associated_data
+    - migs_eu_human_gut_data
+    - migs_eu_human_oral_data
+    - migs_eu_human_skin_data
+    - migs_eu_human_vaginal_data
+    - migs_eu_hydrocarbon_resources_cores_data
+    - migs_eu_hydrocarbon_resources_fluids_swabs_data
+    - migs_eu_microbial_mat_biofilm_data
+    - migs_eu_miscellaneous_natural_or_artificial_environment_data
+    - migs_eu_plant_associated_data
+    - migs_eu_sediment_data
+    - migs_eu_soil_data
+    - migs_eu_symbiont_associated_data
+    - migs_eu_wastewater_sludge_data
+    - migs_eu_water_data
+    - migs_org_data
+    - migs_org_agriculture_data
+    - migs_org_air_data
+    - migs_org_built_environment_data
+    - migs_org_food_animal_and_animal_feed_data
+    - migs_org_food_farm_environment_data
+    - migs_org_food_food_production_facility_data
+    - migs_org_food_human_foods_data
+    - migs_org_host_associated_data
+    - migs_org_human_associated_data
+    - migs_org_human_gut_data
+    - migs_org_human_oral_data
+    - migs_org_human_skin_data
+    - migs_org_human_vaginal_data
+    - migs_org_hydrocarbon_resources_cores_data
+    - migs_org_hydrocarbon_resources_fluids_swabs_data
+    - migs_org_microbial_mat_biofilm_data
+    - migs_org_miscellaneous_natural_or_artificial_environment_data
+    - migs_org_plant_associated_data
+    - migs_org_sediment_data
+    - migs_org_soil_data
+    - migs_org_symbiont_associated_data
+    - migs_org_wastewater_sludge_data
+    - migs_org_water_data
+    - migs_pl_data
+    - migs_pl_agriculture_data
+    - migs_pl_air_data
+    - migs_pl_built_environment_data
+    - migs_pl_food_animal_and_animal_feed_data
+    - migs_pl_food_farm_environment_data
+    - migs_pl_food_food_production_facility_data
+    - migs_pl_food_human_foods_data
+    - migs_pl_host_associated_data
+    - migs_pl_human_associated_data
+    - migs_pl_human_gut_data
+    - migs_pl_human_oral_data
+    - migs_pl_human_skin_data
+    - migs_pl_human_vaginal_data
+    - migs_pl_hydrocarbon_resources_cores_data
+    - migs_pl_hydrocarbon_resources_fluids_swabs_data
+    - migs_pl_microbial_mat_biofilm_data
+    - migs_pl_miscellaneous_natural_or_artificial_environment_data
+    - migs_pl_plant_associated_data
+    - migs_pl_sediment_data
+    - migs_pl_soil_data
+    - migs_pl_symbiont_associated_data
+    - migs_pl_wastewater_sludge_data
+    - migs_pl_water_data
+    - migs_vi_data
+    - migs_vi_agriculture_data
+    - migs_vi_air_data
+    - migs_vi_built_environment_data
+    - migs_vi_food_animal_and_animal_feed_data
+    - migs_vi_food_farm_environment_data
+    - migs_vi_food_food_production_facility_data
+    - migs_vi_food_human_foods_data
+    - migs_vi_host_associated_data
+    - migs_vi_human_associated_data
+    - migs_vi_human_gut_data
+    - migs_vi_human_oral_data
+    - migs_vi_human_skin_data
+    - migs_vi_human_vaginal_data
+    - migs_vi_hydrocarbon_resources_cores_data
+    - migs_vi_hydrocarbon_resources_fluids_swabs_data
+    - migs_vi_microbial_mat_biofilm_data
+    - migs_vi_miscellaneous_natural_or_artificial_environment_data
+    - migs_vi_plant_associated_data
+    - migs_vi_sediment_data
+    - migs_vi_soil_data
+    - migs_vi_symbiont_associated_data
+    - migs_vi_wastewater_sludge_data
+    - migs_vi_water_data
+    - mimag_data
+    - mimag_agriculture_data
+    - mimag_air_data
+    - mimag_built_environment_data
+    - mimag_food_animal_and_animal_feed_data
+    - mimag_food_farm_environment_data
+    - mimag_food_food_production_facility_data
+    - mimag_food_human_foods_data
+    - mimag_host_associated_data
+    - mimag_human_associated_data
+    - mimag_human_gut_data
+    - mimag_human_oral_data
+    - mimag_human_skin_data
+    - mimag_human_vaginal_data
+    - mimag_hydrocarbon_resources_cores_data
+    - mimag_hydrocarbon_resources_fluids_swabs_data
+    - mimag_microbial_mat_biofilm_data
+    - mimag_miscellaneous_natural_or_artificial_environment_data
+    - mimag_plant_associated_data
+    - mimag_sediment_data
+    - mimag_soil_data
+    - mimag_symbiont_associated_data
+    - mimag_wastewater_sludge_data
+    - mimag_water_data
+    - mimarks_c_data
+    - mimarks_c_agriculture_data
+    - mimarks_c_air_data
+    - mimarks_c_built_environment_data
+    - mimarks_c_food_animal_and_animal_feed_data
+    - mimarks_c_food_farm_environment_data
+    - mimarks_c_food_food_production_facility_data
+    - mimarks_c_food_human_foods_data
+    - mimarks_c_host_associated_data
+    - mimarks_c_human_associated_data
+    - mimarks_c_human_gut_data
+    - mimarks_c_human_oral_data
+    - mimarks_c_human_skin_data
+    - mimarks_c_human_vaginal_data
+    - mimarks_c_hydrocarbon_resources_cores_data
+    - mimarks_c_hydrocarbon_resources_fluids_swabs_data
+    - mimarks_c_microbial_mat_biofilm_data
+    - mimarks_c_miscellaneous_natural_or_artificial_environment_data
+    - mimarks_c_plant_associated_data
+    - mimarks_c_sediment_data
+    - mimarks_c_soil_data
+    - mimarks_c_symbiont_associated_data
+    - mimarks_c_wastewater_sludge_data
+    - mimarks_c_water_data
+    - mimarks_s_data
+    - mimarks_s_agriculture_data
+    - mimarks_s_air_data
+    - mimarks_s_built_environment_data
+    - mimarks_s_food_animal_and_animal_feed_data
+    - mimarks_s_food_farm_environment_data
+    - mimarks_s_food_food_production_facility_data
+    - mimarks_s_food_human_foods_data
+    - mimarks_s_host_associated_data
+    - mimarks_s_human_associated_data
+    - mimarks_s_human_gut_data
+    - mimarks_s_human_oral_data
+    - mimarks_s_human_skin_data
+    - mimarks_s_human_vaginal_data
+    - mimarks_s_hydrocarbon_resources_cores_data
+    - mimarks_s_hydrocarbon_resources_fluids_swabs_data
+    - mimarks_s_microbial_mat_biofilm_data
+    - mimarks_s_miscellaneous_natural_or_artificial_environment_data
+    - mimarks_s_plant_associated_data
+    - mimarks_s_sediment_data
+    - mimarks_s_soil_data
+    - mimarks_s_symbiont_associated_data
+    - mimarks_s_wastewater_sludge_data
+    - mimarks_s_water_data
+    - mims_data
+    - mims_agriculture_data
+    - mims_air_data
+    - mims_built_environment_data
+    - mims_food_animal_and_animal_feed_data
+    - mims_food_farm_environment_data
+    - mims_food_food_production_facility_data
+    - mims_food_human_foods_data
+    - mims_host_associated_data
+    - mims_human_associated_data
+    - mims_human_gut_data
+    - mims_human_oral_data
+    - mims_human_skin_data
+    - mims_human_vaginal_data
+    - mims_hydrocarbon_resources_cores_data
+    - mims_hydrocarbon_resources_fluids_swabs_data
+    - mims_microbial_mat_biofilm_data
+    - mims_miscellaneous_natural_or_artificial_environment_data
+    - mims_plant_associated_data
+    - mims_sediment_data
+    - mims_soil_data
+    - mims_symbiont_associated_data
+    - mims_wastewater_sludge_data
+    - mims_water_data
+    - misag_data
+    - misag_agriculture_data
+    - misag_air_data
+    - misag_built_environment_data
+    - misag_food_animal_and_animal_feed_data
+    - misag_food_farm_environment_data
+    - misag_food_food_production_facility_data
+    - misag_food_human_foods_data
+    - misag_host_associated_data
+    - misag_human_associated_data
+    - misag_human_gut_data
+    - misag_human_oral_data
+    - misag_human_skin_data
+    - misag_human_vaginal_data
+    - misag_hydrocarbon_resources_cores_data
+    - misag_hydrocarbon_resources_fluids_swabs_data
+    - misag_microbial_mat_biofilm_data
+    - misag_miscellaneous_natural_or_artificial_environment_data
+    - misag_plant_associated_data
+    - misag_sediment_data
+    - misag_soil_data
+    - misag_symbiont_associated_data
+    - misag_wastewater_sludge_data
+    - misag_water_data
+    - miuvig_data
+    - miuvig_agriculture_data
+    - miuvig_air_data
+    - miuvig_built_environment_data
+    - miuvig_food_animal_and_animal_feed_data
+    - miuvig_food_farm_environment_data
+    - miuvig_food_food_production_facility_data
+    - miuvig_food_human_foods_data
+    - miuvig_host_associated_data
+    - miuvig_human_associated_data
+    - miuvig_human_gut_data
+    - miuvig_human_oral_data
+    - miuvig_human_skin_data
+    - miuvig_human_vaginal_data
+    - miuvig_hydrocarbon_resources_cores_data
+    - miuvig_hydrocarbon_resources_fluids_swabs_data
+    - miuvig_microbial_mat_biofilm_data
+    - miuvig_miscellaneous_natural_or_artificial_environment_data
+    - miuvig_plant_associated_data
+    - miuvig_sediment_data
+    - miuvig_soil_data
+    - miuvig_symbiont_associated_data
+    - miuvig_wastewater_sludge_data
+    - miuvig_water_data
     tree_root: true
   MigsBaAgriculture:
     description: MIxS Data that comply with the MigsBa checklist and the Agriculture
       Extension
     title: MigsBa combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016018
   MigsBaAir:
     description: MIxS Data that comply with the MigsBa checklist and the Air Extension
     title: MigsBa combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016000
   MigsBaBuiltEnvironment:
     description: MIxS Data that comply with the MigsBa checklist and the BuiltEnvironment
       Extension
     title: MigsBa combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016001
   MigsBaFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsBa checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsBa combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016019
   MigsBaFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsBa checklist and the FoodFarmEnvironment
       Extension
     title: MigsBa combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016020
   MigsBaFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsBa checklist and the FoodFoodProductionFacility
       Extension
     title: MigsBa combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016021
   MigsBaFoodHumanFoods:
     description: MIxS Data that comply with the MigsBa checklist and the FoodHumanFoods
       Extension
     title: MigsBa combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016022
   MigsBaHostAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the HostAssociated
       Extension
     title: MigsBa combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016002
   MigsBaHumanAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the HumanAssociated
       Extension
     title: MigsBa combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016003
   MigsBaHumanGut:
     description: MIxS Data that comply with the MigsBa checklist and the HumanGut
       Extension
     title: MigsBa combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016004
   MigsBaHumanOral:
     description: MIxS Data that comply with the MigsBa checklist and the HumanOral
       Extension
     title: MigsBa combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016005
   MigsBaHumanSkin:
     description: MIxS Data that comply with the MigsBa checklist and the HumanSkin
       Extension
     title: MigsBa combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016006
   MigsBaHumanVaginal:
     description: MIxS Data that comply with the MigsBa checklist and the HumanVaginal
       Extension
     title: MigsBa combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016007
   MigsBaHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsBa checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsBa combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016015
   MigsBaHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsBa checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsBa combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016016
   MigsBaMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsBa checklist and the MicrobialMatBiofilm
       Extension
     title: MigsBa combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016008
   MigsBaMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsBa checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsBa combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016009
   MigsBaPlantAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the PlantAssociated
       Extension
     title: MigsBa combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016010
   MigsBaSediment:
     description: MIxS Data that comply with the MigsBa checklist and the Sediment
       Extension
     title: MigsBa combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016011
   MigsBaSoil:
     description: MIxS Data that comply with the MigsBa checklist and the Soil Extension
     title: MigsBa combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016012
   MigsBaSymbiontAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the SymbiontAssociated
       Extension
     title: MigsBa combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016023
   MigsBaWastewaterSludge:
     description: MIxS Data that comply with the MigsBa checklist and the WastewaterSludge
       Extension
     title: MigsBa combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016013
   MigsBaWater:
     description: MIxS Data that comply with the MigsBa checklist and the Water Extension
     title: MigsBa combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MigsBa
+    - MigsBa
     class_uri: MIXS:0010003_0016014
   MigsEuAgriculture:
     description: MIxS Data that comply with the MigsEu checklist and the Agriculture
       Extension
     title: MigsEu combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016018
   MigsEuAir:
     description: MIxS Data that comply with the MigsEu checklist and the Air Extension
     title: MigsEu combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016000
   MigsEuBuiltEnvironment:
     description: MIxS Data that comply with the MigsEu checklist and the BuiltEnvironment
       Extension
     title: MigsEu combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016001
   MigsEuFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsEu checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsEu combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016019
   MigsEuFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsEu checklist and the FoodFarmEnvironment
       Extension
     title: MigsEu combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016020
   MigsEuFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsEu checklist and the FoodFoodProductionFacility
       Extension
     title: MigsEu combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016021
   MigsEuFoodHumanFoods:
     description: MIxS Data that comply with the MigsEu checklist and the FoodHumanFoods
       Extension
     title: MigsEu combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016022
   MigsEuHostAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the HostAssociated
       Extension
     title: MigsEu combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016002
   MigsEuHumanAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the HumanAssociated
       Extension
     title: MigsEu combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016003
   MigsEuHumanGut:
     description: MIxS Data that comply with the MigsEu checklist and the HumanGut
       Extension
     title: MigsEu combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016004
   MigsEuHumanOral:
     description: MIxS Data that comply with the MigsEu checklist and the HumanOral
       Extension
     title: MigsEu combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016005
   MigsEuHumanSkin:
     description: MIxS Data that comply with the MigsEu checklist and the HumanSkin
       Extension
     title: MigsEu combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016006
   MigsEuHumanVaginal:
     description: MIxS Data that comply with the MigsEu checklist and the HumanVaginal
       Extension
     title: MigsEu combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016007
   MigsEuHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsEu checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsEu combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016015
   MigsEuHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsEu checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsEu combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016016
   MigsEuMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsEu checklist and the MicrobialMatBiofilm
       Extension
     title: MigsEu combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016008
   MigsEuMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsEu checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsEu combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016009
   MigsEuPlantAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the PlantAssociated
       Extension
     title: MigsEu combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016010
   MigsEuSediment:
     description: MIxS Data that comply with the MigsEu checklist and the Sediment
       Extension
     title: MigsEu combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016011
   MigsEuSoil:
     description: MIxS Data that comply with the MigsEu checklist and the Soil Extension
     title: MigsEu combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016012
   MigsEuSymbiontAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the SymbiontAssociated
       Extension
     title: MigsEu combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016023
   MigsEuWastewaterSludge:
     description: MIxS Data that comply with the MigsEu checklist and the WastewaterSludge
       Extension
     title: MigsEu combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016013
   MigsEuWater:
     description: MIxS Data that comply with the MigsEu checklist and the Water Extension
     title: MigsEu combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MigsEu
+    - MigsEu
     class_uri: MIXS:0010002_0016014
   MigsOrgAgriculture:
     description: MIxS Data that comply with the MigsOrg checklist and the Agriculture
       Extension
     title: MigsOrg combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016018
   MigsOrgAir:
     description: MIxS Data that comply with the MigsOrg checklist and the Air Extension
     title: MigsOrg combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016000
   MigsOrgBuiltEnvironment:
     description: MIxS Data that comply with the MigsOrg checklist and the BuiltEnvironment
       Extension
     title: MigsOrg combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016001
   MigsOrgFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsOrg combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016019
   MigsOrgFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodFarmEnvironment
       Extension
     title: MigsOrg combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016020
   MigsOrgFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodFoodProductionFacility
       Extension
     title: MigsOrg combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016021
   MigsOrgFoodHumanFoods:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodHumanFoods
       Extension
     title: MigsOrg combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016022
   MigsOrgHostAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the HostAssociated
       Extension
     title: MigsOrg combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016002
   MigsOrgHumanAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanAssociated
       Extension
     title: MigsOrg combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016003
   MigsOrgHumanGut:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanGut
       Extension
     title: MigsOrg combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016004
   MigsOrgHumanOral:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanOral
       Extension
     title: MigsOrg combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016005
   MigsOrgHumanSkin:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanSkin
       Extension
     title: MigsOrg combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016006
   MigsOrgHumanVaginal:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanVaginal
       Extension
     title: MigsOrg combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016007
   MigsOrgHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsOrg checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsOrg combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016015
   MigsOrgHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsOrg checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsOrg combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016016
   MigsOrgMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsOrg checklist and the MicrobialMatBiofilm
       Extension
     title: MigsOrg combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016008
   MigsOrgMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsOrg checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsOrg combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016009
   MigsOrgPlantAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the PlantAssociated
       Extension
     title: MigsOrg combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016010
   MigsOrgSediment:
     description: MIxS Data that comply with the MigsOrg checklist and the Sediment
       Extension
     title: MigsOrg combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016011
   MigsOrgSoil:
     description: MIxS Data that comply with the MigsOrg checklist and the Soil Extension
     title: MigsOrg combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016012
   MigsOrgSymbiontAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the SymbiontAssociated
       Extension
     title: MigsOrg combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016023
   MigsOrgWastewaterSludge:
     description: MIxS Data that comply with the MigsOrg checklist and the WastewaterSludge
       Extension
     title: MigsOrg combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016013
   MigsOrgWater:
-    description: MIxS Data that comply with the MigsOrg checklist and the Water
-      Extension
+    description: MIxS Data that comply with the MigsOrg checklist and the Water Extension
     title: MigsOrg combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MigsOrg
+    - MigsOrg
     class_uri: MIXS:0010006_0016014
   MigsPlAgriculture:
     description: MIxS Data that comply with the MigsPl checklist and the Agriculture
       Extension
     title: MigsPl combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016018
   MigsPlAir:
     description: MIxS Data that comply with the MigsPl checklist and the Air Extension
     title: MigsPl combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016000
   MigsPlBuiltEnvironment:
     description: MIxS Data that comply with the MigsPl checklist and the BuiltEnvironment
       Extension
     title: MigsPl combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016001
   MigsPlFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsPl checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsPl combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016019
   MigsPlFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsPl checklist and the FoodFarmEnvironment
       Extension
     title: MigsPl combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016020
   MigsPlFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsPl checklist and the FoodFoodProductionFacility
       Extension
     title: MigsPl combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016021
   MigsPlFoodHumanFoods:
     description: MIxS Data that comply with the MigsPl checklist and the FoodHumanFoods
       Extension
     title: MigsPl combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016022
   MigsPlHostAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the HostAssociated
       Extension
     title: MigsPl combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016002
   MigsPlHumanAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the HumanAssociated
       Extension
     title: MigsPl combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016003
   MigsPlHumanGut:
     description: MIxS Data that comply with the MigsPl checklist and the HumanGut
       Extension
     title: MigsPl combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016004
   MigsPlHumanOral:
     description: MIxS Data that comply with the MigsPl checklist and the HumanOral
       Extension
     title: MigsPl combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016005
   MigsPlHumanSkin:
     description: MIxS Data that comply with the MigsPl checklist and the HumanSkin
       Extension
     title: MigsPl combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016006
   MigsPlHumanVaginal:
     description: MIxS Data that comply with the MigsPl checklist and the HumanVaginal
       Extension
     title: MigsPl combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016007
   MigsPlHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsPl checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsPl combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016015
   MigsPlHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsPl checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsPl combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016016
   MigsPlMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsPl checklist and the MicrobialMatBiofilm
       Extension
     title: MigsPl combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016008
   MigsPlMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsPl checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsPl combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016009
   MigsPlPlantAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the PlantAssociated
       Extension
     title: MigsPl combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016010
   MigsPlSediment:
     description: MIxS Data that comply with the MigsPl checklist and the Sediment
       Extension
     title: MigsPl combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016011
   MigsPlSoil:
     description: MIxS Data that comply with the MigsPl checklist and the Soil Extension
     title: MigsPl combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016012
   MigsPlSymbiontAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the SymbiontAssociated
       Extension
     title: MigsPl combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016023
   MigsPlWastewaterSludge:
     description: MIxS Data that comply with the MigsPl checklist and the WastewaterSludge
       Extension
     title: MigsPl combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016013
   MigsPlWater:
     description: MIxS Data that comply with the MigsPl checklist and the Water Extension
     title: MigsPl combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MigsPl
+    - MigsPl
     class_uri: MIXS:0010004_0016014
   MigsViAgriculture:
     description: MIxS Data that comply with the MigsVi checklist and the Agriculture
       Extension
     title: MigsVi combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016018
   MigsViAir:
     description: MIxS Data that comply with the MigsVi checklist and the Air Extension
     title: MigsVi combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016000
   MigsViBuiltEnvironment:
     description: MIxS Data that comply with the MigsVi checklist and the BuiltEnvironment
       Extension
     title: MigsVi combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016001
   MigsViFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsVi checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsVi combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016019
   MigsViFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsVi checklist and the FoodFarmEnvironment
       Extension
     title: MigsVi combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016020
   MigsViFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsVi checklist and the FoodFoodProductionFacility
       Extension
     title: MigsVi combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016021
   MigsViFoodHumanFoods:
     description: MIxS Data that comply with the MigsVi checklist and the FoodHumanFoods
       Extension
     title: MigsVi combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016022
   MigsViHostAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the HostAssociated
       Extension
     title: MigsVi combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016002
   MigsViHumanAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the HumanAssociated
       Extension
     title: MigsVi combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016003
   MigsViHumanGut:
     description: MIxS Data that comply with the MigsVi checklist and the HumanGut
       Extension
     title: MigsVi combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016004
   MigsViHumanOral:
     description: MIxS Data that comply with the MigsVi checklist and the HumanOral
       Extension
     title: MigsVi combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016005
   MigsViHumanSkin:
     description: MIxS Data that comply with the MigsVi checklist and the HumanSkin
       Extension
     title: MigsVi combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016006
   MigsViHumanVaginal:
     description: MIxS Data that comply with the MigsVi checklist and the HumanVaginal
       Extension
     title: MigsVi combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016007
   MigsViHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsVi checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsVi combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016015
   MigsViHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsVi checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsVi combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016016
   MigsViMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsVi checklist and the MicrobialMatBiofilm
       Extension
     title: MigsVi combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016008
   MigsViMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsVi checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsVi combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016009
   MigsViPlantAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the PlantAssociated
       Extension
     title: MigsVi combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016010
   MigsViSediment:
     description: MIxS Data that comply with the MigsVi checklist and the Sediment
       Extension
     title: MigsVi combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016011
   MigsViSoil:
     description: MIxS Data that comply with the MigsVi checklist and the Soil Extension
     title: MigsVi combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016012
   MigsViSymbiontAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the SymbiontAssociated
       Extension
     title: MigsVi combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016023
   MigsViWastewaterSludge:
     description: MIxS Data that comply with the MigsVi checklist and the WastewaterSludge
       Extension
     title: MigsVi combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016013
   MigsViWater:
     description: MIxS Data that comply with the MigsVi checklist and the Water Extension
     title: MigsVi combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MigsVi
+    - MigsVi
     class_uri: MIXS:0010005_0016014
   MimagAgriculture:
     description: MIxS Data that comply with the Mimag checklist and the Agriculture
       Extension
     title: Mimag combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016018
   MimagAir:
     description: MIxS Data that comply with the Mimag checklist and the Air Extension
     title: Mimag combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016000
   MimagBuiltEnvironment:
     description: MIxS Data that comply with the Mimag checklist and the BuiltEnvironment
       Extension
     title: Mimag combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016001
   MimagFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Mimag checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Mimag combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016019
   MimagFoodFarmEnvironment:
     description: MIxS Data that comply with the Mimag checklist and the FoodFarmEnvironment
       Extension
     title: Mimag combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016020
   MimagFoodFoodProductionFacility:
     description: MIxS Data that comply with the Mimag checklist and the FoodFoodProductionFacility
       Extension
     title: Mimag combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016021
   MimagFoodHumanFoods:
     description: MIxS Data that comply with the Mimag checklist and the FoodHumanFoods
       Extension
     title: Mimag combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016022
   MimagHostAssociated:
     description: MIxS Data that comply with the Mimag checklist and the HostAssociated
       Extension
     title: Mimag combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016002
   MimagHumanAssociated:
     description: MIxS Data that comply with the Mimag checklist and the HumanAssociated
       Extension
     title: Mimag combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016003
   MimagHumanGut:
-    description: MIxS Data that comply with the Mimag checklist and the HumanGut
-      Extension
+    description: MIxS Data that comply with the Mimag checklist and the HumanGut Extension
     title: Mimag combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016004
   MimagHumanOral:
     description: MIxS Data that comply with the Mimag checklist and the HumanOral
       Extension
     title: Mimag combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016005
   MimagHumanSkin:
     description: MIxS Data that comply with the Mimag checklist and the HumanSkin
       Extension
     title: Mimag combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016006
   MimagHumanVaginal:
     description: MIxS Data that comply with the Mimag checklist and the HumanVaginal
       Extension
     title: Mimag combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016007
   MimagHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Mimag checklist and the HydrocarbonResourcesCores
       Extension
     title: Mimag combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016015
   MimagHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Mimag checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Mimag combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016016
   MimagMicrobialMatBiofilm:
     description: MIxS Data that comply with the Mimag checklist and the MicrobialMatBiofilm
       Extension
     title: Mimag combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016008
   MimagMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Mimag checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Mimag combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016009
   MimagPlantAssociated:
     description: MIxS Data that comply with the Mimag checklist and the PlantAssociated
       Extension
     title: Mimag combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016010
   MimagSediment:
-    description: MIxS Data that comply with the Mimag checklist and the Sediment
-      Extension
+    description: MIxS Data that comply with the Mimag checklist and the Sediment Extension
     title: Mimag combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016011
   MimagSoil:
     description: MIxS Data that comply with the Mimag checklist and the Soil Extension
     title: Mimag combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016012
   MimagSymbiontAssociated:
     description: MIxS Data that comply with the Mimag checklist and the SymbiontAssociated
       Extension
     title: Mimag combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016023
   MimagWastewaterSludge:
     description: MIxS Data that comply with the Mimag checklist and the WastewaterSludge
       Extension
     title: Mimag combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016013
   MimagWater:
     description: MIxS Data that comply with the Mimag checklist and the Water Extension
     title: Mimag combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - Mimag
+    - Mimag
     class_uri: MIXS:0010011_0016014
   MimarksCAgriculture:
     description: MIxS Data that comply with the MimarksC checklist and the Agriculture
       Extension
     title: MimarksC combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016018
   MimarksCAir:
     description: MIxS Data that comply with the MimarksC checklist and the Air Extension
     title: MimarksC combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016000
   MimarksCBuiltEnvironment:
     description: MIxS Data that comply with the MimarksC checklist and the BuiltEnvironment
       Extension
     title: MimarksC combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016001
   MimarksCFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MimarksC checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MimarksC combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016019
   MimarksCFoodFarmEnvironment:
     description: MIxS Data that comply with the MimarksC checklist and the FoodFarmEnvironment
       Extension
     title: MimarksC combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016020
   MimarksCFoodFoodProductionFacility:
     description: MIxS Data that comply with the MimarksC checklist and the FoodFoodProductionFacility
       Extension
     title: MimarksC combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016021
   MimarksCFoodHumanFoods:
     description: MIxS Data that comply with the MimarksC checklist and the FoodHumanFoods
       Extension
     title: MimarksC combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016022
   MimarksCHostAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the HostAssociated
       Extension
     title: MimarksC combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016002
   MimarksCHumanAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the HumanAssociated
       Extension
     title: MimarksC combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016003
   MimarksCHumanGut:
     description: MIxS Data that comply with the MimarksC checklist and the HumanGut
       Extension
     title: MimarksC combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016004
   MimarksCHumanOral:
     description: MIxS Data that comply with the MimarksC checklist and the HumanOral
       Extension
     title: MimarksC combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016005
   MimarksCHumanSkin:
     description: MIxS Data that comply with the MimarksC checklist and the HumanSkin
       Extension
     title: MimarksC combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016006
   MimarksCHumanVaginal:
     description: MIxS Data that comply with the MimarksC checklist and the HumanVaginal
       Extension
     title: MimarksC combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016007
   MimarksCHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MimarksC checklist and the HydrocarbonResourcesCores
       Extension
     title: MimarksC combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016015
   MimarksCHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MimarksC checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MimarksC combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016016
   MimarksCMicrobialMatBiofilm:
     description: MIxS Data that comply with the MimarksC checklist and the MicrobialMatBiofilm
       Extension
     title: MimarksC combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016008
   MimarksCMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MimarksC checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MimarksC combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016009
   MimarksCPlantAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the PlantAssociated
       Extension
     title: MimarksC combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016010
   MimarksCSediment:
     description: MIxS Data that comply with the MimarksC checklist and the Sediment
       Extension
     title: MimarksC combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016011
   MimarksCSoil:
-    description: MIxS Data that comply with the MimarksC checklist and the Soil
-      Extension
+    description: MIxS Data that comply with the MimarksC checklist and the Soil Extension
     title: MimarksC combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016012
   MimarksCSymbiontAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the SymbiontAssociated
       Extension
     title: MimarksC combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016023
   MimarksCWastewaterSludge:
     description: MIxS Data that comply with the MimarksC checklist and the WastewaterSludge
       Extension
     title: MimarksC combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016013
   MimarksCWater:
-    description: MIxS Data that comply with the MimarksC checklist and the Water
-      Extension
+    description: MIxS Data that comply with the MimarksC checklist and the Water Extension
     title: MimarksC combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MimarksC
+    - MimarksC
     class_uri: MIXS:0010009_0016014
   MimarksSAgriculture:
     description: MIxS Data that comply with the MimarksS checklist and the Agriculture
       Extension
     title: MimarksS combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016018
   MimarksSAir:
     description: MIxS Data that comply with the MimarksS checklist and the Air Extension
     title: MimarksS combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016000
   MimarksSBuiltEnvironment:
     description: MIxS Data that comply with the MimarksS checklist and the BuiltEnvironment
       Extension
     title: MimarksS combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016001
   MimarksSFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MimarksS checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MimarksS combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016019
   MimarksSFoodFarmEnvironment:
     description: MIxS Data that comply with the MimarksS checklist and the FoodFarmEnvironment
       Extension
     title: MimarksS combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016020
   MimarksSFoodFoodProductionFacility:
     description: MIxS Data that comply with the MimarksS checklist and the FoodFoodProductionFacility
       Extension
     title: MimarksS combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016021
   MimarksSFoodHumanFoods:
     description: MIxS Data that comply with the MimarksS checklist and the FoodHumanFoods
       Extension
     title: MimarksS combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016022
   MimarksSHostAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the HostAssociated
       Extension
     title: MimarksS combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016002
   MimarksSHumanAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the HumanAssociated
       Extension
     title: MimarksS combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016003
   MimarksSHumanGut:
     description: MIxS Data that comply with the MimarksS checklist and the HumanGut
       Extension
     title: MimarksS combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016004
   MimarksSHumanOral:
     description: MIxS Data that comply with the MimarksS checklist and the HumanOral
       Extension
     title: MimarksS combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016005
   MimarksSHumanSkin:
     description: MIxS Data that comply with the MimarksS checklist and the HumanSkin
       Extension
     title: MimarksS combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016006
   MimarksSHumanVaginal:
     description: MIxS Data that comply with the MimarksS checklist and the HumanVaginal
       Extension
     title: MimarksS combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016007
   MimarksSHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MimarksS checklist and the HydrocarbonResourcesCores
       Extension
     title: MimarksS combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016015
   MimarksSHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MimarksS checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MimarksS combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016016
   MimarksSMicrobialMatBiofilm:
     description: MIxS Data that comply with the MimarksS checklist and the MicrobialMatBiofilm
       Extension
     title: MimarksS combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016008
   MimarksSMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MimarksS checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MimarksS combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016009
   MimarksSPlantAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the PlantAssociated
       Extension
     title: MimarksS combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016010
   MimarksSSediment:
     description: MIxS Data that comply with the MimarksS checklist and the Sediment
       Extension
     title: MimarksS combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016011
   MimarksSSoil:
-    description: MIxS Data that comply with the MimarksS checklist and the Soil
-      Extension
+    description: MIxS Data that comply with the MimarksS checklist and the Soil Extension
     title: MimarksS combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016012
   MimarksSSymbiontAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the SymbiontAssociated
       Extension
     title: MimarksS combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016023
   MimarksSWastewaterSludge:
     description: MIxS Data that comply with the MimarksS checklist and the WastewaterSludge
       Extension
     title: MimarksS combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016013
   MimarksSWater:
-    description: MIxS Data that comply with the MimarksS checklist and the Water
-      Extension
+    description: MIxS Data that comply with the MimarksS checklist and the Water Extension
     title: MimarksS combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - MimarksS
+    - MimarksS
     class_uri: MIXS:0010008_0016014
   MimsAgriculture:
     description: MIxS Data that comply with the Mims checklist and the Agriculture
       Extension
     title: Mims combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016018
   MimsAir:
     description: MIxS Data that comply with the Mims checklist and the Air Extension
     title: Mims combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016000
   MimsBuiltEnvironment:
     description: MIxS Data that comply with the Mims checklist and the BuiltEnvironment
       Extension
     title: Mims combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016001
   MimsFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Mims checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Mims combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016019
   MimsFoodFarmEnvironment:
     description: MIxS Data that comply with the Mims checklist and the FoodFarmEnvironment
       Extension
     title: Mims combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016020
   MimsFoodFoodProductionFacility:
     description: MIxS Data that comply with the Mims checklist and the FoodFoodProductionFacility
       Extension
     title: Mims combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016021
   MimsFoodHumanFoods:
     description: MIxS Data that comply with the Mims checklist and the FoodHumanFoods
       Extension
     title: Mims combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016022
   MimsHostAssociated:
     description: MIxS Data that comply with the Mims checklist and the HostAssociated
       Extension
     title: Mims combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016002
   MimsHumanAssociated:
     description: MIxS Data that comply with the Mims checklist and the HumanAssociated
       Extension
     title: Mims combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016003
   MimsHumanGut:
-    description: MIxS Data that comply with the Mims checklist and the HumanGut
-      Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanGut Extension
     title: Mims combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016004
   MimsHumanOral:
-    description: MIxS Data that comply with the Mims checklist and the HumanOral
-      Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanOral Extension
     title: Mims combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016005
   MimsHumanSkin:
-    description: MIxS Data that comply with the Mims checklist and the HumanSkin
-      Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanSkin Extension
     title: Mims combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016006
   MimsHumanVaginal:
     description: MIxS Data that comply with the Mims checklist and the HumanVaginal
       Extension
     title: Mims combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016007
   MimsHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Mims checklist and the HydrocarbonResourcesCores
       Extension
     title: Mims combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016015
   MimsHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Mims checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Mims combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016016
   MimsMicrobialMatBiofilm:
     description: MIxS Data that comply with the Mims checklist and the MicrobialMatBiofilm
       Extension
     title: Mims combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016008
   MimsMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Mims checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Mims combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016009
   MimsPlantAssociated:
     description: MIxS Data that comply with the Mims checklist and the PlantAssociated
       Extension
     title: Mims combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016010
   MimsSediment:
-    description: MIxS Data that comply with the Mims checklist and the Sediment
-      Extension
+    description: MIxS Data that comply with the Mims checklist and the Sediment Extension
     title: Mims combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016011
   MimsSoil:
     description: MIxS Data that comply with the Mims checklist and the Soil Extension
     title: Mims combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016012
   MimsSymbiontAssociated:
     description: MIxS Data that comply with the Mims checklist and the SymbiontAssociated
       Extension
     title: Mims combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016023
   MimsWastewaterSludge:
     description: MIxS Data that comply with the Mims checklist and the WastewaterSludge
       Extension
     title: Mims combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016013
   MimsWater:
     description: MIxS Data that comply with the Mims checklist and the Water Extension
     title: Mims combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - Mims
+    - Mims
     class_uri: MIXS:0010007_0016014
   MisagAgriculture:
     description: MIxS Data that comply with the Misag checklist and the Agriculture
       Extension
     title: Misag combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016018
   MisagAir:
     description: MIxS Data that comply with the Misag checklist and the Air Extension
     title: Misag combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016000
   MisagBuiltEnvironment:
     description: MIxS Data that comply with the Misag checklist and the BuiltEnvironment
       Extension
     title: Misag combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016001
   MisagFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Misag checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Misag combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016019
   MisagFoodFarmEnvironment:
     description: MIxS Data that comply with the Misag checklist and the FoodFarmEnvironment
       Extension
     title: Misag combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016020
   MisagFoodFoodProductionFacility:
     description: MIxS Data that comply with the Misag checklist and the FoodFoodProductionFacility
       Extension
     title: Misag combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016021
   MisagFoodHumanFoods:
     description: MIxS Data that comply with the Misag checklist and the FoodHumanFoods
       Extension
     title: Misag combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016022
   MisagHostAssociated:
     description: MIxS Data that comply with the Misag checklist and the HostAssociated
       Extension
     title: Misag combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016002
   MisagHumanAssociated:
     description: MIxS Data that comply with the Misag checklist and the HumanAssociated
       Extension
     title: Misag combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016003
   MisagHumanGut:
-    description: MIxS Data that comply with the Misag checklist and the HumanGut
-      Extension
+    description: MIxS Data that comply with the Misag checklist and the HumanGut Extension
     title: Misag combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016004
   MisagHumanOral:
     description: MIxS Data that comply with the Misag checklist and the HumanOral
       Extension
     title: Misag combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016005
   MisagHumanSkin:
     description: MIxS Data that comply with the Misag checklist and the HumanSkin
       Extension
     title: Misag combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016006
   MisagHumanVaginal:
     description: MIxS Data that comply with the Misag checklist and the HumanVaginal
       Extension
     title: Misag combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016007
   MisagHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Misag checklist and the HydrocarbonResourcesCores
       Extension
     title: Misag combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016015
   MisagHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Misag checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Misag combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016016
   MisagMicrobialMatBiofilm:
     description: MIxS Data that comply with the Misag checklist and the MicrobialMatBiofilm
       Extension
     title: Misag combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016008
   MisagMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Misag checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Misag combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016009
   MisagPlantAssociated:
     description: MIxS Data that comply with the Misag checklist and the PlantAssociated
       Extension
     title: Misag combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016010
   MisagSediment:
-    description: MIxS Data that comply with the Misag checklist and the Sediment
-      Extension
+    description: MIxS Data that comply with the Misag checklist and the Sediment Extension
     title: Misag combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016011
   MisagSoil:
     description: MIxS Data that comply with the Misag checklist and the Soil Extension
     title: Misag combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016012
   MisagSymbiontAssociated:
     description: MIxS Data that comply with the Misag checklist and the SymbiontAssociated
       Extension
     title: Misag combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016023
   MisagWastewaterSludge:
     description: MIxS Data that comply with the Misag checklist and the WastewaterSludge
       Extension
     title: Misag combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016013
   MisagWater:
     description: MIxS Data that comply with the Misag checklist and the Water Extension
     title: Misag combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - Misag
+    - Misag
     class_uri: MIXS:0010010_0016014
   MiuvigAgriculture:
     description: MIxS Data that comply with the Miuvig checklist and the Agriculture
       Extension
     title: Miuvig combined with Agriculture
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Agriculture
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016018
   MiuvigAir:
     description: MIxS Data that comply with the Miuvig checklist and the Air Extension
     title: Miuvig combined with Air
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Air
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016000
   MiuvigBuiltEnvironment:
     description: MIxS Data that comply with the Miuvig checklist and the BuiltEnvironment
       Extension
     title: Miuvig combined with BuiltEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: BuiltEnvironment
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016001
   MiuvigFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Miuvig checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Miuvig combined with FoodAnimalAndAnimalFeed
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016019
   MiuvigFoodFarmEnvironment:
     description: MIxS Data that comply with the Miuvig checklist and the FoodFarmEnvironment
       Extension
     title: Miuvig combined with FoodFarmEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016020
   MiuvigFoodFoodProductionFacility:
     description: MIxS Data that comply with the Miuvig checklist and the FoodFoodProductionFacility
       Extension
     title: Miuvig combined with FoodFoodProductionFacility
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016021
   MiuvigFoodHumanFoods:
     description: MIxS Data that comply with the Miuvig checklist and the FoodHumanFoods
       Extension
     title: Miuvig combined with FoodHumanFoods
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: FoodHumanFoods
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016022
   MiuvigHostAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the HostAssociated
       Extension
     title: Miuvig combined with HostAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HostAssociated
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016002
   MiuvigHumanAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the HumanAssociated
       Extension
     title: Miuvig combined with HumanAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanAssociated
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016003
   MiuvigHumanGut:
     description: MIxS Data that comply with the Miuvig checklist and the HumanGut
       Extension
     title: Miuvig combined with HumanGut
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanGut
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016004
   MiuvigHumanOral:
     description: MIxS Data that comply with the Miuvig checklist and the HumanOral
       Extension
     title: Miuvig combined with HumanOral
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanOral
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016005
   MiuvigHumanSkin:
     description: MIxS Data that comply with the Miuvig checklist and the HumanSkin
       Extension
     title: Miuvig combined with HumanSkin
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanSkin
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016006
   MiuvigHumanVaginal:
     description: MIxS Data that comply with the Miuvig checklist and the HumanVaginal
       Extension
     title: Miuvig combined with HumanVaginal
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HumanVaginal
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016007
   MiuvigHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Miuvig checklist and the HydrocarbonResourcesCores
       Extension
     title: Miuvig combined with HydrocarbonResourcesCores
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016015
   MiuvigHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Miuvig checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Miuvig combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016016
   MiuvigMicrobialMatBiofilm:
     description: MIxS Data that comply with the Miuvig checklist and the MicrobialMatBiofilm
       Extension
     title: Miuvig combined with MicrobialMatBiofilm
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016008
   MiuvigMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Miuvig checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Miuvig combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016009
   MiuvigPlantAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the PlantAssociated
       Extension
     title: Miuvig combined with PlantAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: PlantAssociated
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016010
   MiuvigSediment:
     description: MIxS Data that comply with the Miuvig checklist and the Sediment
       Extension
     title: Miuvig combined with Sediment
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Sediment
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016011
   MiuvigSoil:
     description: MIxS Data that comply with the Miuvig checklist and the Soil Extension
     title: Miuvig combined with Soil
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Soil
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016012
   MiuvigSymbiontAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the SymbiontAssociated
       Extension
     title: Miuvig combined with SymbiontAssociated
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: SymbiontAssociated
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016023
   MiuvigWastewaterSludge:
     description: MIxS Data that comply with the Miuvig checklist and the WastewaterSludge
       Extension
     title: Miuvig combined with WastewaterSludge
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: WastewaterSludge
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016013
   MiuvigWater:
     description: MIxS Data that comply with the Miuvig checklist and the Water Extension
     title: Miuvig combined with Water
     in_subset:
-      - combination_classes
+    - combination_classes
     is_a: Water
     mixins:
-      - Miuvig
+    - Miuvig
     class_uri: MIXS:0010012_0016014
 settings:
   country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)


### PR DESCRIPTION
passes local `gen-linkml` which suggest the schema is sound

before size ~ 720 kB

after size ~ 690kB

the diff is to large to render in the web interface

note that there are some changes to the indentation level too

to see complete local diff: `git diff c8451c3 52be773 -- src/mixs/schema/mixs.yaml`


