### PR TITLE
Replace `>` with `>-` in Extensions descriptions

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -15945,7 +15945,7 @@ classes:
         recommended: true
     class_uri: MIXS:0010012
   Agriculture:
-    description: >
+    description: >-
       A collection of terms appropriate when sequencing samples obtained in an agricultural environment. 
       Suitable to capture metadata appropriate to enhance crop productivity and agroecosystem health 
       with the aim to facilitate research of agricultural microbiomes and their relationships to plant productivity 
@@ -16363,7 +16363,7 @@ classes:
     annotations:
       use_cases: Agricultural Microbiomes Research Coordination Network, model cropping and plant systems focused on agricultural plant and soil microbe; microbiome studies in agricultural sites; long-term ecological research in croplands; eDNA in manure samples; describing agricultural microbiome studies
   Air:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting and sequencing samples obtained from a gaseous environment.
     title: air
     is_a: Extension
@@ -16423,7 +16423,7 @@ classes:
     annotations:
       use_cases: bioaerosol samples, pathogen load in urban air, aerosols
   BuiltEnvironment:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples obtained in the 
       built-up environment, which includes terms for surface material, humidity, temperature, moisture and 
       occupancy type along with specific metadata terms describing the indoor air, building and sample properties.
@@ -16622,7 +16622,7 @@ classes:
     annotations:
       use_cases: microbiology studies of the built environment, NASA space station sampling, MetaSUB transit system sampling, home, hospitals, office buildings
   FoodAnimalAndAnimalFeed:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from farm animals and their feed.
     comments:
@@ -16772,7 +16772,7 @@ classes:
     annotations:
       use_cases: Microbiome of farm animals, their feed, and pet food.
   FoodFarmEnvironment:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from the farm environment, including soil, manure, and food harvesting equipment.
     comments:
@@ -17002,7 +17002,7 @@ classes:
     annotations:
       use_cases: Microbiome of farm and field crops as well as environmental samples including irrigation, soil amendments, and farm equipment.
   FoodFoodProductionFacility:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from food production facilities.
     comments:
@@ -17162,7 +17162,7 @@ classes:
     annotations:
       use_cases: Microbiome of food production facilities/factories
   FoodHumanFoods:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from human food products.
     comments:
@@ -17312,7 +17312,7 @@ classes:
     annotations:
       use_cases: Microbiome of foods intended for human consumption.
   HostAssociated:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a non-human host, to examine the host-associated microbiome or genome.
     comments:
@@ -17447,7 +17447,7 @@ classes:
     annotations:
       use_cases: elephant fecal matter or cat oral cavity
   HumanAssociated:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a person to examine their human-associated microbiome or genome, 
       that does not have a specific extension (e.g., skin, gut, vaginal).
@@ -17558,7 +17558,7 @@ classes:
     annotations:
       use_cases: blood samples or biopsy samples.
   HumanGut:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a person to examine their gut-associated microbiome.
     title: human-gut
@@ -17650,7 +17650,7 @@ classes:
     annotations:
       use_cases: human stool or fecal samples, or samples collected directly from the gut.
   HumanOral:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a person to examine their oral-associated microbiome.
     title: human-oral
@@ -17742,7 +17742,7 @@ classes:
     annotations:
       use_cases: mouth swab sampling, dental microbiome samples, microbiome of oral swabs, nasal, mouth, throat, teeth, tongue microbiome studies
   HumanSkin:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a person to examine their skin-associated microbiome.
     title: human-skin
@@ -17834,7 +17834,7 @@ classes:
     annotations:
       use_cases: swab samples taken on a person’s skin surface.
   HumanVaginal:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a person to examine their vaginal-associated microbiome.
     title: human-vaginal
@@ -17933,7 +17933,7 @@ classes:
     annotations:
       use_cases: vaginal swabbing
   HydrocarbonResourcesCores:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from environments pertaining to hydrocarbon resources, specifically core samples.
     title: hydrocarbon resources-cores
@@ -18059,7 +18059,7 @@ classes:
     annotations:
       use_cases: The microbial characterization of hydrocarbon occurrences, defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon rich formations, such as reservoir cores.
   HydrocarbonResourcesFluidsSwabs:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from environments pertaining to hydrocarbon resources, specifically run-off liquids samples and swabs.
     title: hydrocarbon resources-fluids/swabs
@@ -18189,7 +18189,7 @@ classes:
     annotations:
       use_cases: The microbial characterization of hydrocarbon occurrences,  defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon resource fluids.
   MicrobialMatBiofilm:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from biofilm environments including microbial mats.
     title: microbial mat/biofilm
@@ -18280,7 +18280,7 @@ classes:
     annotations:
       use_cases: samples from microbial mats at cold seeps
   MiscellaneousNaturalOrArtificialEnvironment:
-    description: >
+    description: >-
       A collection of generic terms appropriate when collecting and sequencing samples 
       obtained from environments, where there is no specific extension already available.
     title: miscellaneous natural or artificial environment
@@ -18348,7 +18348,7 @@ classes:
     aliases:
       - MIxS-miscellaneous natural or artificial environment
   PlantAssociated:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a plant to examine it’s plant-associated microbiome.
     title: plant-associated
@@ -18503,7 +18503,7 @@ classes:
     annotations:
       use_cases: plant surface swabs, root soil or rhizosphere, cultivated plants, plant phenotyping
   Sediment:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from the sedimentary area of aquatic environments.
     comments:
@@ -18602,7 +18602,7 @@ classes:
     annotations:
       use_cases: river bed or sea floor.
   Soil:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from the uppermost layer of Earth's crust, contributed by the Terragenome Consortium.
     see_also:
@@ -18690,7 +18690,7 @@ classes:
     annotations:
       use_cases: soil collection, island microbiome sampling, farm land or forest floor.
   SymbiontAssociated:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from an organism that lives in close association with any other organism(s).
     title: symbiont-associated
@@ -18812,7 +18812,7 @@ classes:
     annotations:
       use_cases: the microbiome sequence of a flea sampled from a farm animal
   WastewaterSludge:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from any solid, semisolid or liquid waste.
     title: wastewater/sludge
@@ -18872,7 +18872,7 @@ classes:
     annotations:
       use_cases: sewerage or industrial wastewater
   Water:
-    description: >
+    description: >-
       A collection of terms appropriate when collecting samples and sequencing water samples 
       obtained from any aquatic environment.
     title: water


### PR DESCRIPTION
The Extensions section of the index page will start to look like this, rather than the view we have now.

<img width="875" alt="Screenshot 2024-03-26 at 11 50 44 AM" src="https://github.com/GenomicsStandardsConsortium/mixs/assets/20239224/d90cedda-f0ec-494f-9aab-e6a3952dcc32">

We are using the "block chomping indicator" (`>-`) to remove the trailing newline that is added when we use the `>` syntax.