### PR TITLE
correct description of `size_frac_low` and `size_frac_up`

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12181,8 +12181,7 @@ slots:
   size_frac_low:
     annotations:
       Preferred_unit: micrometer
-    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample.
-      Materials larger than the size threshold are excluded from the sample
+    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials smaller than the size threshold are excluded from the sample
     title: size-fraction lower threshold
     examples:
     - value: 0.2 micrometer
@@ -12199,8 +12198,7 @@ slots:
   size_frac_up:
     annotations:
       Preferred_unit: micrometer
-    description: Mesh or pore size of the device used to retain the sample. Materials
-      smaller than the size threshold are excluded from the sample
+    description: Mesh or pore size of the device used to retain the sample. Materials larger than the size threshold are excluded from the sample.
     title: size-fraction upper threshold
     examples:
     - value: 20 micrometer


### PR DESCRIPTION
Closes
https://github.com/GenomicsStandardsConsortium/mixs/issues/566
https://github.com/GenomicsStandardsConsortium/mixs/issues/699 

Change discussed at CIG and TWG.

Based on the issues linked above and feedback from data generators / standard users, this change corrects the description of `siz_frac_low` and `size_frac_up` to reflect what the filter process is doing.
