### PR TITLE
Reformat term list table to `Title (Name)`

### DIFF
--- a/src/scripts/term_list_generator.py
+++ b/src/scripts/term_list_generator.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         with open(output_file, "w") as md_file:
             md_file.write("# All terms in MIxS schema\n\n")
 
-            md_file.write("| Name | Description |\n")
+            md_file.write("| Title (Name) | Description |\n")
             md_file.write("| --- | --- |\n")
 
             for t in terms:
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
                 description = t.description
                 link = docgen.link(t.name)
-                md_file.write(f"| {link} | {description} |\n")
+                md_file.write(f"| {t.title} ({link}) | {description} |\n")
 
         logger.info(f"Term list table has been written to '{output_file}'.")
     except Exception as e:


### PR DESCRIPTION
https://genomicsstandardsconsortium.github.io/mixs/term_list/ should have two columns - Title (Name) & Description.

See here for how the changes from this PR will affect the documentation: https://sujaypatil96.github.io/mixs/term_list/