### PR TITLE
add `soil_conductivity` slot descriptions 

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12287,6 +12287,7 @@ slots:
       interpolated: true
       partial_match: true
   soil_conductivity:
+    description: Soil electrical conductivity (EC) is a measure of how well soil water can carry an electrical current. Electrical conductivity of soil solution is a reliable indicator of its solute (cation or anion) concentration with 1 dS/m approximately equivalent to 10 meq/L (U.S. Salinity Laboratory Staff, 1954).
     annotations:
       Preferred_unit: milliSiemens per centimeter
     title: soil conductivity

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12287,7 +12287,8 @@ slots:
       interpolated: true
       partial_match: true
   soil_conductivity:
-    description: Soil electrical conductivity (EC) is a measure of how well soil water can carry an electrical current. Electrical conductivity of soil solution is a reliable indicator of its solute (cation or anion) concentration with 1 dS/m approximately equivalent to 10 meq/L (U.S. Salinity Laboratory Staff, 1954).
+    description: Conductivity of some soil.
+    comments: Soil electrical conductivity (EC) is a measure of how well soil water can carry an electrical current. Electrical conductivity of soil solution is a reliable indicator of its solute (cation or anion) concentration with 1 dS/m approximately equivalent to 10 meq/L (U.S. Salinity Laboratory Staff, 1954).
     annotations:
       Preferred_unit: milliSiemens per centimeter
     title: soil conductivity
@@ -16314,6 +16315,7 @@ classes:
         recommended: true
       soil_conductivity:
         description: Conductivity of some soil.
+        comments: Soil electrical conductivity (EC) is a measure of how well soil water can carry an electrical current. Electrical conductivity of soil solution is a reliable indicator of its solute (cation or anion) concentration with 1 dS/m approximately equivalent to 10 meq/L (U.S. Salinity Laboratory Staff, 1954).
       soil_cover:
         recommended: true
       soil_horizon:
@@ -16989,6 +16991,7 @@ classes:
         - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       soil_conductivity:
         description: Conductivity of soil at time of sampling.
+        comments: Soil electrical conductivity (EC) is a measure of how well soil water can carry an electrical current. Electrical conductivity of soil solution is a reliable indicator of its solute (cation or anion) concentration with 1 dS/m approximately equivalent to 10 meq/L (U.S. Salinity Laboratory Staff, 1954).
       soil_pH:
         description: The pH of soil at time of sampling.
       soil_type:


### PR DESCRIPTION
https://github.com/GenomicsStandardsConsortium/mixs/issues/813 

Add descriptions for these slots:

- warning Slot 'soil_conductivity' does not have recommended slot 'description' (recommended)

