### PR TITLE
Add document start to `src/mixs/schema/mixs.yaml`

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -21,9 +21,3 @@ rules:
   # at the end of lines.
   # ideally, we want this to be set to be enabled
   trailing-spaces: disable
-
-  # this rule can be used to require or forbid the use of 
-  # document start marker (---)
-  # OK to have this be disabled
-  document-start:
-    present: false

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -1,3 +1,4 @@
+---
 name: mixs
 description: >-
   This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project


### PR DESCRIPTION
Before this PR the `src/mixs/schema/mixs.yaml` did not have a "document start" (`---`). 

@turbomam and i did a Google search for "YAML document start" and this was the page we found helpful: https://www.yaml.info/learn/document.html

The strictest interpretation of the YAML specification (https://www.yaml.info/learn/document.html) does require one.

In this PR, we added the "document start" and then we were able to remove our customized rule that tolerated the absence of the "document start".