### PR TITLE
add enums to replace some `string_syntax`es with complex patterns

### DIFF
--- a/src/data/examples/valid/MixsCompliantData-MIMS-HCRFS-example.yaml
+++ b/src/data/examples/valid/MixsCompliantData-MIMS-HCRFS-example.yaml
@@ -1,0 +1,26 @@
+mims_hydrocarbon_resources_fluids_swabs_data:
+  - collection_date: "2013-03-25T12:42:31+01:00"
+    temp: 1.234 units
+    hcr: Coalbed
+    hc_produced: Bitumen
+    basin: term [ONTOLOGY:123]
+    water_cut: 1.234 units
+    iwf: 1.234
+    samp_type: term [ONTOLOGY:123]
+    samp_collect_point: other
+    sulfate: 1.234 units
+    sulfide: 1.234 units
+    nitrate: 1.234 units
+    api: 1.234 - 9.999 units
+    depth: 1.234 units
+    elev: 1.234 units
+    env_broad_scale: term [ONTOLOGY:123]
+    env_local_scale: term [ONTOLOGY:123]
+    env_medium: term [ONTOLOGY:123]
+    geo_loc_name: "text: text, text"
+    lat_lon: 45.1 45.9
+    project_name: absolutely any text
+    samp_name: msd1
+    samp_taxon_id: Gut Metagenome [NCBITaxon:749906]
+    seq_meth: absolutely any text
+    add_recov_method: "Dump Flood;2011-11-11T11:11:11.11Z"

--- a/src/data/examples/valid/MixsCompliantData-MimsSoil-example.yaml
+++ b/src/data/examples/valid/MixsCompliantData-MimsSoil-example.yaml
@@ -11,6 +11,8 @@ mims_soil_data:
     samp_name: msd1
     samp_taxon_id: Gut Metagenome [NCBITaxon:749906]
     seq_meth: absolutely any text
+    agrochem_addition:
+      - roundup;5 milligram per liter;2018-06-21
   - collection_date: "2013-03-25T12:42:31+01:00"
     depth: 1.234 units
     elev: 1.234 units

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -4246,7 +4246,10 @@ slots:
     keywords:
       - animal
       - equipment
-    string_serialization: '{termLabel} [{termID}]'
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0001113
     multivalued: true
   animal_group_size:
@@ -6298,7 +6301,10 @@ slots:
     keywords:
       - context
       - environmental
-    string_serialization: '{termLabel} [{termID}]'
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000013
     required: true
   env_medium:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -3,12 +3,12 @@ name: mixs
 description: >-
   This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project
 comments:
-- 'slot titles that are associated with more than one slot name/SCN: host sex'
+  - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
 version: v6.2.0
 imports:
-- linkml:types
+  - linkml:types
 prefixes:
   linkml: https://w3id.org/linkml/
   MIXS: https://w3id.org/mixs/
@@ -24,6 +24,23 @@ subsets:
   nucleic acid sequence source:
   investigation:
 enums:
+  BiolStatEnum:
+    permissible_values:
+      breeder's line:
+      clonal selection:
+      hybrid:
+      inbred line:
+      mutant:
+      natural:
+      semi-natural:
+      wild:
+  AssemblyQualEnum:
+    permissible_values:
+      Finished genome:
+      High-quality draft genome:
+      Medium-quality draft genome:
+      Low-quality draft genome:
+      Genome fragment(s):
   AeroStrucEnum:
     permissible_values:
       glider:
@@ -1138,7 +1155,7 @@ slots:
     description: Data that comply with Extension Air
     title: Air data
     keywords:
-    - air
+      - air
     domain: MixsCompliantData
     slot_uri: MIXS:air_data
     multivalued: true
@@ -1446,7 +1463,7 @@ slots:
     description: Data that comply with Extension Sediment
     title: Sediment data
     keywords:
-    - sediment
+      - sediment
     domain: MixsCompliantData
     slot_uri: MIXS:sediment_data
     multivalued: true
@@ -1466,7 +1483,7 @@ slots:
     description: Data that comply with Extension Soil
     title: Soil data
     keywords:
-    - soil
+      - soil
     domain: MixsCompliantData
     slot_uri: MIXS:soil_data
     multivalued: true
@@ -1522,7 +1539,7 @@ slots:
     description: Data that comply with Extension Water
     title: Water data
     keywords:
-    - water
+      - water
     domain: MixsCompliantData
     slot_uri: MIXS:water_data
     multivalued: true
@@ -3703,10 +3720,10 @@ slots:
       This field accepts terms listed under HACCP guide food safety term (http://purl.obolibrary.org/obo/FOODON_03530221)
     title: Hazard Analysis Critical Control Points (HACCP) guide food safety term
     examples:
-    - value: tetrodotoxic poisoning [FOODON:03530249]
+      - value: tetrodotoxic poisoning [FOODON:03530249]
     keywords:
-    - food
-    - term
+      - food
+      - term
     slot_uri: MIXS:0001215
     multivalued: true
     range: string
@@ -3732,10 +3749,10 @@ slots:
       PMID: 28926300'
     title: Interagency Food Safety Analytics Collaboration (IFSAC) category
     examples:
-    - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
+      - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
     keywords:
-    - food
-    string_serialization: '{text}'
+      - food
+    range: string
     slot_uri: MIXS:0001179
     multivalued: true
     required: true
@@ -3746,11 +3763,11 @@ slots:
       mixture
     title: absolute air humidity
     examples:
-    - value: 9 gram per gram
+      - value: 9 gram per gram
     keywords:
-    - absolute
-    - air
-    - humidity
+      - absolute
+      - air
+      - humidity
     slot_uri: MIXS:0000122
     range: string
     required: true
@@ -3761,36 +3778,37 @@ slots:
       interpolated: true
       partial_match: true
   adapters:
-    annotations:
-      Expected_value: adapter A and B sequence
     description: Adapters provide priming sequences for both amplification and sequencing
       of the sample-library fragments. Both adapters should be reported; in uppercase
       letters
     title: adapters
     examples:
-    - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
+      - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
     in_subset:
-    - sequencing
-    string_serialization: '{dna};{dna}'
+      - sequencing
+    structured_pattern:
+      syntax: ^{adapter_A_DNA_sequence};{adapter_B_DNA_sequence}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000048
   add_recov_method:
-    annotations:
-      Expected_value: enumeration;timestamp
     description: Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed
       for increase of hydrocarbon recovery from resource and start date for each one
       of them. If "other" is specified, please propose entry in "additional info"
       field
     title: secondary and tertiary recovery methods and start date
     examples:
-    - value: Polymer Addition;2018-06-21T14:30Z
+      - value: Polymer Addition;2018-06-21T14:30Z
     keywords:
-    - date
-    - method
-    - recover
-    - secondary
-    - start
-    string_serialization: '[Water Injection|Dump Flood|Gas Injection|Wag Immiscible
-      Injection|Polymer Addition|Surfactant Addition|Not Applicable|other];{timestamp}'
+      - date
+      - method
+      - recover
+      - secondary
+      - start
+    structured_pattern:
+      syntax: '^({add_recov_methods});{date_time_stamp}$'
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0001009
     required: true
   additional_info:
@@ -3798,23 +3816,24 @@ slots:
       new entries for fields with controlled vocabulary
     title: additional info
     keywords:
-    - information
+      - information
     slot_uri: MIXS:0000300
     range: string
   address:
-    annotations:
-      Expected_value: value
     description: The street name and building number where the sampling occurred
     title: address
-    string_serialization: '{integer}{text}'
+    structured_pattern:
+      syntax: ^{integer} {text}}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000218
   adj_room:
     description: List of rooms (room number, room name) immediately adjacent to the
       sampling room
     title: adjacent rooms
     keywords:
-    - adjacent
-    - room
+      - adjacent
+      - room
     slot_uri: MIXS:0000219
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -3831,11 +3850,11 @@ slots:
       terms can be separated by pipes
     title: environment adjacent to site
     examples:
-    - value: estuarine biome [ENVO:01000020]
+      - value: estuarine biome [ENVO:01000020]
     keywords:
-    - adjacent
-    - environment
-    - site
+      - adjacent
+      - environment
+      - site
     string_serialization: '{termLabel}{[termID]}'
     slot_uri: MIXS:0001121
     multivalued: true
@@ -3845,37 +3864,40 @@ slots:
       such as welds, rivets, screws and bolts to hold the components together
     title: aerospace structure
     examples:
-    - value: plane
+      - value: plane
     slot_uri: MIXS:0000773
     range: AeroStrucEnum
   agrochem_addition:
     annotations:
-      Expected_value: agrochemical name;agrochemical amount;timestamp
       Preferred_unit: gram, mole per liter, milligram per liter
     description: Addition of fertilizers, pesticides, etc. - amount and time of applications
     title: history/agrochemical additions
     examples:
-    - value: roundup;5 milligram per liter;2018-06-21
+      - value: roundup;5 milligram per liter;2018-06-21
     keywords:
-    - history
-    string_serialization: '{text};{float} {unit};{timestamp}'
+      - history
+    structured_pattern:
+      syntax: ^{agrochemical_name};{amount} {unit};{date_time_stamp}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000639
     multivalued: true
   air_PM_concen:
-    annotations:
-      Expected_value: particulate matter name;measurement value
     description: Concentration of substances that remain suspended in the air, and
       comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can
       report multiple PM's by entering numeric values preceded by name of PM
     title: air particulate matter concentration
     examples:
-    - value: PM2.5;10 microgram per cubic meter
+      - value: PM2.5;10 microgram per cubic meter
     keywords:
-    - air
-    - concentration
-    - particle
-    - particulate
-    string_serialization: '{text};{float} {unit}'
+      - air
+      - concentration
+      - particle
+      - particulate
+    structured_pattern:
+      syntax: ^{particulate_matter_name};{float} {unit}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000108
     multivalued: true
   air_flow_impede:
@@ -3885,9 +3907,9 @@ slots:
       flow through the air filter
     title: local air flow impediments
     examples:
-    - value: obstructed;hay bales; 2 m
+      - value: obstructed;hay bales; 2 m
     keywords:
-    - air
+      - air
     string_serialization: '[obstructed|unobstructed]; {text}; {measurement value}'
     slot_uri: MIXS:0001146
     multivalued: true
@@ -3897,8 +3919,8 @@ slots:
     description: Temperature of the air at the time of sampling
     title: air temperature
     keywords:
-    - air
-    - temperature
+      - air
+      - temperature
     slot_uri: MIXS:0000124
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -3917,11 +3939,11 @@ slots:
       time of the entire treatment; can include different temperature regimens
     title: air temperature regimen
     examples:
-    - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - air
-    - regimen
-    - temperature
+      - air
+      - regimen
+      - temperature
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000551
     multivalued: true
@@ -3931,10 +3953,10 @@ slots:
     description: Aluminum saturation (esp. For tropical soils)
     title: extreme_unusual_properties/Al saturation
     keywords:
-    - extreme
-    - properties
-    - saturation
-    - unusual
+      - extreme
+      - properties
+      - saturation
+      - unusual
     slot_uri: MIXS:0000607
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -3947,11 +3969,11 @@ slots:
     description: Reference or method used in determining Al saturation
     title: extreme_unusual_properties/Al saturation method
     keywords:
-    - extreme
-    - method
-    - properties
-    - saturation
-    - unusual
+      - extreme
+      - method
+      - properties
+      - saturation
+      - unusual
     slot_uri: MIXS:0000324
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -3966,9 +3988,9 @@ slots:
       equivalence point of carbonate or bicarbonate
     title: alkalinity
     examples:
-    - value: 50 milligram per liter
+      - value: 50 milligram per liter
     keywords:
-    - alkalinity
+      - alkalinity
     slot_uri: MIXS:0000421
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -3981,17 +4003,17 @@ slots:
     description: Method used for alkalinity measurement
     title: alkalinity method
     examples:
-    - value: titration
+      - value: titration
     keywords:
-    - alkalinity
-    - method
+      - alkalinity
+      - method
     slot_uri: MIXS:0000298
     range: string
   alkyl_diethers:
     description: Concentration of alkyl diethers
     title: alkyl diethers
     examples:
-    - value: 0.005 mole per liter
+      - value: 0.005 mole per liter
     slot_uri: MIXS:0000490
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4010,9 +4032,9 @@ slots:
       earth's surface above sea level and the sampled position in the air
     title: altitude
     examples:
-    - value: 100 meter
+      - value: 100 meter
     in_subset:
-    - environment
+      - environment
     slot_uri: MIXS:0000094
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4027,7 +4049,7 @@ slots:
     description: Measurement of aminopeptidase activity
     title: aminopeptidase activity
     examples:
-    - value: 0.269 mole per liter per hour
+      - value: 0.269 mole per liter per hour
     slot_uri: MIXS:0000172
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4042,7 +4064,7 @@ slots:
     description: Concentration of ammonium in the sample
     title: ammonium
     examples:
-    - value: 1.5 milligram per liter
+      - value: 1.5 milligram per liter
     slot_uri: MIXS:0000427
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4063,7 +4085,7 @@ slots:
       flux per unit area
     title: amount of light
     keywords:
-    - light
+      - light
     slot_uri: MIXS:0000140
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4078,7 +4100,7 @@ slots:
       (meaning [(A x B) x B] x B)
     title: ancestral data
     examples:
-    - value: A/3*B
+      - value: A/3*B
     slot_uri: MIXS:0000247
     range: string
   anim_water_method:
@@ -4087,12 +4109,12 @@ slots:
       Multiple terms can be separated by pipes
     title: animal water delivery method
     examples:
-    - value: water trough [EOL:0001618]
+      - value: water trough [EOL:0001618]
     keywords:
-    - animal
-    - delivery
-    - method
-    - water
+      - animal
+      - delivery
+      - method
+      - water
     slot_uri: MIXS:0001115
     multivalued: true
     range: string
@@ -4106,40 +4128,41 @@ slots:
       food animal within the last 30 days
     title: food animal antimicrobial
     examples:
-    - value: tetracycline
+      - value: tetracycline
     keywords:
-    - animal
-    - antimicrobial
-    - food
+      - animal
+      - antimicrobial
+      - food
     slot_uri: MIXS:0001243
     range: string
   animal_am_dur:
-    annotations:
-      Expected_value: value
     description: The duration of time (days) that the antimicrobial was administered
       to the food animal
     title: food animal antimicrobial duration
     examples:
-    - value: 3 days
+      - value: 3 days
     keywords:
-    - animal
-    - antimicrobial
-    - duration
-    - food
-    - period
-    string_serialization: '{float} {day}'
+      - animal
+      - antimicrobial
+      - duration
+      - food
+      - period
+    structured_pattern:
+      syntax: ^{float} days$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0001244
   animal_am_freq:
-    description: The frequency per day that the antimicrobial was adminstered to the
+    description: The frequency per day that the antimicrobial was administered to the
       food animal
     title: food animal antimicrobial frequency
     examples:
-    - value: '1.5'
+      - value: '1.5'
     keywords:
-    - animal
-    - antimicrobial
-    - food
-    - frequency
+      - animal
+      - antimicrobial
+      - food
+      - frequency
     slot_uri: MIXS:0001245
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4153,13 +4176,13 @@ slots:
       of the food animal
     title: food animal antimicrobial route of administration
     examples:
-    - value: oral-feed
+      - value: oral-feed
     keywords:
-    - administration
-    - animal
-    - antimicrobial
-    - food
-    - route
+      - administration
+      - animal
+      - antimicrobial
+      - food
+      - route
     slot_uri: MIXS:0001246
     range: string
   animal_am_use:
@@ -4167,12 +4190,12 @@ slots:
       given to the food animal by any route of administration
     title: food animal antimicrobial intended use
     examples:
-    - value: shipping fever
+      - value: shipping fever
     keywords:
-    - animal
-    - antimicrobial
-    - food
-    - use
+      - animal
+      - antimicrobial
+      - food
+      - use
     slot_uri: MIXS:0001247
     range: string
   animal_body_cond:
@@ -4181,12 +4204,12 @@ slots:
       scoring systems, this field is restricted to three categories
     title: food animal body condition
     examples:
-    - value: under conditioned
+      - value: under conditioned
     keywords:
-    - animal
-    - body
-    - condition
-    - food
+      - animal
+      - body
+      - condition
+      - food
     slot_uri: MIXS:0001248
     range: AnimalBodyCondEnum
   animal_diet:
@@ -4202,13 +4225,13 @@ slots:
       is not listed please use text to describe the food product type
     title: food animal source diet
     examples:
-    - value: Hay [FOODON:03301763]
+      - value: Hay [FOODON:03301763]
     keywords:
-    - animal
-    - diet
-    - food
-    - source
-    string_serialization: '{text}'
+      - animal
+      - diet
+      - food
+      - source
+    range: string
     slot_uri: MIXS:0001130
     multivalued: true
   animal_feed_equip:
@@ -4219,10 +4242,10 @@ slots:
       Multiple terms can be separated by pipes
     title: animal feeding equipment
     examples:
-    - value: self feeding [EOL:0001645]| straight feed trough [EOL:0001661]
+      - value: self feeding [EOL:0001645]| straight feed trough [EOL:0001661]
     keywords:
-    - animal
-    - equipment
+      - animal
+      - equipment
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001113
     multivalued: true
@@ -4231,11 +4254,11 @@ slots:
       together as a unit, i.e. a herd or flock
     title: food animal group size
     examples:
-    - value: '80'
+      - value: '80'
     keywords:
-    - animal
-    - food
-    - size
+      - animal
+      - food
+      - size
     slot_uri: MIXS:0001129
     range: integer
   animal_housing:
@@ -4243,9 +4266,9 @@ slots:
       terms listed under terrestrial management housing system (http://opendata.inra.fr/EOL/EOL_0001605)
     title: animal housing system
     examples:
-    - value: pen rearing system [EOL:0001636]
+      - value: pen rearing system [EOL:0001636]
     keywords:
-    - animal
+      - animal
     slot_uri: MIXS:0001180
     multivalued: true
     range: string
@@ -4263,11 +4286,11 @@ slots:
       can be separated by pipes
     title: animal intrusion near sample source
     examples:
-    - value: Thripidae [NCBITaxon:45053]
+      - value: Thripidae [NCBITaxon:45053]
     keywords:
-    - animal
-    - sample
-    - source
+      - animal
+      - sample
+      - source
     slot_uri: MIXS:0001114
     multivalued: true
     range: string
@@ -4280,11 +4303,11 @@ slots:
     description: The sex and reproductive status of the food animal
     title: food animal source sex category
     examples:
-    - value: castrated male
+      - value: castrated male
     keywords:
-    - animal
-    - food
-    - source
+      - animal
+      - food
+      - source
     slot_uri: MIXS:0001249
     range: AnimalSexEnum
   annot:
@@ -4295,10 +4318,10 @@ slots:
       submitter
     title: annotation
     examples:
-    - value: prokka
+      - value: prokka
     in_subset:
-    - sequencing
-    string_serialization: '{text}'
+      - sequencing
+    range: string
     slot_uri: MIXS:0000059
   annual_precpt:
     annotations:
@@ -4307,7 +4330,7 @@ slots:
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean annual precipitation
     keywords:
-    - mean
+      - mean
     slot_uri: MIXS:0000644
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4322,10 +4345,10 @@ slots:
     description: Mean annual temperature
     title: mean annual temperature
     examples:
-    - value: 12.5 degree Celsius
+      - value: 12.5 degree Celsius
     keywords:
-    - mean
-    - temperature
+      - mean
+      - temperature
     slot_uri: MIXS:0000642
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4345,9 +4368,9 @@ slots:
       antibiotic regimens
     title: antibiotic regimen
     examples:
-    - value: penicillin;5 milligram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: penicillin;5 milligram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
+      - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000553
     multivalued: true
@@ -4359,7 +4382,7 @@ slots:
       31.1   API)'
     title: API gravity
     examples:
-    - value: 31.1 API
+      - value: 31.1 API
     slot_uri: MIXS:0000157
     range: string
     required: true
@@ -4374,7 +4397,7 @@ slots:
       outdoor construction
     title: architectural structure
     examples:
-    - value: shed
+      - value: shed
     slot_uri: MIXS:0000774
     range: ArchStrucEnum
   area_samp_size:
@@ -4385,11 +4408,11 @@ slots:
       sample collected
     title: area sampled size
     examples:
-    - value: 12 centimeter x 12 centimeter
+      - value: 12 centimeter x 12 centimeter
     keywords:
-    - area
-    - sample
-    - size
+      - area
+      - sample
+      - size
     string_serialization: '{integer} {unit} x {integer} {unit}'
     slot_uri: MIXS:0001255
   aromatics_pc:
@@ -4433,14 +4456,12 @@ slots:
       in the genome browsers and in the community
     title: assembly name
     examples:
-    - value: HuRef, JCVI_ISG_i3_1.0
+      - value: HuRef, JCVI_ISG_i3_1.0
     in_subset:
-    - sequencing
+      - sequencing
     string_serialization: '{text} {text}'
     slot_uri: MIXS:0000057
   assembly_qual:
-    annotations:
-      Expected_value: enumeration
     description: 'The assembly quality category is based on sets of criteria outlined
       for each assembly quality category. For MISAG/MIMAG; Finished: Single, validated,
       contiguous sequence per replicon without gaps or ambiguities with a consensus
@@ -4462,23 +4483,22 @@ slots:
       which no genome size could be estimated'
     title: assembly quality
     examples:
-    - value: High-quality draft genome
+      - value: High-quality draft genome
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - quality
-    string_serialization: '[Finished genome|High-quality draft genome|Medium-quality
-      draft genome|Low-quality draft genome|Genome fragment(s)]'
+      - quality
+    range: AssemblyQualEnum
     slot_uri: MIXS:0000056
   assembly_software:
     description: Tool(s) used for assembly, including version number and parameters
     title: assembly software
     examples:
-    - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
+      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     slot_uri: MIXS:0000058
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -4493,11 +4513,11 @@ slots:
       to the sequence
     title: relevant electronic resources
     examples:
-    - value: http://www.earthmicrobiome.org/
+      - value: http://www.earthmicrobiome.org/
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - resource
+      - resource
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000091
     multivalued: true
@@ -4509,10 +4529,10 @@ slots:
       relevant scale depends on symbiotic organism and study
     title: duration of association with the host
     keywords:
-    - duration
-    - host
-    - host.
-    - period
+      - duration
+      - host
+      - host.
+      - period
     slot_uri: MIXS:0001299
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4527,7 +4547,7 @@ slots:
     description: Measurement of atmospheric data; can include multiple data
     title: atmospheric data
     examples:
-    - value: wind speed;9 knots
+      - value: wind speed;9 knots
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0001097
     multivalued: true
@@ -4538,9 +4558,9 @@ slots:
       hour over a 24 hour period on the sampling day
     title: average dew point
     examples:
-    - value: 25.5 degree Celsius
+      - value: 25.5 degree Celsius
     keywords:
-    - average
+      - average
     slot_uri: MIXS:0000141
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4554,7 +4574,7 @@ slots:
       daily occupying the sampling room
     title: average daily occupancy
     keywords:
-    - average
+      - average
     slot_uri: MIXS:0000775
     range: float
   avg_temp:
@@ -4564,10 +4584,10 @@ slots:
       over a 24 hour period on the sampling day
     title: average temperature
     examples:
-    - value: 12.5 degree Celsius
+      - value: 12.5 degree Celsius
     keywords:
-    - average
-    - temperature
+      - average
+      - temperature
     slot_uri: MIXS:0000142
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4582,9 +4602,9 @@ slots:
     description: Bacterial production in the water column measured by isotope uptake
     title: bacterial production
     examples:
-    - value: 5 milligram per cubic meter per day
+      - value: 5 milligram per cubic meter per day
     keywords:
-    - production
+      - production
     slot_uri: MIXS:0000683
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4599,7 +4619,7 @@ slots:
     description: Measurement of bacterial respiration in the water column
     title: bacterial respiration
     examples:
-    - value: 300 micromole oxygen per liter per hour
+      - value: 300 micromole oxygen per liter per hour
     slot_uri: MIXS:0000684
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4612,10 +4632,10 @@ slots:
     description: Measurement of bacterial carbon production
     title: bacterial carbon production
     examples:
-    - value: 2.53 microgram per liter per hour
+      - value: 2.53 microgram per liter per hour
     keywords:
-    - carbon
-    - production
+      - carbon
+      - production
     slot_uri: MIXS:0000173
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4627,13 +4647,13 @@ slots:
   bacterial_density:
     annotations:
       Preferred_unit: colony forming units per milliliter; colony forming units per gram
-          of dry weight
+        of dry weight
     description: Number of bacteria in sample, as defined by bacteria density (http://purl.obolibrary.org/obo/GENEPIO_0000043)
     title: bacteria density
     examples:
-    - value: 10 colony forming units per gram dry weight
+      - value: 10 colony forming units per gram dry weight
     keywords:
-    - density
+      - density
     slot_uri: MIXS:0001194
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4649,9 +4669,9 @@ slots:
       above that surface
     title: barometric pressure
     examples:
-    - value: 5 millibar
+      - value: 5 millibar
     keywords:
-    - pressure
+      - pressure
     slot_uri: MIXS:0000096
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4664,7 +4684,7 @@ slots:
     description: Name of the basin (e.g. Campos)
     title: basin name
     examples:
-    - value: Campos
+      - value: Campos
     slot_uri: MIXS:0000290
     range: string
     required: true
@@ -4672,18 +4692,18 @@ slots:
     description: The number of bathrooms in the building
     title: bathroom count
     examples:
-    - value: '1'
+      - value: '1'
     keywords:
-    - count
+      - count
     slot_uri: MIXS:0000776
     range: integer
   bedroom_count:
     description: The number of bedrooms in the building
     title: bedroom count
     examples:
-    - value: '2'
+      - value: '2'
     keywords:
-    - count
+      - count
     slot_uri: MIXS:0000777
     range: integer
   benzene:
@@ -4705,14 +4725,14 @@ slots:
       from metagenomic datasets
     title: binning parameters
     examples:
-    - value: coverage
-      description: was 'coverage and kmer'
-    - value: kmer
-      description: was coverage and kmer
+      - value: coverage
+        description: was 'coverage and kmer'
+      - value: kmer
+        description: was coverage and kmer
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - parameter
+      - parameter
     slot_uri: MIXS:0000077
     range: BinParamEnum
   bin_software:
@@ -4722,11 +4742,11 @@ slots:
       where possible include a product ID (PID) of the tool(s) used
     title: binning software
     examples:
-    - value: MetaCluster-TA (RRID:SCR_004599), MaxBin (biotools:maxbin)
+      - value: MetaCluster-TA (RRID:SCR_004599), MaxBin (biotools:maxbin)
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     string_serialization: '{software};{version}{PID}'
     slot_uri: MIXS:0000078
   biochem_oxygen_dem:
@@ -4737,7 +4757,7 @@ slots:
       at certain temperature over a specific time period
     title: biochemical oxygen demand
     keywords:
-    - oxygen
+      - oxygen
     slot_uri: MIXS:0000653
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4753,9 +4773,9 @@ slots:
       of administration
     title: biocide administration
     examples:
-    - value: ALPHA 1427;Baker Hughes;2008-01-23
+      - value: ALPHA 1427;Baker Hughes;2008-01-23
     keywords:
-    - administration
+      - administration
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001011
     recommended: true
@@ -4768,15 +4788,15 @@ slots:
       days)
     title: biocide administration method
     keywords:
-    - administration
-    - method
+      - administration
+      - method
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration}'
     slot_uri: MIXS:0000456
     recommended: true
   biocide_used:
     annotations:
       Expected_value: commercial name of biocide, active ingredient in biocide or class of
-          biocide
+        biocide
     description: Substance intended for preventing, neutralizing, destroying, repelling,
       or mitigating the effects of any pest or microorganism; that inhibits the growth,
       reproduction, and activity of organisms, including fungal cells; decreases the
@@ -4785,21 +4805,18 @@ slots:
       where the sample was taken. Multiple terms can be separated by pipes
     title: biocide
     examples:
-    - value: Quaternary ammonium compound|SterBac
-    string_serialization: '{text}'
+      - value: Quaternary ammonium compound|SterBac
+    range: string
     slot_uri: MIXS:0001258
     multivalued: true
   biol_stat:
-    annotations:
-      Expected_value: enumeration
     description: The level of genome modification
     title: biological status
     examples:
-    - value: natural
+      - value: natural
     keywords:
-    - status
-    string_serialization: '[wild|natural|semi-natural|inbred line|breeder''s line|hybrid|clonal
-      selection|mutant]'
+      - status
+    range: BiolStatEnum
     slot_uri: MIXS:0000858
   biomass:
     annotations:
@@ -4809,9 +4826,9 @@ slots:
       measured, e.g. Microbial, total. Can include multiple measurements
     title: biomass
     examples:
-    - value: total;20 gram
+      - value: total;20 gram
     keywords:
-    - biomass
+      - biomass
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000174
     multivalued: true
@@ -4820,9 +4837,9 @@ slots:
       as bacteria, viruses or fungi
     title: biotic regimen
     examples:
-    - value: sample inoculated with Rhizobium spp. Culture
+      - value: sample inoculated with Rhizobium spp. Culture
     keywords:
-    - regimen
+      - regimen
     slot_uri: MIXS:0001038
     multivalued: true
     range: string
@@ -4833,12 +4850,12 @@ slots:
       organism(s) is the object
     title: observed biotic relationship
     examples:
-    - value: free living
+      - value: free living
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - observed
-    - relationship
+      - observed
+      - relationship
     slot_uri: MIXS:0000028
     range: BioticRelationshipEnum
   birth_control:
@@ -4846,7 +4863,7 @@ slots:
       Expected_value: medication name
     description: Specification of birth control medication used
     title: birth control
-    string_serialization: '{text}'
+    range: string
     slot_uri: MIXS:0000286
   bishomohopanol:
     annotations:
@@ -4854,7 +4871,7 @@ slots:
     description: Concentration of bishomohopanol
     title: bishomohopanol
     examples:
-    - value: 14 microgram per liter
+      - value: 14 microgram per liter
     slot_uri: MIXS:0000175
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4869,7 +4886,7 @@ slots:
       hematopoietic system disease (https://disease-ontology.org/?id=DOID:74)
     title: blood/blood disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000271
     multivalued: true
     range: string
@@ -4879,9 +4896,9 @@ slots:
     description: Resting diastolic blood pressure, measured as mm mercury
     title: host blood pressure diastolic
     keywords:
-    - host
-    - host.
-    - pressure
+      - host
+      - host.
+      - pressure
     slot_uri: MIXS:0000258
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4896,9 +4913,9 @@ slots:
     description: Resting systolic blood pressure, measured as mm mercury
     title: host blood pressure systolic
     keywords:
-    - host
-    - host.
-    - pressure
+      - host
+      - host.
+      - pressure
     slot_uri: MIXS:0000259
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4913,7 +4930,7 @@ slots:
     description: Concentration of bromide
     title: bromide
     examples:
-    - value: 0.05 parts per million
+      - value: 0.05 parts per million
     slot_uri: MIXS:0000176
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4926,9 +4943,9 @@ slots:
     description: The building design, construction and operation documents
     title: design, construction, and operation documents
     examples:
-    - value: maintenance plans
+      - value: maintenance plans
     keywords:
-    - documents
+      - documents
     slot_uri: MIXS:0000787
     range: BuildDocsEnum
   build_occup_type:
@@ -4936,9 +4953,9 @@ slots:
       is intended to be used
     title: building occupancy type
     examples:
-    - value: market
+      - value: market
     keywords:
-    - type
+      - type
     slot_uri: MIXS:0000761
     multivalued: true
     range: BuildOccupTypeEnum
@@ -4947,7 +4964,7 @@ slots:
     description: A location (geography) where a building is set
     title: building setting
     examples:
-    - value: rural
+      - value: rural
     slot_uri: MIXS:0000768
     range: BuildingSettingEnum
     required: true
@@ -4957,9 +4974,9 @@ slots:
     description: The age of the built structure since construction
     title: built structure age
     examples:
-    - value: 15 years
+      - value: 15 years
     keywords:
-    - age
+      - age
     slot_uri: MIXS:0000145
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -4973,7 +4990,7 @@ slots:
       or low human density
     title: built structure setting
     examples:
-    - value: rural
+      - value: rural
     slot_uri: MIXS:0000778
     range: BuiltStrucSetEnum
   built_struc_type:
@@ -4981,7 +4998,7 @@ slots:
       to form a system capable of supporting loads
     title: built structure type
     keywords:
-    - type
+      - type
     slot_uri: MIXS:0000721
     range: string
   calcium:
@@ -4990,7 +5007,7 @@ slots:
     description: Concentration of calcium in the sample
     title: calcium
     examples:
-    - value: 0.2 micromole per liter
+      - value: 0.2 micromole per liter
     slot_uri: MIXS:0000432
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5005,9 +5022,9 @@ slots:
     description: Carbon dioxide (gas) amount or concentration at the time of sampling
     title: carbon dioxide
     examples:
-    - value: 410 parts per million
+      - value: 410 parts per million
     keywords:
-    - carbon
+      - carbon
     slot_uri: MIXS:0000097
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5022,9 +5039,9 @@ slots:
     description: Carbon monoxide (gas) amount or concentration at the time of sampling
     title: carbon monoxide
     examples:
-    - value: 0.1 parts per million
+      - value: 0.1 parts per million
     keywords:
-    - carbon
+      - carbon
     slot_uri: MIXS:0000098
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5039,11 +5056,11 @@ slots:
     description: Ratio of amount or concentrations of carbon to nitrogen
     title: carbon/nitrogen ratio
     examples:
-    - value: '0.417361111'
+      - value: '0.417361111'
     keywords:
-    - carbon
-    - nitrogen
-    - ratio
+      - carbon
+      - nitrogen
+      - ratio
     string_serialization: '{float}:{float}'
     slot_uri: MIXS:0000310
     range: float
@@ -5053,10 +5070,10 @@ slots:
     description: The area of the ceiling space within the room
     title: ceiling area
     examples:
-    - value: 25 square meter
+      - value: 25 square meter
     keywords:
-    - area
-    - ceiling
+      - area
+      - ceiling
     slot_uri: MIXS:0000148
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5070,39 +5087,39 @@ slots:
       or video preferred; use drawings to indicate location of damaged areas
     title: ceiling condition
     examples:
-    - value: damaged
+      - value: damaged
     keywords:
-    - ceiling
-    - condition
+      - ceiling
+      - condition
     slot_uri: MIXS:0000779
     range: DamagedEnum
   ceil_finish_mat:
     description: The type of material used to finish a ceiling
     title: ceiling finish material
     examples:
-    - value: stucco
+      - value: stucco
     keywords:
-    - ceiling
-    - material
+      - ceiling
+      - material
     slot_uri: MIXS:0000780
     range: CeilFinishMatEnum
   ceil_struc:
     description: The construction format of the ceiling
     title: ceiling structure
     examples:
-    - value: concrete
+      - value: concrete
     keywords:
-    - ceiling
+      - ceiling
     slot_uri: MIXS:0000782
     range: CeilStrucEnum
   ceil_texture:
     description: The feel, appearance, or consistency of a ceiling surface
     title: ceiling texture
     examples:
-    - value: popcorn
+      - value: popcorn
     keywords:
-    - ceiling
-    - texture
+      - ceiling
+      - texture
     slot_uri: MIXS:0000783
     range: CeilingWallTextureEnum
   ceil_thermal_mass:
@@ -5114,8 +5131,8 @@ slots:
       air flow
     title: ceiling thermal mass
     keywords:
-    - ceiling
-    - mass
+      - ceiling
+      - mass
     slot_uri: MIXS:0000143
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5128,19 +5145,19 @@ slots:
     description: The type of ceiling according to the ceiling's appearance or construction
     title: ceiling type
     examples:
-    - value: coffered
+      - value: coffered
     keywords:
-    - ceiling
-    - type
+      - ceiling
+      - type
     slot_uri: MIXS:0000784
     range: CeilTypeEnum
   ceil_water_mold:
     description: Signs of the presence of mold or mildew on the ceiling
     title: ceiling signs of water/mold
     examples:
-    - value: presence of mold visible
+      - value: presence of mold visible
     keywords:
-    - ceiling
+      - ceiling
     slot_uri: MIXS:0000781
     range: MoldVisibilityEnum
   chem_administration:
@@ -5152,9 +5169,9 @@ slots:
       (chebi) (v 163), http://purl.bioontology.org/ontology/chebi
     title: chemical administration
     examples:
-    - value: agar [CHEBI:2509];2018-05-11T20:00Z
+      - value: agar [CHEBI:2509];2018-05-11T20:00Z
     keywords:
-    - administration
+      - administration
     string_serialization: '{termLabel} [{termID}];{timestamp}'
     slot_uri: MIXS:0000751
     multivalued: true
@@ -5168,7 +5185,7 @@ slots:
       the entire treatment; can include multiple mutagen regimens
     title: chemical mutagen
     examples:
-    - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000555
     multivalued: true
@@ -5180,7 +5197,7 @@ slots:
       nitrite
     title: chemical oxygen demand
     keywords:
-    - oxygen
+      - oxygen
     slot_uri: MIXS:0000656
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5198,8 +5215,8 @@ slots:
       hr; 0 days)
     title: chemical treatment method
     keywords:
-    - method
-    - treatment
+      - method
+      - treatment
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration};{duration}'
     slot_uri: MIXS:0000457
   chem_treatment:
@@ -5212,9 +5229,9 @@ slots:
       should also be included
     title: chemical treatment
     examples:
-    - value: ACCENT 1125;DOW;2010-11-17
+      - value: ACCENT 1125;DOW;2010-11-17
     keywords:
-    - treatment
+      - treatment
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001012
   chimera_check:
@@ -5223,11 +5240,11 @@ slots:
       of two or more phylogenetically distinct parent sequences
     title: chimera check software
     examples:
-    - value: uchime;v4.1;default parameters
+      - value: uchime;v4.1;default parameters
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     slot_uri: MIXS:0000052
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -5241,7 +5258,7 @@ slots:
     description: Concentration of chloride in the sample
     title: chloride
     examples:
-    - value: 5000 milligram per liter
+      - value: 5000 milligram per liter
     slot_uri: MIXS:0000429
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5256,7 +5273,7 @@ slots:
     description: Concentration of chlorophyll
     title: chlorophyll
     examples:
-    - value: 5 milligram per cubic meter
+      - value: 5 milligram per cubic meter
     slot_uri: MIXS:0000177
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5272,9 +5289,9 @@ slots:
       climates
     title: climate environment
     examples:
-    - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - environment
+      - environment
     slot_uri: MIXS:0001040
     multivalued: true
     range: string
@@ -5289,11 +5306,11 @@ slots:
       or human construction (http://purl.obolibrary.org/obo/ENVO_00000070)'
     title: collection site geographic feature
     examples:
-    - value: farm [ENVO:00000078]
+      - value: farm [ENVO:00000078]
     keywords:
-    - feature
-    - geographic
-    - site
+      - feature
+      - geographic
+      - site
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001183
     required: true
@@ -5304,11 +5321,11 @@ slots:
       2008-01-23; 2008-01; 2008; Except: 2008-01; 2008 all are ISO8601 compliant'
     title: collection date
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     in_subset:
-    - environment
+      - environment
     keywords:
-    - date
+      - date
     slot_uri: MIXS:0000011
     range: datetime
     required: true
@@ -5321,11 +5338,11 @@ slots:
       genome or group used, and contig feature suggesting a complete genome
     title: completeness approach
     examples:
-    - value: other
-      description: was other <colon> UViG length compared to the average length of
-        reference genomes from the P22virus genus (NCBI RefSeq v83)
+      - value: other
+        description: was other <colon> UViG length compared to the average length of
+          reference genomes from the P22virus genus (NCBI RefSeq v83)
     in_subset:
-    - sequencing
+      - sequencing
     slot_uri: MIXS:0000071
     range: ComplApprEnum
   compl_score:
@@ -5338,11 +5355,11 @@ slots:
       completeness scores'
     title: completeness score
     examples:
-    - value: med;60%
+      - value: med;60%
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - score
+      - score
     string_serialization: '[high|med|low];{percentage}'
     slot_uri: MIXS:0000069
   compl_software:
@@ -5351,11 +5368,11 @@ slots:
     description: Tools used for completion estimate, i.e. checkm, anvi'o, busco
     title: completeness software
     examples:
-    - value: checkm
+      - value: checkm
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     string_serialization: '{software};{version}'
     slot_uri: MIXS:0000070
   conduc:
@@ -5364,7 +5381,7 @@ slots:
     description: Electrical conductivity of water
     title: conductivity
     examples:
-    - value: 10 milliSiemens per centimeter
+      - value: 10 milliSiemens per centimeter
     slot_uri: MIXS:0000692
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5381,12 +5398,12 @@ slots:
       ISO 8601 format
     title: food stored by consumer (storage duration)
     examples:
-    - value: P5D
+      - value: P5D
     keywords:
-    - consumer
-    - duration)
-    - food
-    - storage
+      - consumer
+      - duration)
+      - food
+      - storage
     slot_uri: MIXS:0001195
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -5402,30 +5419,30 @@ slots:
       to onset of illness or sample collection
     title: food stored by consumer (storage temperature)
     examples:
-    - value: 4 degree Celsius
+      - value: 4 degree Celsius
     keywords:
-    - consumer
-    - food
-    - storage
-    - temperature
+      - consumer
+      - food
+      - storage
+      - temperature
     string_serialization: '{float} {unit}|{text}'
     slot_uri: MIXS:0001196
   cons_purch_date:
     description: The date a food product was purchased by consumer
     title: purchase date
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     keywords:
-    - date
+      - date
     slot_uri: MIXS:0001197
     range: datetime
   cons_qty_purchased:
     description: The quantity of food purchased by consumer
     title: quantity purchased
     examples:
-    - value: 5 cans
+      - value: 5 cans
     keywords:
-    - quantity
+      - quantity
     slot_uri: MIXS:0001198
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -5441,20 +5458,20 @@ slots:
       deposited into any of the public databases'
     title: contamination score
     examples:
-    - value: '0.01'
+      - value: '0.01'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - score
+      - score
     slot_uri: MIXS:0000072
     range: float
   contam_screen_input:
     description: The type of sequence data used as input
     title: contamination screening input
     examples:
-    - value: contigs
+      - value: contigs
     in_subset:
-    - sequencing
+      - sequencing
     slot_uri: MIXS:0000005
     range: ContamScreenInputEnum
   contam_screen_param:
@@ -5465,20 +5482,20 @@ slots:
       also be used, i.e. kmer and coverage, or reference database and kmer
     title: contamination screening parameters
     examples:
-    - value: kmer
+      - value: kmer
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - parameter
+      - parameter
     string_serialization: '[ref db|kmer|coverage|combination];{text|integer}'
     slot_uri: MIXS:0000073
   cool_syst_id:
     description: The cooling system identifier
     title: cooling system identifier
     examples:
-    - value: '12345'
+      - value: '12345'
     keywords:
-    - identifier
+      - identifier
     slot_uri: MIXS:0000785
     range: integer
   crop_rotation:
@@ -5487,9 +5504,9 @@ slots:
     description: Whether or not crop is rotated, and if yes, rotation schedule
     title: history/crop rotation
     examples:
-    - value: yes;R2/2017-01-01/2018-12-31/P6M
+      - value: yes;R2/2017-01-01/2018-12-31/P6M
     keywords:
-    - history
+      - history
     slot_uri: MIXS:0000318
   crop_yield:
     annotations:
@@ -5497,9 +5514,9 @@ slots:
     description: Amount of crop produced per unit or area of land
     title: crop yield
     examples:
-    - value: 570 kilogram per metre square
+      - value: 570 kilogram per metre square
     keywords:
-    - crop
+      - crop
     slot_uri: MIXS:0001116
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5514,11 +5531,11 @@ slots:
       colony or colonies
     title: culture isolation date
     examples:
-    - value: '2018-05-11T10:00:00+01:00'
+      - value: '2018-05-11T10:00:00+01:00'
     keywords:
-    - culture
-    - date
-    - isolation
+      - culture
+      - date
+      - isolation
     slot_uri: MIXS:0001181
     range: datetime
   cult_result:
@@ -5526,19 +5543,19 @@ slots:
       assessment such as positive/negative, active/inactive
     title: culture result
     examples:
-    - value: positive
+      - value: positive
     keywords:
-    - culture
+      - culture
     slot_uri: MIXS:0001117
     range: CultResultEnum
   cult_result_org:
     description: Taxonomic information about the cultured organism(s)
     title: culture result organism
     examples:
-    - value: Listeria monocytogenes [NCIT:C86502]
+      - value: Listeria monocytogenes [NCIT:C86502]
     keywords:
-    - culture
-    - organism
+      - culture
+      - organism
     slot_uri: MIXS:0001118
     multivalued: true
     range: string
@@ -5556,9 +5573,9 @@ slots:
       published, use the rooting medium descriptors
     title: culture rooting medium
     examples:
-    - value: http://himedialabs.com/TD/PT158.pdf
+      - value: http://himedialabs.com/TD/PT158.pdf
     keywords:
-    - culture
+      - culture
     string_serialization: '{text}|{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0001041
   cult_target:
@@ -5569,11 +5586,11 @@ slots:
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
     title: culture target microbial analyte
     examples:
-    - value: Listeria monocytogenes [NCIT:C86502]
+      - value: Listeria monocytogenes [NCIT:C86502]
     keywords:
-    - culture
-    - microbial
-    - target
+      - culture
+      - microbial
+      - target
     string_serialization: '{termLabel} [{termID}]|{integer}'
     slot_uri: MIXS:0001119
     multivalued: true
@@ -5583,10 +5600,10 @@ slots:
     description: Present state of sample site
     title: current land use
     examples:
-    - value: conifers
+      - value: conifers
     keywords:
-    - land
-    - use
+      - land
+      - use
     string_serialization: '[cities|farmstead|industrial areas|roads/railroads|rock|sand|gravel|mudflats|salt
       flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste areas|small
       grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
@@ -5608,15 +5625,15 @@ slots:
       systems, or agricultural crop
     title: current vegetation
     keywords:
-    - vegetation
-    string_serialization: '{text}'
+      - vegetation
+    range: string
     slot_uri: MIXS:0000312
   cur_vegetation_meth:
     description: Reference or method used in vegetation classification
     title: current vegetation method
     keywords:
-    - method
-    - vegetation
+      - method
+      - vegetation
     slot_uri: MIXS:0000314
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -5629,11 +5646,11 @@ slots:
       Multiple terms can be separated by pipes, listed in reverse chronological order
     title: extreme weather date
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     keywords:
-    - date
-    - extreme
-    - weather
+      - date
+      - extreme
+      - weather
     slot_uri: MIXS:0001142
     multivalued: true
     range: datetime
@@ -5641,10 +5658,10 @@ slots:
     description: The date of the last time it rained
     title: date last rain
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     keywords:
-    - date
-    - rain
+      - date
+      - rain
     slot_uri: MIXS:0000786
     range: datetime
   decontam_software:
@@ -5653,11 +5670,11 @@ slots:
     description: Tool(s) used in contamination screening
     title: decontamination software
     examples:
-    - value: anvi'o
+      - value: anvi'o
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     string_serialization: '[checkm/refinem|anvi''o|prodege|bbtools:decontaminate.sh|acdc|combination]'
     slot_uri: MIXS:0000074
   density:
@@ -5667,9 +5684,9 @@ slots:
       mass density)
     title: density
     examples:
-    - value: 1000 kilogram per cubic meter
+      - value: 1000 kilogram per cubic meter
     keywords:
-    - density
+      - density
     slot_uri: MIXS:0000435
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5683,7 +5700,7 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: depositional environment
     keywords:
-    - environment
+      - environment
     slot_uri: MIXS:0000992
     range: DeposEnvEnum
     recommended: true
@@ -5695,9 +5712,9 @@ slots:
       reported as an interval for subsurface samples
     title: depth
     in_subset:
-    - environment
+      - environment
     keywords:
-    - depth
+      - depth
     slot_uri: MIXS:0000018
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5712,7 +5729,7 @@ slots:
       skin disease (https://disease-ontology.org/?id=DOID:37)
     title: dermatology disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000284
     multivalued: true
     range: string
@@ -5722,11 +5739,11 @@ slots:
     description: Type of UViG detection
     title: detection type
     examples:
-    - value: independent sequence (UViG)
+      - value: independent sequence (UViG)
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - type
+      - type
     string_serialization: '[independent sequence (UViG)|provirus (UpViG)]'
     slot_uri: MIXS:0000084
   dew_point:
@@ -5736,7 +5753,7 @@ slots:
       at constant barometric pressure, for water vapor to condense into water
     title: dew point
     examples:
-    - value: 22 degree Celsius
+      - value: 22 degree Celsius
     slot_uri: MIXS:0000129
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5752,10 +5769,10 @@ slots:
       the change should be specified
     title: major diet change in last six months
     examples:
-    - value: yes;vegetarian diet
+      - value: yes;vegetarian diet
     keywords:
-    - diet
-    - months
+      - diet
+      - months
     string_serialization: '{boolean};{text}'
     slot_uri: MIXS:0000266
   dietary_claim_use:
@@ -5769,10 +5786,10 @@ slots:
       to the most prominent dietary claim or use
     title: dietary claim or use
     examples:
-    - value: No preservatives [FOODON:03510113]
+      - value: No preservatives [FOODON:03510113]
     keywords:
-    - diet
-    - use
+      - diet
+      - use
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001199
     multivalued: true
@@ -5784,7 +5801,7 @@ slots:
       lipids
     title: diether lipids
     examples:
-    - value: 0.2 nanogram per liter
+      - value: 0.2 nanogram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000178
     multivalued: true
@@ -5795,10 +5812,10 @@ slots:
       portion of the sample
     title: dissolved carbon dioxide
     examples:
-    - value: 5 milligram per liter
+      - value: 5 milligram per liter
     keywords:
-    - carbon
-    - dissolved
+      - carbon
+      - dissolved
     slot_uri: MIXS:0000436
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5813,9 +5830,9 @@ slots:
     description: Concentration of dissolved hydrogen
     title: dissolved hydrogen
     examples:
-    - value: 0.3 micromole per liter
+      - value: 0.3 micromole per liter
     keywords:
-    - dissolved
+      - dissolved
     slot_uri: MIXS:0000179
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5831,11 +5848,11 @@ slots:
       measured after filtering the sample using a 0.45 micrometer filter
     title: dissolved inorganic carbon
     examples:
-    - value: 2059 micromole per kilogram
+      - value: 2059 micromole per kilogram
     keywords:
-    - carbon
-    - dissolved
-    - inorganic
+      - carbon
+      - dissolved
+      - inorganic
     slot_uri: MIXS:0000434
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5850,11 +5867,11 @@ slots:
     description: Concentration of dissolved inorganic nitrogen
     title: dissolved inorganic nitrogen
     examples:
-    - value: 761 micromole per liter
+      - value: 761 micromole per liter
     keywords:
-    - dissolved
-    - inorganic
-    - nitrogen
+      - dissolved
+      - inorganic
+      - nitrogen
     slot_uri: MIXS:0000698
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5867,11 +5884,11 @@ slots:
     description: Concentration of dissolved inorganic phosphorus in the sample
     title: dissolved inorganic phosphorus
     examples:
-    - value: 56.5 micromole per liter
+      - value: 56.5 micromole per liter
     keywords:
-    - dissolved
-    - inorganic
-    - phosphorus
+      - dissolved
+      - inorganic
+      - phosphorus
     slot_uri: MIXS:0000106
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5886,7 +5903,7 @@ slots:
     description: Concentration of dissolved iron in the sample
     title: dissolved iron
     keywords:
-    - dissolved
+      - dissolved
     slot_uri: MIXS:0000139
     range: string
     recommended: true
@@ -5903,11 +5920,11 @@ slots:
       of the sample, or aqueous phase of the fluid
     title: dissolved organic carbon
     examples:
-    - value: 197 micromole per liter
+      - value: 197 micromole per liter
     keywords:
-    - carbon
-    - dissolved
-    - organic
+      - carbon
+      - dissolved
+      - organic
     slot_uri: MIXS:0000433
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5921,11 +5938,11 @@ slots:
       nitrogen - NH4 - NO3 - NO2
     title: dissolved organic nitrogen
     examples:
-    - value: 0.05 micromole per liter
+      - value: 0.05 micromole per liter
     keywords:
-    - dissolved
-    - nitrogen
-    - organic
+      - dissolved
+      - nitrogen
+      - organic
     slot_uri: MIXS:0000162
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5940,10 +5957,10 @@ slots:
     description: Concentration of dissolved oxygen
     title: dissolved oxygen
     examples:
-    - value: 175 micromole per kilogram
+      - value: 175 micromole per kilogram
     keywords:
-    - dissolved
-    - oxygen
+      - dissolved
+      - oxygen
     slot_uri: MIXS:0000119
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5959,8 +5976,8 @@ slots:
       as it contributes to oxgen-corrosion and microbial activity (e.g. Mic)
     title: dissolved oxygen in fluids
     keywords:
-    - dissolved
-    - oxygen
+      - dissolved
+      - oxygen
     slot_uri: MIXS:0000438
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -5973,66 +5990,66 @@ slots:
     description: Dominant hand of the subject
     title: dominant hand
     examples:
-    - value: right
+      - value: right
     slot_uri: MIXS:0000944
     range: DominantHandEnum
   door_comp_type:
     description: The composite type of the door
     title: door type, composite
     examples:
-    - value: revolving
+      - value: revolving
     keywords:
-    - door
-    - type
+      - door
+      - type
     slot_uri: MIXS:0000795
     range: DoorCompTypeEnum
   door_cond:
     description: The phsical condition of the door
     title: door condition
     examples:
-    - value: new
+      - value: new
     keywords:
-    - condition
-    - door
+      - condition
+      - door
     slot_uri: MIXS:0000788
     range: DamagedRupturedEnum
   door_direct:
     description: The direction the door opens
     title: door direction of opening
     examples:
-    - value: inward
+      - value: inward
     keywords:
-    - direction
-    - door
+      - direction
+      - door
     slot_uri: MIXS:0000789
     range: DoorDirectEnum
   door_loc:
     description: The relative location of the door in the room
     title: door location
     examples:
-    - value: north
+      - value: north
     keywords:
-    - door
-    - location
+      - door
+      - location
     slot_uri: MIXS:0000790
     range: CompassDirections8Enum
   door_mat:
     description: The material the door is composed of
     title: door material
     examples:
-    - value: wood
+      - value: wood
     keywords:
-    - door
-    - material
+      - door
+      - material
     slot_uri: MIXS:0000791
     range: DoorMatEnum
   door_move:
     description: The type of movement of the door
     title: door movement
     examples:
-    - value: swinging
+      - value: swinging
     keywords:
-    - door
+      - door
     slot_uri: MIXS:0000792
     range: DoorMoveEnum
   door_size:
@@ -6041,11 +6058,11 @@ slots:
     description: The size of the door
     title: door area or size
     examples:
-    - value: 2.5 square meter
+      - value: 2.5 square meter
     keywords:
-    - area
-    - door
-    - size
+      - area
+      - door
+      - size
     slot_uri: MIXS:0000158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6058,20 +6075,20 @@ slots:
     description: The type of door material
     title: door type
     examples:
-    - value: wooden
+      - value: wooden
     keywords:
-    - door
-    - type
+      - door
+      - type
     slot_uri: MIXS:0000794
     range: DoorTypeEnum
   door_type_metal:
     description: The type of metal door
     title: door type, metal
     examples:
-    - value: hollow
+      - value: hollow
     keywords:
-    - door
-    - type
+      - door
+      - type
     slot_uri: MIXS:0000796
     range: DoorTypeMetalEnum
   door_type_wood:
@@ -6080,10 +6097,10 @@ slots:
     description: The type of wood door
     title: door type, wood
     examples:
-    - value: battened
+      - value: battened
     keywords:
-    - door
-    - type
+      - door
+      - type
     string_serialization: '[bettened and ledged|battened|ledged and braced|battened|ledged
       and framed|battened|ledged, braced and frame|framed and paneled|glashed or sash|flush|louvered|wire
       gauged]'
@@ -6092,27 +6109,27 @@ slots:
     description: Signs of the presence of mold or mildew on a door
     title: door signs of water/mold
     examples:
-    - value: presence of mold visible
+      - value: presence of mold visible
     keywords:
-    - door
+      - door
     slot_uri: MIXS:0000793
     range: MoldVisibilityEnum
   douche:
     description: Date of most recent douche
     title: douche
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000967
     range: datetime
   down_par:
     annotations:
       Preferred_unit: microEinstein per square meter per second, microEinstein per square
-          centimeter per second
+        centimeter per second
     description: Visible waveband radiance and irradiance measurements in the water
       column
     title: downward PAR
     examples:
-    - value: 28.71 microEinstein per square meter per second
+      - value: 28.71 microEinstein per square meter per second
     slot_uri: MIXS:0000703
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6125,9 +6142,9 @@ slots:
     description: Drainage classification from a standard system such as the USDA system
     title: drainage classification
     examples:
-    - value: well
+      - value: well
     keywords:
-    - classification
+      - classification
     slot_uri: MIXS:0001085
     range: DrainageClassEnum
   drawings:
@@ -6135,9 +6152,9 @@ slots:
       phase-conceptual, schematic, design development, and construction documents
     title: drawings
     examples:
-    - value: sketch
+      - value: sketch
     keywords:
-    - drawings
+      - drawings
     slot_uri: MIXS:0000798
     range: DrawingsEnum
   drug_usage:
@@ -6147,10 +6164,10 @@ slots:
       multiple drugs used
     title: drug usage
     examples:
-    - value: Lipitor;2/day
+      - value: Lipitor;2/day
     keywords:
-    - drug
-    - use
+      - drug
+      - use
     string_serialization: '{text};{integer}/[year|month|week|day|hour]'
     slot_uri: MIXS:0000894
     multivalued: true
@@ -6160,7 +6177,7 @@ slots:
     description: Percentage of volatile solids removed from the anaerobic digestor
     title: efficiency percent
     keywords:
-    - percent
+      - percent
     slot_uri: MIXS:0000657
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6178,11 +6195,11 @@ slots:
       surface, such as an aircraft in flight or a spacecraft in orbit
     title: elevation
     examples:
-    - value: 100 meter
+      - value: 100 meter
     in_subset:
-    - environment
+      - environment
     keywords:
-    - elevation
+      - elevation
     slot_uri: MIXS:0000093
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6195,9 +6212,9 @@ slots:
     description: The number of elevators within the built structure
     title: elevator count
     examples:
-    - value: '2'
+      - value: '2'
     keywords:
-    - count
+      - count
     slot_uri: MIXS:0000799
     range: integer
   emulsions:
@@ -6218,10 +6235,10 @@ slots:
       degradation phenotypes for plasmids, converting genes for phage
     title: encoded traits
     examples:
-    - value: beta-lactamase class A
+      - value: beta-lactamase class A
     in_subset:
-    - nucleic acid sequence source
-    string_serialization: '{text}'
+      - nucleic acid sequence source
+    range: string
     slot_uri: MIXS:0000034
   enrichment_protocol:
     description: The microbiological workflow or protocol followed to test for the
@@ -6229,10 +6246,10 @@ slots:
       PubMed or DOI reference for published protocols
     title: enrichment protocol
     examples:
-    - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
+      - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
     keywords:
-    - enrichment
-    - protocol
+      - enrichment
+      - protocol
     slot_uri: MIXS:0001177
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -6248,12 +6265,12 @@ slots:
       EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: broad-scale environmental context
     examples:
-    - value: rangeland biome [ENVO:01000247]
+      - value: rangeland biome [ENVO:01000247]
     in_subset:
-    - environment
+      - environment
     keywords:
-    - context
-    - environmental
+      - context
+      - environmental
     slot_uri: MIXS:0000012
     range: string
     required: true
@@ -6265,7 +6282,7 @@ slots:
   env_local_scale:
     annotations:
       Expected_value: Environmental entities having causal influences upon the entity at
-          time of sampling
+        time of sampling
     description: 'Report the entity or entities which are in the sample or specimen
       s local vicinity and which you believe have significant causal influences on
       your sample or specimen. We recommend using EnvO terms which are of smaller
@@ -6275,12 +6292,12 @@ slots:
       field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: local environmental context
     examples:
-    - value: hillside [ENVO:01000333]
+      - value: hillside [ENVO:01000333]
     in_subset:
-    - environment
+      - environment
     keywords:
-    - context
-    - environmental
+      - context
+      - environmental
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000013
     required: true
@@ -6294,11 +6311,11 @@ slots:
       (e.g. a tree, a leaf, a table top)'
     title: environmental medium
     examples:
-    - value: bluegrass field soil [ENVO:00005789]
+      - value: bluegrass field soil [ENVO:00005789]
     in_subset:
-    - environment
+      - environment
     keywords:
-    - environmental
+      - environmental
     slot_uri: MIXS:0000014
     range: string
     required: true
@@ -6319,20 +6336,20 @@ slots:
       taken from
     title: food production environmental monitoring zone
     examples:
-    - value: Zone 1
+      - value: Zone 1
     keywords:
-    - environmental
-    - food
-    - production
-    string_serialization: '{text}'
+      - environmental
+      - food
+      - production
+    range: string
     slot_uri: MIXS:0001254
   escalator:
     description: The number of escalators within the built structure
     title: escalator count
     examples:
-    - value: '4'
+      - value: '4'
     keywords:
-    - count
+      - count
     slot_uri: MIXS:0000800
     range: integer
   estimated_size:
@@ -6343,11 +6360,11 @@ slots:
       form for a long or unspecified period
     title: estimated size
     examples:
-    - value: 300000 bp
+      - value: 300000 bp
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - size
+      - size
     string_serialization: '{integer} bp'
     slot_uri: MIXS:0000024
   ethnicity:
@@ -6358,8 +6375,8 @@ slots:
       society, culture, nation or social treatment within their residing area. https://en.wikipedia.org/wiki/List_of_contemporary_ethnic_groups
     title: ethnicity
     examples:
-    - value: native american
-    string_serialization: '{text}'
+      - value: native american
+    range: string
     slot_uri: MIXS:0000895
     multivalued: true
   ethylbenzene:
@@ -6393,7 +6410,7 @@ slots:
     description: The number of exposed pipes in the room
     title: exposed pipes
     keywords:
-    - pipes
+      - pipes
     slot_uri: MIXS:0000220
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -6410,12 +6427,12 @@ slots:
       Ontology for Biomedical Investigations (OBI)
     title: experimental factor
     examples:
-    - value: time series design [EFO:0001779]
+      - value: time series design [EFO:0001779]
     in_subset:
-    - investigation
+      - investigation
     keywords:
-    - experimental
-    - factor
+      - experimental
+      - factor
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000008
     multivalued: true
@@ -6425,29 +6442,29 @@ slots:
     description: The number of exterior doors in the built structure
     title: exterior door count
     keywords:
-    - count
-    - door
-    - exterior
+      - count
+      - door
+      - exterior
     slot_uri: MIXS:0000170
     range: integer
   ext_wall_orient:
     description: The orientation of the exterior wall
     title: orientations of exterior wall
     examples:
-    - value: northwest
+      - value: northwest
     keywords:
-    - exterior
-    - wall
+      - exterior
+      - wall
     slot_uri: MIXS:0000817
     range: CompassDirections8Enum
   ext_window_orient:
     description: The compass direction the exterior window of the room is facing
     title: orientations of exterior window
     examples:
-    - value: southwest
+      - value: southwest
     keywords:
-    - exterior
-    - window
+      - exterior
+      - window
     slot_uri: MIXS:0000818
     range: CompassDirections8Enum
   extr_weather_event:
@@ -6455,11 +6472,11 @@ slots:
       Multiple terms can be separated by pipes, listed in reverse chronological order
     title: extreme weather event
     examples:
-    - value: hail
+      - value: hail
     keywords:
-    - event
-    - extreme
-    - weather
+      - event
+      - extreme
+      - weather
     slot_uri: MIXS:0001141
     multivalued: true
     range: ExtrWeatherEventEnum
@@ -6469,17 +6486,17 @@ slots:
       (borrelia has 15+ plasmids)
     title: extrachromosomal elements
     examples:
-    - value: '5'
+      - value: '5'
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     slot_uri: MIXS:0000023
     range: integer
   extreme_event:
     description: Unusual physical events that may have affected microbial populations
     title: history/extreme events
     keywords:
-    - event
-    - history
+      - event
+      - history
     slot_uri: MIXS:0000320
     range: datetime
   facility_type:
@@ -6487,10 +6504,10 @@ slots:
       was taken. This is independent of the specific product(s) within the facility
     title: facility type
     examples:
-    - value: manufacturing-processing
+      - value: manufacturing-processing
     keywords:
-    - facility
-    - type
+      - facility
+      - type
     slot_uri: MIXS:0001252
     multivalued: true
     range: FacilityTypeEnum
@@ -6499,9 +6516,9 @@ slots:
       Resources. The list can be found at http://www.fao.org/nr/land/sols/soil/wrb-soil-maps/reference-groups
     title: soil_taxonomic/FAO classification
     examples:
-    - value: Luvisols
+      - value: Luvisols
     keywords:
-    - classification
+      - classification
     slot_uri: MIXS:0001083
     range: FaoClassEnum
   farm_equip:
@@ -6511,11 +6528,11 @@ slots:
       Multiple terms can be separated by pipes
     title: farm equipment used
     examples:
-    - value: combine harvester [AGRO:00000473]
+      - value: combine harvester [AGRO:00000473]
     keywords:
-    - equipment
-    - farm
-    - use
+      - equipment
+      - farm
+      - use
     slot_uri: MIXS:0001126
     multivalued: true
     range: string
@@ -6527,17 +6544,17 @@ slots:
   farm_equip_san:
     annotations:
       Expected_value: text or commercial name of sanitizer or class of sanitizer or active
-          ingredient in sanitizer
+        ingredient in sanitizer
       Preferred_unit: parts per million
     description: Method used to sanitize growing and harvesting equipment. This can
       including type and concentration of sanitizing solution.  Multiple terms can
       be separated by one or more pipes
     title: farm equipment sanitization
     examples:
-    - value: hot water pressure wash, hypochlorite solution, 50 parts per million
+      - value: hot water pressure wash, hypochlorite solution, 50 parts per million
     keywords:
-    - equipment
-    - farm
+      - equipment
+      - farm
     string_serialization: '{text} {float} {unit}'
     slot_uri: MIXS:0001124
     multivalued: true
@@ -6546,11 +6563,11 @@ slots:
       might be on a Daily basis, Weekly, Monthly, Quarterly or Annually
     title: farm equipment sanitization frequency
     examples:
-    - value: Biweekly
+      - value: Biweekly
     keywords:
-    - equipment
-    - farm
-    - frequency
+      - equipment
+      - farm
+      - frequency
     slot_uri: MIXS:0001125
     range: string
   farm_equip_shared:
@@ -6559,10 +6576,10 @@ slots:
       Multiple terms can be separated by pipes
     title: equipment shared with other farms
     examples:
-    - value: combine harvester [AGRO:00000473]
+      - value: combine harvester [AGRO:00000473]
     keywords:
-    - equipment
-    - farm
+      - equipment
+      - farm
     slot_uri: MIXS:0001123
     multivalued: true
     range: string
@@ -6576,12 +6593,12 @@ slots:
       of livestock
     title: farm watering water source
     examples:
-    - value: well
-      description: was water well (ENVO:01000002)
+      - value: well
+        description: was water well (ENVO:01000002)
     keywords:
-    - farm
-    - source
-    - water
+      - farm
+      - source
+      - water
     slot_uri: MIXS:0001110
     range: FarmWaterSourceEnum
     recommended: true
@@ -6590,12 +6607,12 @@ slots:
       etc
     title: feature prediction
     examples:
-    - value: Prodigal;2.6.3;default parameters
+      - value: Prodigal;2.6.3;default parameters
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - feature
-    - predict
+      - feature
+      - predict
     slot_uri: MIXS:0000061
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -6610,9 +6627,9 @@ slots:
       the desired final product
     title: fermentation chemical additives
     examples:
-    - value: salt
+      - value: salt
     keywords:
-    - fermentation
+      - fermentation
     string_serialization: '{float} {unit}'
     slot_uri: MIXS:0001185
     multivalued: true
@@ -6623,10 +6640,10 @@ slots:
     description: The amount of chemical added to the fermentation process
     title: fermentation chemical additives percentage
     examples:
-    - value: '0.01'
+      - value: '0.01'
     keywords:
-    - fermentation
-    - percent
+      - fermentation
+      - percent
     slot_uri: MIXS:0001186
     multivalued: true
     range: float
@@ -6637,10 +6654,10 @@ slots:
     description: The amount of headspace oxygen in a fermentation vessel
     title: fermentation headspace oxygen
     examples:
-    - value: '0.05'
+      - value: '0.05'
     keywords:
-    - fermentation
-    - oxygen
+      - fermentation
+      - oxygen
     slot_uri: MIXS:0001187
     range: float
     recommended: true
@@ -6650,9 +6667,9 @@ slots:
       source, water, micronutrients and chemical additives
     title: fermentation medium
     examples:
-    - value: molasses
+      - value: molasses
     keywords:
-    - fermentation
+      - fermentation
     slot_uri: MIXS:0001188
     range: string
     recommended: true
@@ -6660,10 +6677,10 @@ slots:
     description: The pH of the fermented food fermentation process
     title: fermentation pH
     examples:
-    - value: '4.5'
+      - value: '4.5'
     keywords:
-    - fermentation
-    - ph
+      - fermentation
+      - ph
     slot_uri: MIXS:0001189
     range: float
     recommended: true
@@ -6673,13 +6690,13 @@ slots:
     description: The relative humidity of the fermented food fermentation process
     title: fermentation relative humidity
     comments:
-    - percent or float?
+      - percent or float?
     examples:
-    - value: 95%
+      - value: 95%
     keywords:
-    - fermentation
-    - humidity
-    - relative
+      - fermentation
+      - humidity
+      - relative
     slot_uri: MIXS:0001190
     range: string
     recommended: true
@@ -6695,10 +6712,10 @@ slots:
     description: The temperature of the fermented food fermentation process
     title: fermentation temperature
     examples:
-    - value: 22 degrees Celsius
+      - value: 22 degrees Celsius
     keywords:
-    - fermentation
-    - temperature
+      - fermentation
+      - temperature
     slot_uri: MIXS:0001191
     range: string
     recommended: true
@@ -6714,10 +6731,10 @@ slots:
     description: The time duration of the fermented food fermentation process
     title: fermentation time
     examples:
-    - value: P10D
+      - value: P10D
     keywords:
-    - fermentation
-    - time
+      - fermentation
+      - time
     slot_uri: MIXS:0001192
     range: string
     recommended: true
@@ -6730,9 +6747,9 @@ slots:
     description: The type of vessel used for containment of the fermentation
     title: fermentation vessel
     examples:
-    - value: steel drum
+      - value: steel drum
     keywords:
-    - fermentation
+      - fermentation
     slot_uri: MIXS:0001193
     range: string
     recommended: true
@@ -6744,9 +6761,9 @@ slots:
       order
     title: fertilizer administration
     examples:
-    - value: fish emulsion [AGRO:00000082]
+      - value: fish emulsion [AGRO:00000082]
     keywords:
-    - administration
+      - administration
     slot_uri: MIXS:0001127
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -6760,10 +6777,10 @@ slots:
       order
     title: fertilizer administration date
     examples:
-    - value: '2018-05-11T10:00:00+01:00'
+      - value: '2018-05-11T10:00:00+01:00'
     keywords:
-    - administration
-    - date
+      - administration
+      - date
     slot_uri: MIXS:0001128
     range: datetime
   fertilizer_regm:
@@ -6777,9 +6794,9 @@ slots:
       regimens
     title: fertilizer regimen
     examples:
-    - value: urea;0.6 milligram per liter;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
+      - value: urea;0.6 milligram per liter;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
+      - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000556
     multivalued: true
@@ -6793,10 +6810,10 @@ slots:
     description: A device which removes solid particulates or airborne molecular contaminants
     title: filter type
     examples:
-    - value: HEPA
+      - value: HEPA
     keywords:
-    - filter
-    - type
+      - filter
+      - type
     slot_uri: MIXS:0000765
     multivalued: true
     range: FilterTypeEnum
@@ -6805,23 +6822,23 @@ slots:
     description: Historical and/or physical evidence of fire
     title: history/fire
     keywords:
-    - history
+      - history
     slot_uri: MIXS:0001086
     range: datetime
   fireplace_type:
     description: A firebox with chimney
     title: fireplace type
     examples:
-    - value: wood burning
+      - value: wood burning
     keywords:
-    - type
+      - type
     slot_uri: MIXS:0000802
     range: FireplaceTypeEnum
   flooding:
     description: Historical and/or physical evidence of flooding
     title: history/flooding
     keywords:
-    - history
+      - history
     slot_uri: MIXS:0000319
     range: datetime
   floor_age:
@@ -6830,8 +6847,8 @@ slots:
     description: The time period since installment of the carpet or flooring
     title: floor age
     keywords:
-    - age
-    - floor
+      - age
+      - floor
     slot_uri: MIXS:0000164
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6846,8 +6863,8 @@ slots:
     description: The area of the floor space within the room
     title: floor area
     keywords:
-    - area
-    - floor
+      - area
+      - floor
     slot_uri: MIXS:0000165
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6861,10 +6878,10 @@ slots:
       or video preferred; use drawings to indicate location of damaged areas
     title: floor condition
     examples:
-    - value: new
+      - value: new
     keywords:
-    - condition
-    - floor
+      - condition
+      - floor
     slot_uri: MIXS:0000803
     range: DamagedEnum
   floor_count:
@@ -6872,8 +6889,8 @@ slots:
       penthouse
     title: floor count
     keywords:
-    - count
-    - floor
+      - count
+      - floor
     slot_uri: MIXS:0000225
     range: integer
   floor_finish_mat:
@@ -6882,10 +6899,10 @@ slots:
     description: The floor covering type; the finished surface that is walked on
     title: floor finish material
     examples:
-    - value: carpet
+      - value: carpet
     keywords:
-    - floor
-    - material
+      - floor
+      - material
     string_serialization: '[tile|wood strip or parquet|carpet|rug|laminate wood|lineoleum|vinyl
       composition tile|sheet vinyl|stone|bamboo|cork|terrazo|concrete|none;specify
       unfinished|sealed|clear finish|paint]'
@@ -6895,9 +6912,9 @@ slots:
       flooring is installed
     title: floor structure
     examples:
-    - value: concrete
+      - value: concrete
     keywords:
-    - floor
+      - floor
     slot_uri: MIXS:0000806
     range: FloorStrucEnum
   floor_thermal_mass:
@@ -6906,8 +6923,8 @@ slots:
     description: The ability of the floor to provide inertia against temperature fluctuations
     title: floor thermal mass
     keywords:
-    - floor
-    - mass
+      - floor
+      - mass
     slot_uri: MIXS:0000166
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6920,9 +6937,9 @@ slots:
     description: Signs of the presence of mold or mildew in a room
     title: floor signs of water/mold
     examples:
-    - value: ceiling discoloration
+      - value: ceiling discoloration
     keywords:
-    - floor
+      - floor
     slot_uri: MIXS:0000805
     range: FloorWaterMoldEnum
   fluor:
@@ -6931,7 +6948,7 @@ slots:
     description: Raw or converted fluorescence of water
     title: fluorescence
     examples:
-    - value: 2.5 volts
+      - value: 2.5 volts
     slot_uri: MIXS:0000704
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -6944,7 +6961,7 @@ slots:
     description: Specification of foetal health status, should also include abortion
     title: amniotic fluid/foetal health status
     keywords:
-    - status
+      - status
     slot_uri: MIXS:0000275
     range: string
   food_additive:
@@ -6958,9 +6975,9 @@ slots:
       also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
     title: food additive
     examples:
-    - value: xanthan gum [FOODON:03413321]
+      - value: xanthan gum [FOODON:03413321]
     keywords:
-    - food
+      - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001200
     multivalued: true
@@ -6971,9 +6988,9 @@ slots:
       This field accepts terms listed under dietary claim or use (http://purl.obolibrary.org/obo/FOODON_03510213)
     title: food allergen labeling
     examples:
-    - value: food allergen labelling about crustaceans and products thereof [FOODON:03510215]
+      - value: food allergen labelling about crustaceans and products thereof [FOODON:03510215]
     keywords:
-    - food
+      - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001201
     multivalued: true
@@ -6982,13 +6999,13 @@ slots:
       from the food source. Multiple terms can be separated by pipes
     title: food cleaning process
     examples:
-    - value: rinsed with water
-      description: was rinsed with water|scrubbed with brush
-    - value: scrubbed with brush
-      description: was rinsed with water|scrubbed with brush
+      - value: rinsed with water
+        description: was rinsed with water|scrubbed with brush
+      - value: scrubbed with brush
+        description: was rinsed with water|scrubbed with brush
     keywords:
-    - food
-    - process
+      - food
+      - process
     slot_uri: MIXS:0001182
     range: FoodCleanProcEnum
   food_contact_surf:
@@ -6999,10 +7016,10 @@ slots:
       under food contact surface (http://purl.obolibrary.org/obo/FOODON_03500010)
     title: food contact surface
     examples:
-    - value: cellulose acetate [FOODON:03500034]
+      - value: cellulose acetate [FOODON:03500034]
     keywords:
-    - food
-    - surface
+      - food
+      - surface
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001131
     multivalued: true
@@ -7015,9 +7032,9 @@ slots:
       form. This field accepts terms listed under food container or wrapping (http://purl.obolibrary.org/obo/FOODON_03490100)
     title: food container or wrapping
     examples:
-    - value: Plastic shrink-pack [FOODON:03490137]
+      - value: Plastic shrink-pack [FOODON:03490137]
     keywords:
-    - food
+      - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001132
   food_cooking_proc:
@@ -7027,10 +7044,10 @@ slots:
       accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
     title: food cooking process
     examples:
-    - value: food blanching [FOODON:03470175]
+      - value: food blanching [FOODON:03470175]
     keywords:
-    - food
-    - process
+      - food
+      - process
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001202
     multivalued: true
@@ -7043,11 +7060,11 @@ slots:
       Service. Washington, DC. March 2012. http://dx.doi.org/10.9752/MS045.03-2012'
     title: food distribution point geographic location
     examples:
-    - value: 'USA: Delmarva, Peninsula'
+      - value: 'USA: Delmarva, Peninsula'
     keywords:
-    - food
-    - geographic
-    - location
+      - food
+      - geographic
+      - location
     slot_uri: MIXS:0001203
     multivalued: true
     range: string
@@ -7067,11 +7084,11 @@ slots:
       Service. Washington, DC. March 2012. http://dx.doi.org/10.9752/MS045.03-2012'
     title: food distribution point geographic location (city)
     examples:
-    - value: Atlanta[GAZ:00004445]
+      - value: Atlanta[GAZ:00004445]
     keywords:
-    - food
-    - geographic
-    - location
+      - food
+      - geographic
+      - location
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001204
     multivalued: true
@@ -7082,10 +7099,10 @@ slots:
       a part of an organism or the whole, and may involve killing the organism
     title: Food harvesting process
     examples:
-    - value: hand-picked
+      - value: hand-picked
     keywords:
-    - food
-    - process
+      - food
+      - process
     slot_uri: MIXS:0001133
     multivalued: true
     range: string
@@ -7099,10 +7116,10 @@ slots:
       listed in order as on the food label.  See also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
     title: food ingredient
     examples:
-    - value: bean (whole) [FOODON:00002753]
+      - value: bean (whole) [FOODON:00002753]
     keywords:
-    - food
-    - ingredient
+      - food
+      - ingredient
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001205
     multivalued: true
@@ -7112,11 +7129,11 @@ slots:
       name legal status (http://purl.obolibrary.org/obo/FOODON_03530087)
     title: food product name legal status
     examples:
-    - value: protected geographic indication [FOODON:03530256]
+      - value: protected geographic indication [FOODON:03530256]
     keywords:
-    - food
-    - product
-    - status
+      - food
+      - product
+      - status
     slot_uri: MIXS:0001206
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -7131,12 +7148,12 @@ slots:
       location (http://purl.obolibrary.org/obo/GAZ_00000448)
     title: food product origin geographic location
     examples:
-    - value: 'USA: Delmarva, Peninsula'
+      - value: 'USA: Delmarva, Peninsula'
     keywords:
-    - food
-    - geographic
-    - location
-    - product
+      - food
+      - geographic
+      - location
+      - product
     slot_uri: MIXS:0001207
     range: string
     pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
@@ -7150,10 +7167,10 @@ slots:
     description: The maximum number of product units within a package
     title: food package capacity
     examples:
-    - value: 454 grams
+      - value: 454 grams
     keywords:
-    - food
-    - package
+      - food
+      - package
     slot_uri: MIXS:0001208
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7170,9 +7187,9 @@ slots:
       food packing medium integrity (http://purl.obolibrary.org/obo/FOODON_03530218)
     title: food packing medium integrity
     examples:
-    - value: food packing medium compromised [FOODON:00002517]
+      - value: food packing medium compromised [FOODON:00002517]
     keywords:
-    - food
+      - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001209
     multivalued: true
@@ -7189,7 +7206,7 @@ slots:
       terms may apply and can be separated by pipes
     title: food packing medium
     keywords:
-    - food
+      - food
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001134
     multivalued: true
@@ -7201,10 +7218,10 @@ slots:
       field accepts terms listed under food preservation process (http://purl.obolibrary.org/obo/FOODON_03470107)
     title: food preservation process
     examples:
-    - value: food slow freezing [FOODON:03470128]
+      - value: food slow freezing [FOODON:03470128]
     keywords:
-    - food
-    - process
+      - food
+      - process
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001135
     multivalued: true
@@ -7218,11 +7235,11 @@ slots:
       prior to food packaging
     title: material of contact prior to food packaging
     examples:
-    - value: processed in stainless steel container [FOODON:03530081]
+      - value: processed in stainless steel container [FOODON:03530081]
     keywords:
-    - food
-    - material
-    - prior
+      - food
+      - material
+      - prior
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001210
     multivalued: true
@@ -7234,10 +7251,10 @@ slots:
       Multiple terms may apply and can be separated by pipes
     title: food production system characteristics
     examples:
-    - value: organic plant cultivation [FOODON:03530253]
+      - value: organic plant cultivation [FOODON:03530253]
     keywords:
-    - food
-    - production
+      - food
+      - production
     slot_uri: MIXS:0001211
     multivalued: true
     range: string
@@ -7251,10 +7268,10 @@ slots:
       organic, free-range, industrial, dairy, beef
     title: food production characteristics
     examples:
-    - value: wild caught
+      - value: wild caught
     keywords:
-    - food
-    - production
+      - food
+      - production
     slot_uri: MIXS:0001136
     multivalued: true
     range: string
@@ -7263,10 +7280,10 @@ slots:
       or non-English names)
     title: food product synonym
     examples:
-    - value: pinot gris
+      - value: pinot gris
     keywords:
-    - food
-    - product
+      - food
+      - product
     slot_uri: MIXS:0001212
     multivalued: true
     range: string
@@ -7278,11 +7295,11 @@ slots:
       under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
     title: food product by quality
     examples:
-    - value: raw [FOODON:03311126]
+      - value: raw [FOODON:03311126]
     keywords:
-    - food
-    - product
-    - quality
+      - food
+      - product
+      - quality
     slot_uri: MIXS:0001213
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -7303,9 +7320,9 @@ slots:
       type. Multiple terms can be separated by one or more pipes
     title: food product type
     keywords:
-    - food
-    - product
-    - type
+      - food
+      - product
+      - type
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001184
   food_quality_date:
@@ -7317,11 +7334,11 @@ slots:
       "best if used by," best by," "use by," or "freeze by."
     title: food quality date
     examples:
-    - value: best by 2020-05-24
+      - value: best by 2020-05-24
     keywords:
-    - date
-    - food
-    - quality
+      - date
+      - food
+      - quality
     string_serialization: '[best by|best if used by|freeze by|use by]; date'
     slot_uri: MIXS:0001178
   food_source:
@@ -7331,8 +7348,8 @@ slots:
       ingredient is derived or a chemical food source [FDA CFSAN 1995]
     title: food source
     keywords:
-    - food
-    - source
+      - food
+      - source
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001139
   food_source_age:
@@ -7342,13 +7359,13 @@ slots:
       host organism, age may be more appropriate to report in days, weeks, or years
     title: food source age
     comments:
-    - ISO 8601 period or measurement value?
+      - ISO 8601 period or measurement value?
     examples:
-    - value: 6 months
+      - value: 6 months
     keywords:
-    - age
-    - food
-    - source
+      - age
+      - food
+      - source
     slot_uri: MIXS:0001251
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7368,9 +7385,9 @@ slots:
       but also to any foods that contain listed foods as ingredients
     title: food traceability list category
     examples:
-    - value: tropical tree fruits
+      - value: tropical tree fruits
     keywords:
-    - food
+      - food
     slot_uri: MIXS:0001214
     range: FoodTraceListEnum
   food_trav_mode:
@@ -7381,11 +7398,11 @@ slots:
       be separated by one or more pipes
     title: food shipping transportation method
     examples:
-    - value: train travel [GENEPIO:0001060]
+      - value: train travel [GENEPIO:0001060]
     keywords:
-    - food
-    - method
-    - transport
+      - food
+      - method
+      - transport
     slot_uri: MIXS:0001137
     multivalued: true
     range: string
@@ -7404,10 +7421,10 @@ slots:
       terms can be separated by one or more pipes
     title: food shipping transportation vehicle
     examples:
-    - value: aircraft [ENVO:01001488]|car [ENVO:01000605]
+      - value: aircraft [ENVO:01001488]|car [ENVO:01000605]
     keywords:
-    - food
-    - transport
+      - food
+      - transport
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001138
     multivalued: true
@@ -7421,11 +7438,11 @@ slots:
       fields accepts terms listed under food treatment process (http://purl.obolibrary.org/obo/FOODON_03460111)
     title: food treatment process
     examples:
-    - value: gluten removal process [FOODON:03460750]
+      - value: gluten removal process [FOODON:03460750]
     keywords:
-    - food
-    - process
-    - treatment
+      - food
+      - process
+      - treatment
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001140
     multivalued: true
@@ -7434,16 +7451,16 @@ slots:
       cleaning might be on a Daily basis, Weekly, Monthly, Quarterly or Annually
     title: frequency of cleaning
     examples:
-    - value: Daily
+      - value: Daily
     keywords:
-    - frequency
+      - frequency
     slot_uri: MIXS:0000226
     range: FreqCleanEnum
   freq_cook:
     description: The number of times a meal is cooked per week
     title: frequency of cooking
     keywords:
-    - frequency
+      - frequency
     slot_uri: MIXS:0000227
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -7460,9 +7477,9 @@ slots:
       start and end time of the entire treatment; can include multiple fungicide regimens
     title: fungicide regimen
     examples:
-    - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
+      - regimen
     slot_uri: MIXS:0000557
     multivalued: true
     range: string
@@ -7470,7 +7487,7 @@ slots:
     description: The types of furniture present in the sampled room
     title: furniture
     examples:
-    - value: chair
+      - value: chair
     slot_uri: MIXS:0000807
     range: FurnitureEnum
   gaseous_environment:
@@ -7481,9 +7498,9 @@ slots:
       and total experimental duration; can include multiple gaseous environment regimens
     title: gaseous environment
     examples:
-    - value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - environment
+      - environment
     slot_uri: MIXS:0000558
     multivalued: true
     range: string
@@ -7504,7 +7521,7 @@ slots:
       gastrointestinal system disease (https://disease-ontology.org/?id=DOID:77)
     title: gastrointestinal tract disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000280
     multivalued: true
     range: string
@@ -7512,7 +7529,7 @@ slots:
     description: The gender type of the restroom
     title: gender of restroom
     examples:
-    - value: male
+      - value: male
     slot_uri: MIXS:0000808
     range: GenderRestroomEnum
   genetic_mod:
@@ -7524,7 +7541,7 @@ slots:
       transfection
     title: genetic modification
     examples:
-    - value: aox1A transgenic
+      - value: aox1A transgenic
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000859
   geo_loc_name:
@@ -7534,12 +7551,12 @@ slots:
       (http://purl.bioontology.org/ontology/GAZ)
     title: geographic location (country and/or sea,region)
     examples:
-    - value: 'USA: Maryland, Bethesda'
+      - value: 'USA: Maryland, Bethesda'
     in_subset:
-    - environment
+      - environment
     keywords:
-    - geographic
-    - location
+      - geographic
+      - location
     slot_uri: MIXS:0000010
     range: string
     required: true
@@ -7559,7 +7576,7 @@ slots:
     description: Measurement of glucosidase activity
     title: glucosidase activity
     examples:
-    - value: 5 mol per liter per hour
+      - value: 5 mol per liter per hour
     slot_uri: MIXS:0000137
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7573,7 +7590,7 @@ slots:
       specifying which is used
     title: gravidity
     examples:
-    - value: yes;due date:2018-05-11
+      - value: yes;due date:2018-05-11
     string_serialization: '{boolean};{timestamp}'
     slot_uri: MIXS:0000875
   gravity:
@@ -7587,7 +7604,7 @@ slots:
       include multiple treatments
     title: gravity
     examples:
-    - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000559
     multivalued: true
@@ -7599,19 +7616,19 @@ slots:
       use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
     title: growth facility
     examples:
-    - value: Growth chamber [CO_715:0000189]
+      - value: Growth chamber [CO_715:0000189]
     keywords:
-    - facility
-    - growth
+      - facility
+      - growth
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001043
   growth_habit:
     description: Characteristic shape, appearance or growth form of a plant species
     title: growth habit
     examples:
-    - value: spreading
+      - value: spreading
     keywords:
-    - growth
+      - growth
     slot_uri: MIXS:0001044
     range: GrowthHabitEnum
   growth_hormone_regm:
@@ -7625,10 +7642,10 @@ slots:
       hormone regimens
     title: growth hormone regimen
     examples:
-    - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - growth
-    - regimen
+      - growth
+      - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000560
     multivalued: true
@@ -7638,9 +7655,9 @@ slots:
       Thesaurus).  The name of the medium used to grow the microorganism
     title: growth medium
     examples:
-    - value: LB broth
+      - value: LB broth
     keywords:
-    - growth
+      - growth
     slot_uri: MIXS:0001108
     range: string
   gynecologic_disord:
@@ -7649,7 +7666,7 @@ slots:
       female reproductive system disease (https://disease-ontology.org/?id=DOID:229)
     title: gynecological disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000288
     multivalued: true
     range: string
@@ -7657,16 +7674,16 @@ slots:
     description: The total count of hallways and cooridors in the built structure
     title: hallway/corridor count
     keywords:
-    - corridor
-    - count
-    - hallway
+      - corridor
+      - count
+      - hallway
     slot_uri: MIXS:0000228
     range: integer
   handidness:
     description: The handidness of the individual sampled
     title: handidness
     examples:
-    - value: right handedness
+      - value: right handedness
     slot_uri: MIXS:0000809
     range: HandidnessEnum
   hc_produced:
@@ -7674,10 +7691,10 @@ slots:
       etc). If "other" is specified, please propose entry in "additional info" field
     title: hydrocarbon type produced
     examples:
-    - value: Gas
+      - value: Gas
     keywords:
-    - hydrocarbon
-    - type
+      - hydrocarbon
+      - type
     slot_uri: MIXS:0000989
     range: HcProducedEnum
     required: true
@@ -7691,11 +7708,11 @@ slots:
       entry in "additional info" field
     title: hydrocarbon resource type
     examples:
-    - value: Oil Sand
+      - value: Oil Sand
     keywords:
-    - hydrocarbon
-    - resource
-    - type
+      - hydrocarbon
+      - resource
+      - type
     slot_uri: MIXS:0000988
     range: HcrEnum
     required: true
@@ -7706,8 +7723,8 @@ slots:
       Waterflooding) expressed as TDS
     title: formation water salinity
     keywords:
-    - salinity
-    - water
+      - salinity
+      - water
     slot_uri: MIXS:0000406
     range: string
     recommended: true
@@ -7722,11 +7739,11 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: hydrocarbon resource geological age
     examples:
-    - value: Silurian
+      - value: Silurian
     keywords:
-    - age
-    - hydrocarbon
-    - resource
+      - age
+      - hydrocarbon
+      - resource
     slot_uri: MIXS:0000993
     range: GeolAgeEnum
     recommended: true
@@ -7736,9 +7753,9 @@ slots:
     description: Original pressure of the hydrocarbon resource
     title: hydrocarbon resource original pressure
     keywords:
-    - hydrocarbon
-    - pressure
-    - resource
+      - hydrocarbon
+      - pressure
+      - resource
     slot_uri: MIXS:0000395
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -7752,11 +7769,11 @@ slots:
     description: Original temperature of the hydrocarbon resource
     title: hydrocarbon resource original temperature
     examples:
-    - value: 150-295 degree Celsius
+      - value: 150-295 degree Celsius
     keywords:
-    - hydrocarbon
-    - resource
-    - temperature
+      - hydrocarbon
+      - resource
+      - temperature
     slot_uri: MIXS:0000393
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -7768,9 +7785,9 @@ slots:
     description: Methods of conditioning or heating a room or building
     title: heating and cooling system type
     examples:
-    - value: heat pump
+      - value: heat pump
     keywords:
-    - type
+      - type
     slot_uri: MIXS:0000766
     multivalued: true
     range: HeatCoolTypeEnum
@@ -7779,28 +7796,28 @@ slots:
     description: The location of heat delivery within the room
     title: heating delivery locations
     examples:
-    - value: north
+      - value: north
     keywords:
-    - delivery
-    - location
-    - locations
+      - delivery
+      - location
+      - locations
     slot_uri: MIXS:0000810
     range: CompassDirections8Enum
   heat_sys_deliv_meth:
     description: The method by which the heat is delivered through the system
     title: heating system delivery method
     examples:
-    - value: radiant
+      - value: radiant
     keywords:
-    - delivery
-    - method
+      - delivery
+      - method
     slot_uri: MIXS:0000812
     range: HeatSysDelivMethEnum
   heat_system_id:
     description: The heating system identifier
     title: heating system identifier
     keywords:
-    - identifier
+      - identifier
     slot_uri: MIXS:0000833
     range: integer
   heavy_metals:
@@ -7811,11 +7828,11 @@ slots:
       For multiple heavy metals and concentrations, add multiple copies of this field
     title: extreme_unusual_properties/heavy metals
     examples:
-    - value: mercury;0.09 micrograms per gram
+      - value: mercury;0.09 micrograms per gram
     keywords:
-    - extreme
-    - properties
-    - unusual
+      - extreme
+      - properties
+      - unusual
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000652
     multivalued: true
@@ -7823,10 +7840,10 @@ slots:
     description: Reference or method used in determining heavy metals
     title: extreme_unusual_properties/heavy metals method
     keywords:
-    - extreme
-    - method
-    - properties
-    - unusual
+      - extreme
+      - method
+      - properties
+      - unusual
     slot_uri: MIXS:0000343
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -7840,7 +7857,7 @@ slots:
     description: The average carpet fiber height in the indoor environment
     title: height carpet fiber mat
     keywords:
-    - height
+      - height
     slot_uri: MIXS:0000167
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7859,9 +7876,9 @@ slots:
       time of the entire treatment; can include multiple regimens
     title: herbicide regimen
     examples:
-    - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
+      - regimen
     slot_uri: MIXS:0000561
     multivalued: true
     range: string
@@ -7869,8 +7886,8 @@ slots:
     description: Reference or method used in determining the horizon
     title: horizon method
     keywords:
-    - horizon
-    - method
+      - horizon
+      - method
     slot_uri: MIXS:0000321
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -7885,9 +7902,9 @@ slots:
       and study, e.g. Could be seconds for amoebae or centuries for trees
     title: host age
     keywords:
-    - age
-    - host
-    - host.
+      - age
+      - host
+      - host.
     slot_uri: MIXS:0000255
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7900,10 +7917,10 @@ slots:
     description: Original body habitat where the sample was obtained from
     title: host body habitat
     keywords:
-    - body
-    - habitat
-    - host
-    - host.
+      - body
+      - habitat
+      - host
+      - host.
     slot_uri: MIXS:0000866
     range: string
   host_body_mass_index:
@@ -7912,10 +7929,10 @@ slots:
     description: Body mass index, calculated as weight/(height)squared
     title: host body-mass index
     examples:
-    - value: 22 kilogram per square meter
+      - value: 22 kilogram per square meter
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000317
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7932,12 +7949,12 @@ slots:
       (fma) or Uber-anatomy ontology (UBERON)
     title: host body product
     examples:
-    - value: mucus [FMA:66938]
+      - value: mucus [FMA:66938]
     keywords:
-    - body
-    - host
-    - host.
-    - product
+      - body
+      - host
+      - host.
+      - product
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000888
   host_body_site:
@@ -7948,9 +7965,9 @@ slots:
       of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
     title: host body site
     keywords:
-    - body
-    - host
-    - site
+      - body
+      - host
+      - site
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000867
   host_body_temp:
@@ -7959,10 +7976,10 @@ slots:
     description: Core body temperature of the host when sample was collected
     title: host body temperature
     keywords:
-    - body
-    - host
-    - host.
-    - temperature
+      - body
+      - host
+      - host.
+      - temperature
     slot_uri: MIXS:0000274
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -7978,11 +7995,11 @@ slots:
       is localized outside of cells'
     title: host cellular location
     examples:
-    - value: extracellular
+      - value: extracellular
     keywords:
-    - host
-    - host.
-    - location
+      - host
+      - host.
+      - location
     slot_uri: MIXS:0001313
     range: HostCellularLocEnum
     recommended: true
@@ -7990,8 +8007,8 @@ slots:
     description: The color of host
     title: host color
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000260
     range: string
   host_common_name:
@@ -8000,18 +8017,18 @@ slots:
     description: Common name of the host
     title: host common name
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000248
     range: string
   host_dependence:
     description: Type of host dependence for the symbiotic host organism to its host
     title: host dependence
     examples:
-    - value: obligate
+      - value: obligate
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0001315
     range: HostDependenceEnum
     required: true
@@ -8020,9 +8037,9 @@ slots:
       etc., for humans high-fat, meditteranean etc.; can include multiple diet types
     title: host diet
     keywords:
-    - diet
-    - host
-    - host.
+      - diet
+      - host
+      - host.
     slot_uri: MIXS:0000869
     multivalued: true
     range: string
@@ -8035,12 +8052,12 @@ slots:
       non-human host diseases are free text
     title: host disease status
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - disease
-    - host
-    - host.
-    - status
+      - disease
+      - host
+      - host.
+      - status
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000031
   host_dry_mass:
@@ -8049,12 +8066,12 @@ slots:
     description: Measurement of dry mass
     title: host dry mass
     examples:
-    - value: 500 gram
+      - value: 500 gram
     keywords:
-    - dry
-    - host
-    - host.
-    - mass
+      - dry
+      - host
+      - host.
+      - mass
     slot_uri: MIXS:0000257
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8070,10 +8087,10 @@ slots:
       relationships
     title: host family relationship
     keywords:
-    - family
-    - host
-    - host.
-    - relationship
+      - family
+      - host
+      - host.
+      - relationship
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0000872
     multivalued: true
@@ -8081,20 +8098,20 @@ slots:
     description: Observed genotype
     title: host genotype
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000365
     range: string
   host_growth_cond:
     description: Literature reference giving growth conditions of the host
     title: host growth conditions
     examples:
-    - value: https://academic.oup.com/icesjms/article/68/2/349/617247
+      - value: https://academic.oup.com/icesjms/article/68/2/349/617247
     keywords:
-    - condition
-    - growth
-    - host
-    - host.
+      - condition
+      - growth
+      - host
+      - host.
     slot_uri: MIXS:0000871
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -8108,9 +8125,9 @@ slots:
     description: The height of subject
     title: host height
     keywords:
-    - height
-    - host
-    - host.
+      - height
+      - host
+      - host.
     slot_uri: MIXS:0000264
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8126,19 +8143,19 @@ slots:
       be indicated as [YES or NO]
     title: host HIV status
     examples:
-    - value: yes;yes
+      - value: yes;yes
     keywords:
-    - host
-    - host.
-    - status
+      - host
+      - host.
+      - status
     string_serialization: '{boolean};{boolean}'
     slot_uri: MIXS:0000265
   host_infra_spec_name:
     description: Taxonomic information about the host below subspecies level
     title: host infra-specific name
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000253
     range: string
   host_infra_spec_rank:
@@ -8146,9 +8163,9 @@ slots:
       such as variety, form, rank etc
     title: host infra-specific rank
     keywords:
-    - host
-    - host.
-    - rank
+      - host
+      - host.
+      - rank
     slot_uri: MIXS:0000254
     range: string
   host_last_meal:
@@ -8158,8 +8175,8 @@ slots:
       values
     title: host last meal
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     string_serialization: '{text};{duration}'
     slot_uri: MIXS:0000870
     multivalued: true
@@ -8169,11 +8186,11 @@ slots:
     description: The length of subject
     title: host length
     examples:
-    - value: 1 meter
+      - value: 1 meter
     keywords:
-    - host
-    - host.
-    - length
+      - host
+      - host.
+      - length
     slot_uri: MIXS:0000256
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8188,10 +8205,10 @@ slots:
     description: Description of life stage of host
     title: host life stage
     keywords:
-    - host
-    - host.
-    - life
-    string_serialization: '{text}'
+      - host
+      - host.
+      - life
+    range: string
     slot_uri: MIXS:0000251
   host_number:
     annotations:
@@ -8199,25 +8216,25 @@ slots:
     description: Number of symbiotic host individuals pooled at the time of collection
     title: host number individual
     examples:
-    - value: '3'
+      - value: '3'
     keywords:
-    - host
-    - host.
-    - number
+      - host
+      - host.
+      - number
     string_serialization: '{float} m'
     slot_uri: MIXS:0001305
   host_occupation:
     description: Most frequent job performed by subject
     title: host occupation
     comments:
-    - Couldn't convert host_occupation with value veterinary to integer
-    - almost all host_occupation values in the NCBI biosample_set are strings, not
-      integers
+      - Couldn't convert host_occupation with value veterinary to integer
+      - almost all host_occupation values in the NCBI biosample_set are strings, not
+        integers
     examples:
-    - value: veterinary
+      - value: veterinary
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000896
     range: string
   host_of_host_coinf:
@@ -8232,13 +8249,13 @@ slots:
       with the host (A) use the term Observed host symbiont
     title: observed coinfecting organisms in host of host
     examples:
-    - value: Maritrema novaezealandense
+      - value: Maritrema novaezealandense
     keywords:
-    - host
-    - host.
-    - observed
-    - organism
-    string_serialization: '{text}'
+      - host
+      - host.
+      - observed
+      - organism
+    range: string
     slot_uri: MIXS:0001310
   host_of_host_disease:
     annotations:
@@ -8249,13 +8266,13 @@ slots:
       at https://www.disease-ontology.org, non-human host diseases are free text
     title: host of the symbiotic host disease status
     examples:
-    - value: rabies [DOID:11260]
+      - value: rabies [DOID:11260]
     keywords:
-    - disease
-    - host
-    - host.
-    - status
-    - symbiosis
+      - disease
+      - host
+      - host.
+      - status
+      - symbiosis
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0001319
     multivalued: true
@@ -8270,13 +8287,13 @@ slots:
       its local environmental context will be the term for intestine from UBERON (http://uberon.github.io/)
     title: host of the symbiotic host local environmental context
     examples:
-    - value: small intestine[uberon:0002108]
+      - value: small intestine[uberon:0002108]
     keywords:
-    - context
-    - environmental
-    - host
-    - host.
-    - symbiosis
+      - context
+      - environmental
+      - host
+      - host.
+      - symbiosis
     string_serialization: small intestine [UBERON:0002108]
     slot_uri: MIXS:0001325
     multivalued: true
@@ -8296,12 +8313,12 @@ slots:
       discrete, countable entities (e.g. intestines, heart)'
     title: host of the symbiotic host environemental medium
     examples:
-    - value: feces[uberon:0001988]
+      - value: feces[uberon:0001988]
     keywords:
-    - environmental
-    - host
-    - host.
-    - symbiosis
+      - environmental
+      - host
+      - host.
+      - symbiosis
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001326
   host_of_host_fam_rel:
@@ -8312,11 +8329,11 @@ slots:
       relationships
     title: host of the symbiotic host family relationship
     keywords:
-    - family
-    - host
-    - host.
-    - relationship
-    - symbiosis
+      - family
+      - host
+      - host.
+      - relationship
+      - symbiosis
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0001328
     multivalued: true
@@ -8324,9 +8341,9 @@ slots:
     description: Observed genotype of the host of the symbiotic host organism
     title: host of the symbiotic host genotype
     keywords:
-    - host
-    - host.
-    - symbiosis
+      - host
+      - host.
+      - symbiosis
     slot_uri: MIXS:0001331
     range: string
   host_of_host_gravid:
@@ -8336,9 +8353,9 @@ slots:
       and if yes date due or date post-conception, specifying which is used
     title: host of the symbiotic host gravidity
     keywords:
-    - host
-    - host.
-    - symbiosis
+      - host
+      - host.
+      - symbiosis
     string_serialization: '{boolean};{timestamp}'
     slot_uri: MIXS:0001333
   host_of_host_infname:
@@ -8346,9 +8363,9 @@ slots:
       below subspecies level
     title: host of the symbiotic host infra-specific name
     keywords:
-    - host
-    - host.
-    - symbiosis
+      - host
+      - host.
+      - symbiosis
     slot_uri: MIXS:0001329
     range: string
   host_of_host_infrank:
@@ -8356,21 +8373,21 @@ slots:
       below subspecies level, such as variety, form, rank etc
     title: host of the symbiotic host infra-specific rank
     keywords:
-    - host
-    - host.
-    - rank
-    - symbiosis
+      - host
+      - host.
+      - rank
+      - symbiosis
     slot_uri: MIXS:0001330
     range: string
   host_of_host_name:
     description: Common name of the host of the symbiotic host organism
     title: host of the symbiotic host common name
     examples:
-    - value: snail
+      - value: snail
     keywords:
-    - host
-    - host.
-    - symbiosis
+      - host
+      - host.
+      - symbiosis
     slot_uri: MIXS:0001324
     range: string
   host_of_host_pheno:
@@ -8380,9 +8397,9 @@ slots:
       quality ontology (PATO) terms, see http://purl.bioontology.org/ontology/pato
     title: host of the symbiotic host phenotype
     keywords:
-    - host
-    - host.
-    - symbiosis
+      - host
+      - host.
+      - symbiosis
     string_serialization: '{term}'
     slot_uri: MIXS:0001332
   host_of_host_sub_id:
@@ -8390,12 +8407,12 @@ slots:
       subject can be referred to, de-identified, e.g. #H14'
     title: host of the symbiotic host subject id
     examples:
-    - value: H3
+      - value: H3
     keywords:
-    - host
-    - host.
-    - identifier
-    - symbiosis
+      - host
+      - host.
+      - identifier
+      - symbiosis
     slot_uri: MIXS:0001327
     range: string
   host_of_host_taxid:
@@ -8404,13 +8421,13 @@ slots:
     description: NCBI taxon id of the host of the symbiotic host organism
     title: host of the symbiotic host taxon id
     examples:
-    - value: '145637'
+      - value: '145637'
     keywords:
-    - host
-    - host.
-    - identifier
-    - symbiosis
-    - taxon
+      - host
+      - host.
+      - identifier
+      - symbiosis
+      - taxon
     string_serialization: '{integer}'
     slot_uri: MIXS:0001306
   host_of_host_totmass:
@@ -8418,11 +8435,11 @@ slots:
       the unit depends on the host
     title: host of the symbiotic host total mass
     keywords:
-    - host
-    - host.
-    - mass
-    - symbiosis
-    - total
+      - host
+      - host.
+      - mass
+      - symbiosis
+      - total
     slot_uri: MIXS:0001334
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8438,21 +8455,21 @@ slots:
       ontology (pato) or the Human Phenotype Ontology (HP)
     title: host phenotype
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000874
   host_pred_appr:
     description: Tool or approach used for host prediction
     title: host prediction approach
     examples:
-    - value: CRISPR spacer match
+      - value: CRISPR spacer match
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - host
-    - host.
-    - predict
+      - host
+      - host.
+      - predict
     slot_uri: MIXS:0000088
     range: HostPredApprEnum
   host_pred_est_acc:
@@ -8460,14 +8477,14 @@ slots:
       discovery rates should be included, either computed de novo or from the literature
     title: host prediction estimated accuracy
     examples:
-    - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
+      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
         genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - host
-    - host.
-    - predict
+      - host
+      - host.
+      - predict
     slot_uri: MIXS:0000089
     range: string
   host_pulse:
@@ -8476,10 +8493,10 @@ slots:
     description: Resting pulse, measured as beats per minute
     title: host pulse
     examples:
-    - value: 65 beats per minute
+      - value: 65 beats per minute
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000333
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8494,11 +8511,11 @@ slots:
     description: Gender or physical sex of the host
     title: host sex
     comments:
-    - example of non-binary from Excel sheets does not match any of the enumerated
-      values
+      - example of non-binary from Excel sheets does not match any of the enumerated
+        values
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     string_serialization: '[female|hermaphrodite|non-binary|male|transgender|transgender
       (female to male)|transgender (male to female)
 
@@ -8508,10 +8525,10 @@ slots:
     description: Morphological shape of host
     title: host shape
     examples:
-    - value: round
+      - value: round
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000261
     range: string
   host_spec_range:
@@ -8521,13 +8538,13 @@ slots:
       of infecting, defined by NCBI taxonomy identifier
     title: host specificity or range
     examples:
-    - value: '9606'
+      - value: '9606'
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - host
-    - host.
-    - range
+      - host
+      - host.
+      - range
     string_serialization: '{integer}'
     slot_uri: MIXS:0000030
     multivalued: true
@@ -8536,10 +8553,10 @@ slots:
       (symbiont able to establish associations with distantly related hosts) or species-specific'
     title: host specificity
     examples:
-    - value: species-specific
+      - value: species-specific
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0001308
     range: HostSpecificityEnum
     recommended: true
@@ -8547,15 +8564,15 @@ slots:
     description: A unique identifier by which each subject can be referred to, de-identified
     title: host subject id
     keywords:
-    - host
-    - host.
-    - identifier
+      - host
+      - host.
+      - identifier
     slot_uri: MIXS:0000861
     range: string
   host_subspecf_genlin:
     annotations:
       Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
-          e.g. serovar, biotype, ecotype, variety, cultivar
+        e.g. serovar, biotype, ecotype, variety, cultivar
     description: Information about the genetic distinctness of the host organism below
       the subspecies level e.g., serovar, serotype, biotype, ecotype, variety, cultivar,
       or any relevant genetic typing schemes like Group I plasmid. Subspecies should
@@ -8563,11 +8580,11 @@ slots:
       name and the lineage rank separated by a colon, e.g., biovar:abc123
     title: host subspecific genetic lineage
     examples:
-    - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
+      - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
     keywords:
-    - host
-    - host.
-    - lineage
+      - host
+      - host.
+      - lineage
     string_serialization: '{rank name}:{text}'
     slot_uri: MIXS:0001318
     multivalued: true
@@ -8575,10 +8592,10 @@ slots:
     description: The growth substrate of the host
     title: host substrate
     examples:
-    - value: rock
+      - value: rock
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000252
     range: string
   host_symbiont:
@@ -8590,11 +8607,11 @@ slots:
       of the parasite)
     title: observed host symbionts
     keywords:
-    - host
-    - host.
-    - observed
-    - symbiosis
-    string_serialization: '{text}'
+      - host
+      - host.
+      - observed
+      - symbiosis
+    range: string
     slot_uri: MIXS:0001298
     multivalued: true
   host_taxid:
@@ -8603,9 +8620,9 @@ slots:
     description: NCBI taxon id of the host, e.g. 9606
     title: host taxid
     keywords:
-    - host
-    - host.
-    - taxon
+      - host
+      - host.
+      - taxon
     slot_uri: MIXS:0000250
   host_tot_mass:
     annotations:
@@ -8613,10 +8630,10 @@ slots:
     description: Total mass of the host at collection, the unit depends on host
     title: host total mass
     keywords:
-    - host
-    - host.
-    - mass
-    - total
+      - host
+      - host.
+      - mass
+      - total
     slot_uri: MIXS:0000263
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8631,12 +8648,12 @@ slots:
     description: Measurement of wet mass
     title: host wet mass
     examples:
-    - value: 1500 gram
+      - value: 1500 gram
     keywords:
-    - host
-    - host.
-    - mass
-    - wet
+      - host
+      - host.
+      - mass
+      - wet
     slot_uri: MIXS:0000567
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8650,14 +8667,14 @@ slots:
       date
     title: HRT
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000969
     range: datetime
   humidity:
     description: Amount of water vapour in the air, at the time of sampling
     title: humidity
     keywords:
-    - humidity
+      - humidity
     slot_uri: MIXS:0000100
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8677,10 +8694,10 @@ slots:
       and end time of the entire treatment; can include multiple regimens
     title: humidity regimen
     examples:
-    - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - humidity
-    - regimen
+      - humidity
+      - regimen
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000568
     multivalued: true
@@ -8694,27 +8711,27 @@ slots:
       to the definitions provided
     title: hygienic food production area
     examples:
-    - value: Low Hygiene Area
+      - value: Low Hygiene Area
     keywords:
-    - area
-    - food
-    - production
-    string_serialization: '{text}'
+      - area
+      - food
+      - production
+    range: string
     slot_uri: MIXS:0001253
   hysterectomy:
     description: Specification of whether hysterectomy was performed
     title: hysterectomy
     examples:
-    - value: 'no'
+      - value: 'no'
     slot_uri: MIXS:0000287
     range: boolean
   ihmc_medication_code:
     description: Can include multiple medication codes
     title: IHMC medication code
     examples:
-    - value: '810'
+      - value: '810'
     keywords:
-    - code
+      - code
     slot_uri: MIXS:0000884
     multivalued: true
     range: integer
@@ -8723,9 +8740,9 @@ slots:
       discrete areas of a building is used
     title: indoor space
     examples:
-    - value: foyer
+      - value: foyer
     keywords:
-    - indoor
+      - indoor
     slot_uri: MIXS:0000763
     range: IndoorSpaceEnum
     required: true
@@ -8733,10 +8750,10 @@ slots:
     description: Type of indoor surface
     title: indoor surface
     examples:
-    - value: wall
+      - value: wall
     keywords:
-    - indoor
-    - surface
+      - indoor
+      - surface
     slot_uri: MIXS:0000764
     range: IndoorSurfEnum
   indust_eff_percent:
@@ -8746,7 +8763,7 @@ slots:
       plant
     title: industrial effluent percent
     keywords:
-    - percent
+      - percent
     slot_uri: MIXS:0000662
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8763,8 +8780,8 @@ slots:
       etc.; can include multiple particles
     title: inorganic particles
     keywords:
-    - inorganic
-    - particle
+      - inorganic
+      - particle
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000664
     multivalued: true
@@ -8774,8 +8791,8 @@ slots:
     description: The recorded value at sampling time (power density)
     title: inside lux light
     keywords:
-    - inside
-    - light
+      - inside
+      - light
     slot_uri: MIXS:0000168
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -8789,11 +8806,11 @@ slots:
       or video preferred; use drawings to indicate location of damaged areas
     title: interior wall condition
     examples:
-    - value: damaged
+      - value: damaged
     keywords:
-    - condition
-    - interior
-    - wall
+      - condition
+      - interior
+      - wall
     slot_uri: MIXS:0000813
     range: DamagedEnum
   intended_consumer:
@@ -8804,9 +8821,9 @@ slots:
       (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
     title: intended consumer
     examples:
-    - value: 9606 o rsenior as food consumer [FOODON:03510254]
+      - value: 9606 o rsenior as food consumer [FOODON:03510254]
     keywords:
-    - consumer
+      - consumer
     string_serialization: '{integer}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001144
     multivalued: true
@@ -8816,13 +8833,13 @@ slots:
       the organism/material
     title: isolation and growth condition
     examples:
-    - value: doi:10.1016/j.syapm.2018.01.009
+      - value: doi:10.1016/j.syapm.2018.01.009
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - condition
-    - growth
-    - isolation
+      - condition
+      - growth
+      - isolation
     slot_uri: MIXS:0000003
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -8835,10 +8852,10 @@ slots:
       and/or tertiary recovery
     title: injection water breakthrough date of specific well
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     keywords:
-    - date
-    - water
+      - date
+      - water
     slot_uri: MIXS:0001010
     range: datetime
   iwf:
@@ -8848,13 +8865,13 @@ slots:
       the time of sampling. (e.g. 87%)
     title: injection water fraction
     comments:
-    - pattern was "[0-9]*\\.?[0-9]+ ?%"
-    - percent or float?
+      - pattern was "[0-9]*\\.?[0-9]+ ?%"
+      - percent or float?
     examples:
-    - value: '0.79'
+      - value: '0.79'
     keywords:
-    - fraction
-    - water
+      - fraction
+      - water
     slot_uri: MIXS:0000455
     range: float
     required: true
@@ -8870,7 +8887,7 @@ slots:
       kidney disease (https://disease-ontology.org/?id=DOID:557)
     title: urine/kidney disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000277
     multivalued: true
     range: string
@@ -8878,25 +8895,23 @@ slots:
     description: The last time the floor was cleaned (swept, mopped, vacuumed)
     title: last time swept/mopped/vacuumed
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     keywords:
-    - time
+      - time
     slot_uri: MIXS:0000814
     range: datetime
   lat_lon:
-    annotations:
-      Expected_value: decimal degrees,  limit to 8 decimal points
     description: The geographical origin of the sample as defined by latitude and
-      longitude. The values should be reported in decimal degrees and in WGS84 system
+      longitude. The values should be reported in decimal degrees, limited to 8 decimal points,
+      and in WGS84 system
     title: geographic location (latitude and longitude)
     examples:
-    - value: 50.586825 6.408977
+      - value: 50.586825 6.408977
     in_subset:
-    - environment
+      - environment
     keywords:
-    - geographic
-    - location
-    string_serialization: '{float} {float}'
+      - geographic
+      - location
     slot_uri: MIXS:0000009
     required: true
     pattern: ^(-?((?:[0-8]?[0-9](?:\.\d{0,8})?)|90)) -?[0-9]+(?:\.[0-9]{0,8})?$|^-?(1[0-7]{1,2})$
@@ -8909,22 +8924,22 @@ slots:
       of reads
     title: library layout
     examples:
-    - value: paired
+      - value: paired
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - library
+      - library
     slot_uri: MIXS:0000041
     range: LibLayoutEnum
   lib_reads_seqd:
     description: Total number of clones sequenced from the library
     title: library reads sequenced
     examples:
-    - value: '20'
+      - value: '20'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - library
+      - library
     slot_uri: MIXS:0000040
     range: integer
   lib_screen:
@@ -8934,23 +8949,23 @@ slots:
       creating libraries
     title: library screening strategy
     examples:
-    - value: enriched, screened, normalized
+      - value: enriched, screened, normalized
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - library
-    string_serialization: '{text}'
+      - library
+    range: string
     slot_uri: MIXS:0000043
   lib_size:
     description: Total number of clones in the library prepared for the project
     title: library size
     examples:
-    - value: '50'
+      - value: '50'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - library
-    - size
+      - library
+      - size
     slot_uri: MIXS:0000039
     range: integer
   lib_vector:
@@ -8959,12 +8974,12 @@ slots:
     description: Cloning vector type(s) used in construction of libraries
     title: library vector
     examples:
-    - value: Bacteriophage P1
+      - value: Bacteriophage P1
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - library
-    string_serialization: '{text}'
+      - library
+    range: string
     slot_uri: MIXS:0000042
   library_prep_kit:
     annotations:
@@ -8974,10 +8989,10 @@ slots:
       of sequencing-ready libraries for small genomes, amplicons, and plasmids
     title: library preparation kit
     keywords:
-    - kit
-    - library
-    - preparation
-    string_serialization: '{text}'
+      - kit
+      - library
+      - preparation
+    range: string
     slot_uri: MIXS:0001145
   light_intensity:
     annotations:
@@ -8985,10 +9000,10 @@ slots:
     description: Measurement of light intensity
     title: light intensity
     examples:
-    - value: 0.3 lux
+      - value: 0.3 lux
     keywords:
-    - intensity
-    - light
+      - intensity
+      - light
     slot_uri: MIXS:0000706
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9005,10 +9020,10 @@ slots:
       both light intensity and quality
     title: light regimen
     examples:
-    - value: incandescant light;10 lux;450 nanometer
+      - value: incandescant light;10 lux;450 nanometer
     keywords:
-    - light
-    - regimen
+      - light
+      - regimen
     string_serialization: '{text};{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000569
   light_type:
@@ -9018,10 +9033,10 @@ slots:
       include absence of light
     title: light type
     examples:
-    - value: desk lamp
+      - value: desk lamp
     keywords:
-    - light
-    - type
+      - light
+      - type
     slot_uri: MIXS:0000769
     multivalued: true
     range: LightTypeEnum
@@ -9030,7 +9045,7 @@ slots:
     description: Link to additional analysis results performed on the sample
     title: links to additional analysis
     keywords:
-    - link
+      - link
     slot_uri: MIXS:0000340
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9044,17 +9059,17 @@ slots:
     description: Link to digitized soil maps or other soil classification information
     title: link to classification information
     keywords:
-    - classification
-    - information
-    - link
+      - classification
+      - information
+      - link
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000329
   link_climate_info:
     description: Link to climate resource
     title: link to climate information
     keywords:
-    - information
-    - link
+      - information
+      - link
     slot_uri: MIXS:0000328
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9067,9 +9082,9 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: lithology
     examples:
-    - value: Volcanic
+      - value: Volcanic
     keywords:
-    - lithology
+      - lithology
     slot_uri: MIXS:0000990
     range: LithologyEnum
     recommended: true
@@ -9079,7 +9094,7 @@ slots:
       liver disease (https://disease-ontology.org/?id=DOID:409)
     title: liver disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000282
     multivalued: true
     range: string
@@ -9089,15 +9104,15 @@ slots:
     description: Soil classification based on local soil classification system
     title: soil_taxonomic/local classification
     keywords:
-    - classification
-    string_serialization: '{text}'
+      - classification
+    range: string
     slot_uri: MIXS:0000330
   local_class_meth:
     description: Reference or method used in determining the local soil classification
     title: soil_taxonomic/local classification method
     keywords:
-    - classification
-    - method
+      - classification
+      - method
     slot_uri: MIXS:0000331
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9115,9 +9130,9 @@ slots:
       provided'
     title: lot number
     examples:
-    - value: 1239ABC01A, split Cornish hens
+      - value: 1239ABC01A, split Cornish hens
     keywords:
-    - number
+      - number
     string_serialization: '{integer}, {text}'
     slot_uri: MIXS:0001147
     multivalued: true
@@ -9126,21 +9141,21 @@ slots:
       as a binning parameter in the extraction of genomes from metagenomic datasets
     title: MAG coverage software
     examples:
-    - value: bbmap
+      - value: bbmap
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     slot_uri: MIXS:0000080
     range: MagCovSoftwareEnum
   magnesium:
     annotations:
       Preferred_unit: mole per liter, milligram per liter, parts per million, micromole per
-          kilogram
+        kilogram
     description: Concentration of magnesium in the sample
     title: magnesium
     examples:
-    - value: 52.8 micromole per kilogram
+      - value: 52.8 micromole per kilogram
     slot_uri: MIXS:0000431
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9153,14 +9168,14 @@ slots:
     description: Specification of the maternal health status
     title: amniotic fluid/maternal health status
     keywords:
-    - status
+      - status
     slot_uri: MIXS:0000273
     range: string
   max_occup:
     description: The maximum amount of people allowed in the indoor environment
     title: maximum occupancy
     keywords:
-    - maximum
+      - maximum
     slot_uri: MIXS:0000229
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -9174,10 +9189,10 @@ slots:
     description: Measurement of mean friction velocity
     title: mean friction velocity
     examples:
-    - value: 0.5 meter per second
+      - value: 0.5 meter per second
     keywords:
-    - mean
-    - velocity
+      - mean
+      - velocity
     slot_uri: MIXS:0000498
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9192,11 +9207,11 @@ slots:
     description: Measurement of mean peak friction velocity
     title: mean peak friction velocity
     examples:
-    - value: 1 meter per second
+      - value: 1 meter per second
     keywords:
-    - mean
-    - peak
-    - velocity
+      - mean
+      - peak
+      - velocity
     slot_uri: MIXS:0000502
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9209,7 +9224,7 @@ slots:
     description: 'mechanical structure: a moving structure'
     title: mechanical structure
     examples:
-    - value: elevator
+      - value: elevator
     slot_uri: MIXS:0000815
     range: MechStrucEnum
   mechanical_damage:
@@ -9219,7 +9234,7 @@ slots:
       include multiple damages and sites
     title: mechanical damage
     examples:
-    - value: pruning;bark
+      - value: pruning;bark
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0001052
     multivalued: true
@@ -9227,23 +9242,23 @@ slots:
     description: Whether full medical history was collected
     title: medical history performed
     examples:
-    - value: '1'
+      - value: '1'
     keywords:
-    - history
+      - history
     slot_uri: MIXS:0000897
     range: boolean
   menarche:
     description: Date of most recent menstruation
     title: menarche
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000965
     range: datetime
   menopause:
     description: Date of onset of menopause
     title: menopause
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000968
     range: datetime
   methane:
@@ -9263,13 +9278,13 @@ slots:
     description: Reference or method used in determining microbial biomass
     title: microbial biomass method
     comments:
-    - slot name/scn was microbial_biomass_meth
+      - slot name/scn was microbial_biomass_meth
     examples:
-    - value: http://dx.doi.org/10.1016/j.soilbio.2005.01.021
+      - value: http://dx.doi.org/10.1016/j.soilbio.2005.01.021
     keywords:
-    - biomass
-    - method
-    - microbial
+      - biomass
+      - method
+      - microbial
     slot_uri: MIXS:0000339
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9285,10 +9300,10 @@ slots:
       not listed please use text to describe the culture medium
     title: microbiological culture medium
     examples:
-    - value: brain heart infusion agar [MICRO:0000566]
+      - value: brain heart infusion agar [MICRO:0000566]
     keywords:
-    - culture
-    - microbiological
+      - culture
+      - microbiological
     slot_uri: MIXS:0001216
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
@@ -9303,27 +9318,27 @@ slots:
       terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
     title: microbial starter
     examples:
-    - value: starter cultures [FOODON:03544454]
+      - value: starter cultures [FOODON:03544454]
     keywords:
-    - microbial
+      - microbial
     string_serialization: '{term label} [{termID}]|{text}'
     slot_uri: MIXS:0001217
   microb_start_count:
     annotations:
       Expected_value: organism name; measurement value; enumeration
       Preferred_unit: colony forming units per milliliter; colony forming units per gram
-          of dry weight
+        of dry weight
     description: 'Total cell count of starter culture per gram, volume or area of
       sample and the method that was used for the enumeration (e.g. qPCR, atp, mpn,
       etc.) should also be provided. (example : total prokaryotes; 3.5e7 cells per
       ml; qPCR)'
     title: microbial starter organism count
     examples:
-    - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
+      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
     keywords:
-    - count
-    - microbial
-    - organism
+      - count
+      - microbial
+      - organism
     string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|spread plate|other]'
     slot_uri: MIXS:0001218
   microb_start_inoc:
@@ -9332,9 +9347,9 @@ slots:
     description: The amount of starter culture used to inoculate a new batch
     title: microbial starter inoculation
     examples:
-    - value: 100 milligrams
+      - value: 100 milligrams
     keywords:
-    - microbial
+      - microbial
     slot_uri: MIXS:0001219
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9348,10 +9363,10 @@ slots:
       inoculum
     title: microbial starter preparation
     examples:
-    - value: liquid starter culture, propagated 3 cycles in milk prior to inoculation
+      - value: liquid starter culture, propagated 3 cycles in milk prior to inoculation
     keywords:
-    - microbial
-    - preparation
+      - microbial
+      - preparation
     slot_uri: MIXS:0001220
     range: string
   microb_start_source:
@@ -9359,10 +9374,10 @@ slots:
       commercially supplied, list supplier
     title: microbial starter source
     examples:
-    - value: backslopped, GetCulture
+      - value: backslopped, GetCulture
     keywords:
-    - microbial
-    - source
+      - microbial
+      - source
     slot_uri: MIXS:0001221
     range: string
   microb_start_taxID:
@@ -9371,12 +9386,12 @@ slots:
       two or more microbes
     title: microbial starter NCBI taxonomy ID
     examples:
-    - value: Lactobacillus rhamnosus [NCIT:C123495]
+      - value: Lactobacillus rhamnosus [NCIT:C123495]
     keywords:
-    - identifier
-    - microbial
-    - ncbi
-    - taxon
+      - identifier
+      - microbial
+      - ncbi
+      - taxon
     slot_uri: MIXS:0001222
     range: string
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
@@ -9392,8 +9407,8 @@ slots:
       to have correction factors used for conversion to the final units
     title: microbial biomass
     keywords:
-    - biomass
-    - microbial
+      - biomass
+      - microbial
     slot_uri: MIXS:0000650
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9408,11 +9423,11 @@ slots:
       be reported in uppercase letters
     title: multiplex identifiers
     examples:
-    - value: GTGAATAT
+      - value: GTGAATAT
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - identifier
+      - identifier
     slot_uri: MIXS:0000047
     range: string
     pattern: ^[ACGTRKSYMWBHDVN]+$
@@ -9423,7 +9438,7 @@ slots:
   mineral_nutr_regm:
     annotations:
       Expected_value: mineral nutrient name;mineral nutrient amount;treatment interval and
-          duration
+        duration
       Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of mineral supplements;
       should include the name of mineral nutrient, amount administered, treatment
@@ -9432,11 +9447,11 @@ slots:
       mineral nutrient regimens
     title: mineral nutrient regimen
     examples:
-    - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - mineral
-    - nutrient
-    - regimen
+      - mineral
+      - nutrient
+      - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000570
     multivalued: true
@@ -9447,9 +9462,9 @@ slots:
       listed here
     title: miscellaneous parameter
     examples:
-    - value: Bicarbonate ion concentration;2075 micromole per kilogram
+      - value: Bicarbonate ion concentration;2075 micromole per kilogram
     keywords:
-    - parameter
+      - parameter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000752
     multivalued: true
@@ -9458,7 +9473,7 @@ slots:
       host from which it was sampled
     title: mode of transmission
     examples:
-    - value: horizontal:castrator
+      - value: horizontal:castrator
     slot_uri: MIXS:0001312
     range: ModeTransmissionEnum
     recommended: true
@@ -9468,7 +9483,7 @@ slots:
     description: Concentration of n-alkanes; can include multiple n-alkanes
     title: n-alkanes
     examples:
-    - value: n-hexadecane;100 milligram per liter
+      - value: n-hexadecane;100 milligram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000503
     multivalued: true
@@ -9478,9 +9493,9 @@ slots:
     description: The substance or equipment used as a negative control in an investigation
     title: negative control type
     in_subset:
-    - investigation
+      - investigation
     keywords:
-    - type
+      - type
     slot_uri: MIXS:0001321
     range: NegContTypeEnum
     recommended: true
@@ -9490,9 +9505,9 @@ slots:
     description: Concentration of nitrate in the sample
     title: nitrate
     examples:
-    - value: 65 micromole per liter
+      - value: 65 micromole per liter
     keywords:
-    - nitrate
+      - nitrate
     slot_uri: MIXS:0000425
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9507,9 +9522,9 @@ slots:
     description: Concentration of nitrite in the sample
     title: nitrite
     examples:
-    - value: 0.5 micromole per liter
+      - value: 0.5 micromole per liter
     keywords:
-    - nitrite
+      - nitrite
     slot_uri: MIXS:0000426
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9524,9 +9539,9 @@ slots:
     description: Concentration of nitrogen (total)
     title: nitrogen
     examples:
-    - value: 4.2 micromole per liter
+      - value: 4.2 micromole per liter
     keywords:
-    - nitrogen
+      - nitrogen
     slot_uri: MIXS:0000504
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9545,11 +9560,11 @@ slots:
       time of the entire treatment; can include multiple non-mineral nutrient regimens
     title: non-mineral nutrient regimen
     examples:
-    - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
+      - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
     keywords:
-    - non-mineral
-    - nutrient
-    - regimen
+      - non-mineral
+      - nutrient
+      - regimen
     slot_uri: MIXS:0000571
     multivalued: true
     range: string
@@ -9561,7 +9576,7 @@ slots:
       or upper respiratory tract disease (https://disease-ontology.org/?id=DOID:974)
     title: nose/mouth/teeth/throat disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000283
     multivalued: true
     range: string
@@ -9572,7 +9587,7 @@ slots:
       tract disease (https://disease-ontology.org/?id=DOID:974)
     title: nose throat disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000270
     multivalued: true
     range: string
@@ -9582,9 +9597,9 @@ slots:
       TMA, NASBA) of specific nucleic acids
     title: nucleic acid amplification
     examples:
-    - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
+      - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
     in_subset:
-    - sequencing
+      - sequencing
     slot_uri: MIXS:0000038
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9598,9 +9613,9 @@ slots:
       the nucleic acid fraction from a sample
     title: nucleic acid extraction
     examples:
-    - value: https://mobio.com/media/wysiwyg/pdfs/protocols/12888.pdf
+      - value: https://mobio.com/media/wysiwyg/pdfs/protocols/12888.pdf
     in_subset:
-    - sequencing
+      - sequencing
     slot_uri: MIXS:0000037
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -9615,10 +9630,10 @@ slots:
       of an input material is performed
     title: nucleic acid extraction kit
     examples:
-    - value: Qiagen PowerSoil Kit
+      - value: Qiagen PowerSoil Kit
     keywords:
-    - kit
-    string_serialization: '{text}'
+      - kit
+    range: string
     slot_uri: MIXS:0001223
     multivalued: true
   num_replicons:
@@ -9630,11 +9645,11 @@ slots:
       virus. Always applied to the haploid chromosome count of a eukaryote
     title: number of replicons
     examples:
-    - value: '2'
+      - value: '2'
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - number
+      - number
     string_serialization: '{integer}'
     slot_uri: MIXS:0000022
     range: integer
@@ -9642,10 +9657,10 @@ slots:
     description: The number of samples collected during the current sampling event
     title: number of samples collected
     examples:
-    - value: 116 samples
+      - value: 116 samples
     keywords:
-    - number
-    - sample
+      - number
+      - sample
     slot_uri: MIXS:0001224
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9659,18 +9674,18 @@ slots:
       up a given genome, SAG, MAG, or UViG
     title: number of contigs
     examples:
-    - value: '40'
+      - value: '40'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - number
+      - number
     slot_uri: MIXS:0000060
     range: integer
   number_pets:
     description: The number of pets residing in the sampled space
     title: number of pets
     keywords:
-    - number
+      - number
     slot_uri: MIXS:0000231
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -9682,7 +9697,7 @@ slots:
     description: The number of plant(s) in the sampling space
     title: number of houseplants
     keywords:
-    - number
+      - number
     slot_uri: MIXS:0000230
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -9694,7 +9709,7 @@ slots:
     description: The number of individuals currently occupying in the sampling location
     title: number of residents
     keywords:
-    - number
+      - number
     slot_uri: MIXS:0000232
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -9706,9 +9721,9 @@ slots:
     description: Average number of occupants at time of sampling per square footage
     title: occupant density at sampling
     examples:
-    - value: '0.1'
+      - value: '0.1'
     keywords:
-    - density
+      - density
     slot_uri: MIXS:0000217
     range: float
     required: true
@@ -9716,16 +9731,16 @@ slots:
     description: The type of documentation of occupancy
     title: occupancy documentation
     examples:
-    - value: estimate
+      - value: estimate
     keywords:
-    - documentation
+      - documentation
     slot_uri: MIXS:0000816
     range: OccupDocumentEnum
   occup_samp:
     description: Number of occupants present at time of sample within the given space
     title: occupancy at sampling
     examples:
-    - value: '10'
+      - value: '10'
     slot_uri: MIXS:0000772
     range: float
     required: true
@@ -9738,10 +9753,10 @@ slots:
     description: Concentration of organic carbon
     title: organic carbon
     examples:
-    - value: 1.5 microgram per liter
+      - value: 1.5 microgram per liter
     keywords:
-    - carbon
-    - organic
+      - carbon
+      - organic
     slot_uri: MIXS:0000508
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9753,8 +9768,8 @@ slots:
   org_count_qpcr_info:
     annotations:
       Expected_value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
-          denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
-          elongation:degrees_minutes; total cycles
+        denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
+        elongation:degrees_minutes; total cycles
       Preferred_unit: number of cells per gram (or ml or cm^2)
     description: 'If qpcr was used for the cell count, the target gene name, the primer
       sequence and the cycling conditions should also be provided. (Example: 16S rrna;
@@ -9763,9 +9778,9 @@ slots:
       30 cycles)'
     title: organism count qPCR information
     keywords:
-    - count
-    - information
-    - organism
+      - count
+      - information
+      - organism
     string_serialization: '{text};FWD:{dna};REV:{dna};initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
       elongation:degrees_minutes; total cycles'
     slot_uri: MIXS:0000099
@@ -9775,9 +9790,9 @@ slots:
     description: Concentration of organic matter
     title: organic matter
     examples:
-    - value: 1.75 milligram per cubic meter
+      - value: 1.75 milligram per cubic meter
     keywords:
-    - organic
+      - organic
     slot_uri: MIXS:0000204
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9790,10 +9805,10 @@ slots:
     description: Concentration of organic nitrogen
     title: organic nitrogen
     examples:
-    - value: 4 micromole per liter
+      - value: 4 micromole per liter
     keywords:
-    - nitrogen
-    - organic
+      - nitrogen
+      - organic
     slot_uri: MIXS:0000205
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9810,8 +9825,8 @@ slots:
       fibers, plant material, humus, etc
     title: organic particles
     keywords:
-    - organic
-    - particle
+      - organic
+      - particle
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000665
     multivalued: true
@@ -9824,8 +9839,8 @@ slots:
       also be provided. (example: total prokaryotes; 3.5e7 cells per ml; qpcr)'
     title: organism count
     keywords:
-    - count
-    - organism
+      - count
+      - organism
     string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|other]'
     slot_uri: MIXS:0000103
     multivalued: true
@@ -9838,12 +9853,12 @@ slots:
       primarily used during the analysis
     title: OTU classification approach
     examples:
-    - value: 95% ANI;85% AF; greedy incremental clustering
+      - value: 95% ANI;85% AF; greedy incremental clustering
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - classification
-    - otu
+      - classification
+      - otu
     string_serialization: '{ANI cutoff};{AF cutoff};{clustering method}'
     slot_uri: MIXS:0000085
   otu_db:
@@ -9853,12 +9868,12 @@ slots:
       study) used to cluster new genomes in "species-level" OTUs, if any
     title: OTU database
     examples:
-    - value: NCBI Viral RefSeq;83
+      - value: NCBI Viral RefSeq;83
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - database
-    - otu
+      - database
+      - otu
     string_serialization: '{database};{version}'
     slot_uri: MIXS:0000087
   otu_seq_comp_appr:
@@ -9868,11 +9883,11 @@ slots:
       OTUs
     title: OTU sequence comparison approach
     examples:
-    - value: 'blastn;2.6.0+;e-value cutoff: 0.001'
+      - value: 'blastn;2.6.0+;e-value cutoff: 0.001'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - otu
+      - otu
     string_serialization: '{software};{version};{parameters}'
     slot_uri: MIXS:0000086
   owc_tvdss:
@@ -9881,9 +9896,9 @@ slots:
     description: Depth of the original oil water contact (OWC) zone (average) (m TVDSS)
     title: oil water contact depth
     keywords:
-    - depth
-    - oil
-    - water
+      - depth
+      - oil
+      - water
     slot_uri: MIXS:0000405
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9896,11 +9911,11 @@ slots:
     description: Oxygenation status of sample
     title: oxygenation status of sample
     examples:
-    - value: aerobic
+      - value: aerobic
     keywords:
-    - oxygen
-    - sample
-    - status
+      - oxygen
+      - sample
+      - status
     slot_uri: MIXS:0000753
     range: OxyStatSampEnum
   oxygen:
@@ -9909,9 +9924,9 @@ slots:
     description: Oxygen (gas) amount or concentration at the time of sampling
     title: oxygen
     examples:
-    - value: 600 parts per million
+      - value: 600 parts per million
     keywords:
-    - oxygen
+      - oxygen
     slot_uri: MIXS:0000104
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9924,12 +9939,12 @@ slots:
     description: Concentration of particulate organic carbon
     title: particulate organic carbon
     examples:
-    - value: 1.92 micromole per liter
+      - value: 1.92 micromole per liter
     keywords:
-    - carbon
-    - organic
-    - particle
-    - particulate
+      - carbon
+      - organic
+      - particle
+      - particulate
     slot_uri: MIXS:0000515
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9944,12 +9959,12 @@ slots:
     description: Concentration of particulate organic nitrogen
     title: particulate organic nitrogen
     examples:
-    - value: 0.3 micromole per liter
+      - value: 0.3 micromole per liter
     keywords:
-    - nitrogen
-    - organic
-    - particle
-    - particulate
+      - nitrogen
+      - organic
+      - particle
+      - particulate
     slot_uri: MIXS:0000719
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -9966,10 +9981,10 @@ slots:
       field accepts terms listed under part of plant or animal (http://purl.obolibrary.org/obo/FOODON_03420116)
     title: part of plant or animal
     examples:
-    - value: chuck [FOODON:03530021]
+      - value: chuck [FOODON:03530021]
     keywords:
-    - animal
-    - plant
+      - animal
+      - plant
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001149
     multivalued: true
@@ -9982,8 +9997,8 @@ slots:
       preceded by the name of the particle type; can include multiple values
     title: particle classification
     keywords:
-    - classification
-    - particle
+      - classification
+      - particle
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000206
     multivalued: true
@@ -9993,25 +10008,25 @@ slots:
     description: To what is the entity pathogenic
     title: known pathogenicity
     examples:
-    - value: human, animal, plant, fungi, bacteria
+      - value: human, animal, plant, fungi, bacteria
     in_subset:
-    - nucleic acid sequence source
-    string_serialization: '{text}'
+      - nucleic acid sequence source
+    range: string
     slot_uri: MIXS:0000027
   pcr_cond:
     annotations:
       Expected_value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
-          elongation:degrees_minutes;total cycles
+        elongation:degrees_minutes;total cycles
     description: Description of reaction conditions and components of polymerase chain reaction performed during library preparation.
     title: pcr conditions
     examples:
-    - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
-    - value: initial denaturation:94degC_1.5min
+      - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
+      - value: initial denaturation:94degC_1.5min
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - condition
-    - pcr
+      - condition
+      - pcr
     string_serialization: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
       elongation:degrees_minutes;total cycles
     slot_uri: MIXS:0000049
@@ -10024,11 +10039,11 @@ slots:
       a single PCR reaction. The primer sequence should be reported in uppercase letters
     title: pcr primers
     examples:
-    - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
+      - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - pcr
+      - pcr
     string_serialization: FWD:{dna};REV:{dna}
     slot_uri: MIXS:0000046
   permeability:
@@ -10049,9 +10064,9 @@ slots:
       of the entire perturbation period; can include multiple perturbation types
     title: perturbation
     examples:
-    - value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
+      - value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
     keywords:
-    - perturbation
+      - perturbation
     string_serialization: '{text};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000754
     multivalued: true
@@ -10065,9 +10080,9 @@ slots:
       regimens
     title: pesticide regimen
     examples:
-    - value: pyrethrum;0.6 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: pyrethrum;0.6 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
+      - regimen
     slot_uri: MIXS:0000573
     multivalued: true
     range: string
@@ -10079,11 +10094,11 @@ slots:
       present
     title: presence of pets or farm animals
     examples:
-    - value: yes; 5 cats
+      - value: yes; 5 cats
     keywords:
-    - animal
-    - farm
-    - presence
+      - animal
+      - farm
+      - presence
     string_serialization: '{boolean};{text}'
     slot_uri: MIXS:0000267
     multivalued: true
@@ -10093,10 +10108,10 @@ slots:
     description: Concentration of petroleum hydrocarbon
     title: petroleum hydrocarbon
     examples:
-    - value: 0.05 micromole per liter
+      - value: 0.05 micromole per liter
     keywords:
-    - hydrocarbon
-    - petroleum
+      - hydrocarbon
+      - petroleum
     slot_uri: MIXS:0000516
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10110,19 +10125,19 @@ slots:
       phase of the fluid
     title: pH
     examples:
-    - value: '7.2'
+      - value: '7.2'
     keywords:
-    - ph
+      - ph
     slot_uri: MIXS:0001001
     range: float
   ph_meth:
     description: Reference or method used in determining pH
     title: pH method
     examples:
-    - value: https://www.epa.gov/sites/production/files/2015-12/documents/9040c.pdf
+      - value: https://www.epa.gov/sites/production/files/2015-12/documents/9040c.pdf
     keywords:
-    - method
-    - ph
+      - method
+      - ph
     slot_uri: MIXS:0001106
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -10137,10 +10152,10 @@ slots:
       end time of the entire treatment; can include multiple regimen
     title: pH regimen
     examples:
-    - value: 7.6;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
+      - value: 7.6;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - ph
-    - regimen
+      - ph
+      - regimen
     slot_uri: MIXS:0001056
     multivalued: true
     range: string
@@ -10151,7 +10166,7 @@ slots:
     description: Concentration of phaeopigments; can include multiple phaeopigments
     title: phaeopigments
     examples:
-    - value: 2.5 milligram per cubic meter
+      - value: 2.5 milligram per cubic meter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000180
     multivalued: true
@@ -10161,9 +10176,9 @@ slots:
     description: Concentration of phosphate
     title: phosphate
     examples:
-    - value: 0.7 micromole per liter
+      - value: 0.7 micromole per liter
     keywords:
-    - phosphate
+      - phosphate
     slot_uri: MIXS:0000505
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10178,7 +10193,7 @@ slots:
     description: Concentration of phospholipid fatty acids; can include multiple values
     title: phospholipid fatty acid
     examples:
-    - value: 2.98 milligram per liter
+      - value: 2.98 milligram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000181
     multivalued: true
@@ -10188,7 +10203,7 @@ slots:
     description: Measurement of photon flux
     title: photon flux
     examples:
-    - value: 3.926 micromole photons per second per square meter
+      - value: 3.926 micromole photons per second per square meter
     slot_uri: MIXS:0000725
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10205,9 +10220,9 @@ slots:
       term method term detailing the method of activity measurement
     title: photosynthetic activity
     examples:
-    - value: 0.1 mol CO2 m-2 s-1
-      description: added a magnitude to the example from the XLSX file, " mol CO2
-        m-2 s-1"
+      - value: 0.1 mol CO2 m-2 s-1
+        description: added a magnitude to the example from the XLSX file, " mol CO2
+          m-2 s-1"
     slot_uri: MIXS:0001296
     range: string
     recommended: true
@@ -10221,7 +10236,7 @@ slots:
     description: Reference or method used in measurement of photosythetic activity
     title: photosynthetic activity method
     keywords:
-    - method
+      - method
     slot_uri: MIXS:0001336
     multivalued: true
     range: string
@@ -10241,8 +10256,8 @@ slots:
       or other controlled vocabulary
     title: plant growth medium
     keywords:
-    - growth
-    - plant
+      - growth
+      - plant
     string_serialization: '{termLabel} [{termID}] or [husk|other artificial liquid
       medium|other artificial solid medium|peat moss|perlite|pumice|sand|soil|vermiculite|water]'
     slot_uri: MIXS:0001057
@@ -10254,10 +10269,10 @@ slots:
       of plant maturity (http://purl.obolibrary.org/obo/FOODON_03530050)
     title: degree of plant part maturity
     examples:
-    - value: ripe or mature [FOODON:03530052]
+      - value: ripe or mature [FOODON:03530052]
     keywords:
-    - degree
-    - plant
+      - degree
+      - plant
     string_serialization: '{term label}{term ID}'
     slot_uri: MIXS:0001120
   plant_product:
@@ -10266,20 +10281,20 @@ slots:
     description: Substance produced by the plant, where the sample was obtained from
     title: plant product
     examples:
-    - value: xylem sap [PO:0025539]
+      - value: xylem sap [PO:0025539]
     keywords:
-    - plant
-    - product
-    string_serialization: '{text}'
+      - plant
+      - product
+    range: string
     slot_uri: MIXS:0001058
   plant_reprod_crop:
     description: Plant reproductive part used in the field during planting to start
       the crop
     title: plant reproductive part
     examples:
-    - value: seedling
+      - value: seedling
     keywords:
-    - plant
+      - plant
     slot_uri: MIXS:0001150
     multivalued: true
     range: PlantReprodCropEnum
@@ -10288,9 +10303,9 @@ slots:
       staminate, monoecieous, hermaphrodite
     title: plant sex
     examples:
-    - value: Hermaphroditic
+      - value: Hermaphroditic
     keywords:
-    - plant
+      - plant
     slot_uri: MIXS:0001059
     range: PlantSexEnum
   plant_struc:
@@ -10300,9 +10315,9 @@ slots:
       sex of it can be recorded here
     title: plant structure
     examples:
-    - value: epidermis [PO:0005679]
+      - value: epidermis [PO:0005679]
     keywords:
-    - plant
+      - plant
     slot_uri: MIXS:0001060
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -10316,12 +10331,12 @@ slots:
       Multiple terms can be separated by pipes
     title: plant water delivery method
     examples:
-    - value: drip irrigation process [AGRO:00000056]
+      - value: drip irrigation process [AGRO:00000056]
     keywords:
-    - delivery
-    - method
-    - plant
-    - water
+      - delivery
+      - method
+      - plant
+      - water
     slot_uri: MIXS:0001111
     range: string
     recommended: true
@@ -10339,9 +10354,9 @@ slots:
       to http://purl.bioontology.org/ontology/PATO
     title: ploidy
     examples:
-    - value: allopolyploidy [PATO:0001379]
+      - value: allopolyploidy [PATO:0001379]
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     slot_uri: MIXS:0000021
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
@@ -10358,7 +10373,7 @@ slots:
       by name of pollutant
     title: pollutants
     examples:
-    - value: lead;0.15 microgram per cubic meter
+      - value: lead;0.15 microgram per cubic meter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000107
     multivalued: true
@@ -10370,10 +10385,10 @@ slots:
       yes, the number of extracts that were pooled should be given
     title: pooling of DNA extracts (if done)
     examples:
-    - value: yes, 5
+      - value: yes, 5
     keywords:
-    - dna
-    - pooling
+      - dna
+      - pooling
     slot_uri: MIXS:0000325
   porosity:
     annotations:
@@ -10383,7 +10398,7 @@ slots:
       total volume of sample
     title: porosity
     keywords:
-    - porosity
+      - porosity
     string_serialization: '{float} - {float} {unit}'
     slot_uri: MIXS:0000211
   pos_cont_type:
@@ -10391,9 +10406,9 @@ slots:
       a process which is part of an investigation delivers a true positive
     title: positive control type
     in_subset:
-    - investigation
+      - investigation
     keywords:
-    - type
+      - type
     string_serialization: '{term} or {text}'
     slot_uri: MIXS:0001322
     recommended: true
@@ -10403,7 +10418,7 @@ slots:
     description: Concentration of potassium in the sample
     title: potassium
     examples:
-    - value: 463 milligram per liter
+      - value: 463 milligram per liter
     slot_uri: MIXS:0000430
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10434,17 +10449,17 @@ slots:
     description: The process of pre-treatment removes materials that can be easily
       collected from the raw wastewater
     title: pre-treatment
-    string_serialization: '{text}'
+    range: string
     slot_uri: MIXS:0000348
   pred_genome_struc:
     description: Expected structure of the viral genome
     title: predicted genome structure
     examples:
-    - value: non-segmented
+      - value: non-segmented
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - predict
+      - predict
     slot_uri: MIXS:0000083
     range: PredGenomeStrucEnum
   pred_genome_type:
@@ -10453,19 +10468,19 @@ slots:
     description: Type of genome predicted for the UViG
     title: predicted genome type
     examples:
-    - value: dsDNA
+      - value: dsDNA
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - predict
-    - type
+      - predict
+      - type
     string_serialization: '[DNA|dsDNA|ssDNA|RNA|dsRNA|ssRNA|ssRNA (+)|ssRNA (-)|mixed|uncharacterized]'
     slot_uri: MIXS:0000082
   pregnancy:
     description: Date due of pregnancy
     title: pregnancy
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     slot_uri: MIXS:0000966
     range: datetime
   pres_animal_insect:
@@ -10475,10 +10490,10 @@ slots:
       space
     title: presence of pets, animals, or insects
     examples:
-    - value: cat;5
+      - value: cat;5
     keywords:
-    - animal
-    - presence
+      - animal
+      - presence
     string_serialization: '[cat|dog|rodent|snake|other];{integer}'
     slot_uri: MIXS:0000819
   pressure:
@@ -10487,9 +10502,9 @@ slots:
     description: Pressure to which the sample is subject to, in atmospheres
     title: pressure
     examples:
-    - value: 50 atmosphere
+      - value: 50 atmosphere
     keywords:
-    - pressure
+      - pressure
     slot_uri: MIXS:0000412
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10502,10 +10517,10 @@ slots:
     description: Reference or method used in determining previous land use and dates
     title: history/previous land use method
     keywords:
-    - history
-    - land
-    - method
-    - use
+      - history
+      - land
+      - method
+      - use
     slot_uri: MIXS:0000316
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -10519,11 +10534,11 @@ slots:
     description: Previous land use and dates
     title: history/previous land use
     examples:
-    - value: fallow; 2018-05-11:T14:30Z
+      - value: fallow; 2018-05-11:T14:30Z
     keywords:
-    - history
-    - land
-    - use
+      - history
+      - land
+      - use
     string_serialization: '{text};{timestamp}'
     slot_uri: MIXS:0000315
   primary_prod:
@@ -10533,10 +10548,10 @@ slots:
       uptake
     title: primary production
     examples:
-    - value: 100 milligram per cubic meter per day
+      - value: 100 milligram per cubic meter per day
     keywords:
-    - primary
-    - production
+      - primary
+      - production
     slot_uri: MIXS:0000728
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10553,9 +10568,9 @@ slots:
       processed
     title: primary treatment
     keywords:
-    - primary
-    - treatment
-    string_serialization: '{text}'
+      - primary
+      - treatment
+    range: string
     slot_uri: MIXS:0000349
   prod_label_claims:
     description: Labeling claims containing descriptors such as wild caught, free-range,
@@ -10563,9 +10578,9 @@ slots:
       include more than one term, separated by ";"
     title: production labeling claims
     examples:
-    - value: free range
+      - value: free range
     keywords:
-    - production
+      - production
     slot_uri: MIXS:prod_label_claims
     multivalued: true
     range: string
@@ -10575,8 +10590,8 @@ slots:
     description: Oil and/or gas production rates per well (e.g. 524 m3 / day)
     title: production rate
     keywords:
-    - production
-    - rate
+      - production
+      - rate
     slot_uri: MIXS:0000452
     range: string
     recommended: true
@@ -10590,11 +10605,11 @@ slots:
     description: Date of field's first production
     title: production start date
     examples:
-    - value: '2013-03-25T12:42:31+01:00'
+      - value: '2013-03-25T12:42:31+01:00'
     keywords:
-    - date
-    - production
-    - start
+      - date
+      - production
+      - start
     slot_uri: MIXS:0001008
     range: datetime
     recommended: true
@@ -10603,18 +10618,18 @@ slots:
       area position in relation to surrounding areas
     title: profile position
     examples:
-    - value: summit
+      - value: summit
     slot_uri: MIXS:0001084
     range: ProfilePositionEnum
   project_name:
     description: Name of the project within which the sequencing was organized
     title: project name
     examples:
-    - value: Forest soil metagenome
+      - value: Forest soil metagenome
     in_subset:
-    - investigation
+      - investigation
     keywords:
-    - project
+      - project
     slot_uri: MIXS:0000092
     range: string
     required: true
@@ -10628,10 +10643,10 @@ slots:
       lytic. For plasmids: incompatibility group. For eukaryotes: sexual/asexual'
     title: propagation
     examples:
-    - value: lytic
+      - value: lytic
     in_subset:
-    - nucleic acid sequence source
-    string_serialization: '{text}'
+      - nucleic acid sequence source
+    range: string
     slot_uri: MIXS:0000033
   pulmonary_disord:
     description: History of pulmonary disorders; can include multiple disorders. The
@@ -10639,7 +10654,7 @@ slots:
       lung disease (https://disease-ontology.org/?id=DOID:850)
     title: lung/pulmonary disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000269
     multivalued: true
     range: string
@@ -10647,7 +10662,7 @@ slots:
     description: The quadrant position of the sampling room within the building
     title: quadrant position
     examples:
-    - value: West side
+      - value: West side
     slot_uri: MIXS:0000820
     range: QuadPosEnum
   radiation_regm:
@@ -10661,9 +10676,9 @@ slots:
       the entire treatment; can include multiple radiation regimens
     title: radiation regimen
     examples:
-    - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
+      - regimen
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000575
     multivalued: true
@@ -10677,10 +10692,10 @@ slots:
       can include multiple regimens
     title: rainfall regimen
     examples:
-    - value: 15 millimeter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: 15 millimeter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - rain
-    - regimen
+      - rain
+      - regimen
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000576
     multivalued: true
@@ -10692,19 +10707,19 @@ slots:
       high solid or low solid, and single stage or multistage
     title: reactor type
     keywords:
-    - type
-    string_serialization: '{text}'
+      - type
+    range: string
     slot_uri: MIXS:0000350
   reassembly_bin:
     description: Has an assembly been performed on a genome bin extracted from a metagenomic
       assembly?
     title: reassembly post binning
     examples:
-    - value: 'no'
+      - value: 'no'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - post
+      - post
     slot_uri: MIXS:0000079
     range: boolean
   redox_potential:
@@ -10714,7 +10729,7 @@ slots:
       oxidation or reduction potential
     title: redox potential
     examples:
-    - value: 300 millivolt
+      - value: 300 millivolt
     slot_uri: MIXS:0000182
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10728,9 +10743,9 @@ slots:
       primary genome report
     title: reference for biomaterial
     examples:
-    - value: doi:10.1016/j.syapm.2018.01.009
+      - value: doi:10.1016/j.syapm.2018.01.009
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     slot_uri: MIXS:0000025
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -10745,12 +10760,12 @@ slots:
       and reference to website or publication
     title: reference database(s)
     examples:
-    - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017
-        doi:10.1093/nar/gkw975
+      - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017
+          doi:10.1093/nar/gkw975
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - database
+      - database
     string_serialization: '{database};{version};{reference}'
     slot_uri: MIXS:0000062
   rel_air_humidity:
@@ -10760,13 +10775,13 @@ slots:
       by the actual mass of the vapor and air
     title: relative air humidity
     comments:
-    - percent or float?
+      - percent or float?
     examples:
-    - value: '0.8'
+      - value: '0.8'
     keywords:
-    - air
-    - humidity
-    - relative
+      - air
+      - humidity
+      - relative
     slot_uri: MIXS:0000121
     range: float
     required: true
@@ -10782,10 +10797,10 @@ slots:
     description: The recorded outside relative humidity value at the time of sampling
     title: outside relative humidity
     examples:
-    - value: 12 per kilogram of air
+      - value: 12 per kilogram of air
     keywords:
-    - humidity
-    - relative
+      - humidity
+      - relative
     slot_uri: MIXS:0000188
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10799,21 +10814,21 @@ slots:
       plant, near irrigation ditch, from the dirt road
     title: relative location of sample
     examples:
-    - value: furrow
+      - value: furrow
     keywords:
-    - location
-    - relative
-    - sample
+      - location
+      - relative
+      - sample
     slot_uri: MIXS:0001161
     range: string
   rel_samp_loc:
     description: The sampling location within the train car
     title: relative sampling location
     examples:
-    - value: center of car
+      - value: center of car
     keywords:
-    - location
-    - relative
+      - location
+      - relative
     slot_uri: MIXS:0000821
     range: RelSampLocEnum
   rel_to_oxygen:
@@ -10821,12 +10836,12 @@ slots:
       anaerobic are valid descriptors for microbial environments
     title: relationship to oxygen
     examples:
-    - value: aerobe
+      - value: aerobe
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - oxygen
-    - relationship
+      - oxygen
+      - relationship
     slot_uri: MIXS:0000015
     range: RelToOxygenEnum
   repository_name:
@@ -10837,8 +10852,8 @@ slots:
       or otherwise not retained
     title: repository name
     examples:
-    - value: FDA CFSAN Microbiology Laboratories
-    string_serialization: '{text}'
+      - value: FDA CFSAN Microbiology Laboratories
+    range: string
     slot_uri: MIXS:0001152
     multivalued: true
   reservoir:
@@ -10870,9 +10885,9 @@ slots:
     description: The rate at which outside air replaces indoor air in a given space
     title: room air exchange rate
     keywords:
-    - air
-    - rate
-    - room
+      - air
+      - rate
+      - room
     slot_uri: MIXS:0000169
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -10886,27 +10901,27 @@ slots:
       of a distinguisahable space within a built structure
     title: room architectural elements
     keywords:
-    - room
+      - room
     slot_uri: MIXS:0000233
     range: string
   room_condt:
     description: The condition of the room at the time of sampling
     title: room condition
     examples:
-    - value: new
+      - value: new
     keywords:
-    - condition
-    - room
+      - condition
+      - room
     slot_uri: MIXS:0000822
     range: RoomCondtEnum
   room_connected:
     description: List of rooms connected to the sampling room by a doorway
     title: rooms connected by a doorway
     examples:
-    - value: office
+      - value: office
     keywords:
-    - doorway
-    - room
+      - doorway
+      - room
     slot_uri: MIXS:0000826
     range: RoomConnectedEnum
   room_count:
@@ -10914,8 +10929,8 @@ slots:
       types
     title: room count
     keywords:
-    - count
-    - room
+      - count
+      - room
     slot_uri: MIXS:0000234
     range: integer
   room_dim:
@@ -10925,10 +10940,10 @@ slots:
     description: The length, width and height of sampling room
     title: room dimensions
     examples:
-    - value: 4 meter x 4 meter x 4 meter
+      - value: 4 meter x 4 meter x 4 meter
     keywords:
-    - dimensions
-    - room
+      - dimensions
+      - room
     string_serialization: '{integer} {unit} x {integer} {unit} x {integer} {unit}'
     slot_uri: MIXS:0000192
   room_door_dist:
@@ -10938,9 +10953,9 @@ slots:
       room and adjacent rooms
     title: room door distance
     keywords:
-    - distance
-    - door
-    - room
+      - distance
+      - door
+      - room
     slot_uri: MIXS:0000193
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -10953,8 +10968,8 @@ slots:
       sampling room
     title: rooms that share a door with sampling room
     keywords:
-    - door
-    - room
+      - door
+      - room
     slot_uri: MIXS:0000242
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -10967,8 +10982,8 @@ slots:
       as sampling room
     title: rooms that are on the same hallway
     keywords:
-    - hallway
-    - room
+      - hallway
+      - room
     slot_uri: MIXS:0000238
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -10980,10 +10995,10 @@ slots:
     description: The position of the room within the building
     title: room location in building
     examples:
-    - value: interior room
+      - value: interior room
     keywords:
-    - location
-    - room
+      - location
+      - room
     slot_uri: MIXS:0000823
     range: RoomLocEnum
   room_moist_dam_hist:
@@ -10991,9 +11006,9 @@ slots:
       of events of moisture damage or mold observed
     title: room moisture damage or mold history
     keywords:
-    - history
-    - moisture
-    - room
+      - history
+      - moisture
+      - room
     slot_uri: MIXS:0000235
     range: integer
   room_net_area:
@@ -11002,8 +11017,8 @@ slots:
     description: The net floor area of sampling room. Net area excludes wall thicknesses
     title: room net area
     keywords:
-    - area
-    - room
+      - area
+      - room
     slot_uri: MIXS:0000194
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11015,7 +11030,7 @@ slots:
     description: Count of room occupancy at time of sampling
     title: room occupancy
     keywords:
-    - room
+      - room
     slot_uri: MIXS:0000236
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11028,9 +11043,9 @@ slots:
       elements
     title: room sampling position
     examples:
-    - value: south corner
+      - value: south corner
     keywords:
-    - room
+      - room
     slot_uri: MIXS:0000824
     range: RoomSampPosEnum
   room_type:
@@ -11040,10 +11055,10 @@ slots:
       distinguishable space within a structure
     title: room type
     examples:
-    - value: bathroom
+      - value: bathroom
     keywords:
-    - room
-    - type
+      - room
+      - type
     string_serialization: '[attic|bathroom|closet|conference room|elevator|examining
       room|hallway|kitchen|mail room|private office|open office|stairwell|,restroom|lobby|vestibule|mechanical
       or electrical room|data center|laboratory_wet|laboratory_dry|gymnasium|natatorium|auditorium|lockers|cafe|warehouse]'
@@ -11054,8 +11069,8 @@ slots:
     description: Volume of sampling room
     title: room volume
     keywords:
-    - room
-    - volume
+      - room
+      - volume
     slot_uri: MIXS:0000195
     range: string
     pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11068,8 +11083,8 @@ slots:
       sampling room
     title: rooms that share a wall with sampling room
     keywords:
-    - room
-    - wall
+      - room
+      - wall
     slot_uri: MIXS:0000243
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
@@ -11081,9 +11096,9 @@ slots:
     description: Number of windows in the room
     title: room window count
     keywords:
-    - count
-    - room
-    - window
+      - count
+      - room
+      - window
     slot_uri: MIXS:0000237
     range: integer
   root_cond:
@@ -11091,9 +11106,9 @@ slots:
       container dimensions, number of plants per container
     title: rooting conditions
     examples:
-    - value: http://himedialabs.com/TD/PT158.pdf
+      - value: http://himedialabs.com/TD/PT158.pdf
     keywords:
-    - condition
+      - condition
     slot_uri: MIXS:0001061
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11108,9 +11123,9 @@ slots:
     description: Source of organic carbon in the culture rooting medium; e.g. sucrose
     title: rooting medium carbon
     examples:
-    - value: sucrose
+      - value: sucrose
     keywords:
-    - carbon
+      - carbon
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000577
   root_med_macronutr:
@@ -11121,9 +11136,9 @@ slots:
       Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
     title: rooting medium macronutrients
     examples:
-    - value: KH2PO4;170  milligram per liter
+      - value: KH2PO4;170  milligram per liter
     keywords:
-    - macronutrients
+      - macronutrients
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000578
   root_med_micronutr:
@@ -11134,18 +11149,18 @@ slots:
       Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
     title: rooting medium micronutrients
     examples:
-    - value: H3BO3;6.2  milligram per liter
+      - value: H3BO3;6.2  milligram per liter
     keywords:
-    - micronutrients
+      - micronutrients
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000579
   root_med_ph:
     description: pH measurement of the culture rooting medium; e.g. 5.5
     title: rooting medium pH
     examples:
-    - value: '7.5'
+      - value: '7.5'
     keywords:
-    - ph
+      - ph
     slot_uri: MIXS:0001062
     range: float
   root_med_regl:
@@ -11156,7 +11171,7 @@ slots:
       auxins, gybberellins, abscisic acid; e.g. 0.5  mg/L NAA
     title: rooting medium regulators
     examples:
-    - value: abscisic acid;0.75 milligram per liter
+      - value: abscisic acid;0.75 milligram per liter
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000581
   root_med_solid:
@@ -11164,7 +11179,7 @@ slots:
       e.g. agar
     title: rooting medium solidifier
     examples:
-    - value: agar
+      - value: agar
     slot_uri: MIXS:0001063
     range: string
   root_med_suppl:
@@ -11176,9 +11191,9 @@ slots:
       (0.5  mg/L)
     title: rooting medium organic supplements
     examples:
-    - value: nicotinic acid;0.5 milligram per liter
+      - value: nicotinic acid;0.5 milligram per liter
     keywords:
-    - organic
+      - organic
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000580
   route_transmission:
@@ -11188,7 +11203,7 @@ slots:
       in mode_transmission)
     title: route of transmission
     keywords:
-    - route
+      - route
     slot_uri: MIXS:0001316
     range: RouteTransmissionEnum
   salinity:
@@ -11202,9 +11217,9 @@ slots:
       seawater
     title: salinity
     examples:
-    - value: 25 practical salinity unit
+      - value: 25 practical salinity unit
     keywords:
-    - salinity
+      - salinity
     slot_uri: MIXS:0000183
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11223,10 +11238,10 @@ slots:
       include multiple salt regimens
     title: salt regimen
     examples:
-    - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
-    - salt
+      - regimen
+      - salt
     slot_uri: MIXS:0000582
     multivalued: true
     range: string
@@ -11234,10 +11249,10 @@ slots:
     description: Reason for the sample
     title: sample capture status
     examples:
-    - value: farm sample
+      - value: farm sample
     keywords:
-    - sample
-    - status
+      - sample
+      - status
     slot_uri: MIXS:0000860
     range: SampCaptStatusEnum
   samp_collect_device:
@@ -11248,20 +11263,20 @@ slots:
       This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094)
     title: sample collection device
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - device
-    - sample
+      - device
+      - sample
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000002
   samp_collect_method:
     description: The method employed for collecting the sample
     title: sample collection method
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - method
-    - sample
+      - method
+      - sample
     slot_uri: MIXS:0001225
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11275,9 +11290,9 @@ slots:
       in "additional info" field
     title: sample collection point
     examples:
-    - value: well
+      - value: well
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0001015
     range: SampCollectPointEnum
     required: true
@@ -11286,10 +11301,10 @@ slots:
       penetration, infection, growth and reproduction, dissemination of pathogen
     title: sample disease stage
     examples:
-    - value: infection
+      - value: infection
     keywords:
-    - disease
-    - sample
+      - disease
+      - sample
     slot_uri: MIXS:0000249
     range: SampDisStageEnum
   samp_floor:
@@ -11298,20 +11313,20 @@ slots:
     description: The floor of the building, where the sampling room is located
     title: sampling floor
     examples:
-    - value: 4th floor
+      - value: 4th floor
     keywords:
-    - floor
+      - floor
     string_serialization: '[1st floor|2nd floor|{integer} floor|basement|lobby]'
     slot_uri: MIXS:0000828
   samp_loc_condition:
     description: The condition of the sample location at the time of sampling
     title: sample location condition
     examples:
-    - value: new
+      - value: new
     keywords:
-    - condition
-    - location
-    - sample
+      - condition
+      - location
+      - sample
     slot_uri: MIXS:0001257
     range: SampLocConditionEnum
   samp_loc_corr_rate:
@@ -11326,9 +11341,9 @@ slots:
       in MIC as well as potential microbial interplays
     title: corrosion rate at sample location
     keywords:
-    - location
-    - rate
-    - sample
+      - location
+      - rate
+      - sample
     slot_uri: MIXS:0000136
     range: string
     recommended: true
@@ -11343,13 +11358,13 @@ slots:
       performed
     title: sample material processing
     examples:
-    - value: filtering of seawater, storing samples in ethanol
+      - value: filtering of seawater, storing samples in ethanol
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - material
-    - process
-    - sample
+      - material
+      - process
+      - sample
     slot_uri: MIXS:0000016
     range: string
   samp_md:
@@ -11364,11 +11379,11 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: sample measured depth
     examples:
-    - value: 1534 meter;MSL
+      - value: 1534 meter;MSL
     keywords:
-    - depth
-    - measurement
-    - sample
+      - depth
+      - measurement
+      - sample
     string_serialization: '{float} {unit};[GL|DF|RT|KB|MSL|other]'
     slot_uri: MIXS:0000413
   samp_name:
@@ -11383,11 +11398,11 @@ slots:
       field source_mat_id is recommended in addition to sample_name
     title: sample name
     examples:
-    - value: ISDsoil1
+      - value: ISDsoil1
     in_subset:
-    - investigation
+      - investigation
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0001107
     range: string
     required: true
@@ -11397,10 +11412,10 @@ slots:
       cells. Please provide a short description of the samples that were pooled
     title: sample pooling
     examples:
-    - value: 5uL of extracted genomic DNA from 5 leaves were pooled
+      - value: 5uL of extracted genomic DNA from 5 leaves were pooled
     keywords:
-    - pooling
-    - sample
+      - pooling
+      - sample
     slot_uri: MIXS:0001153
     multivalued: true
     range: string
@@ -11411,7 +11426,7 @@ slots:
       etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)
     title: preservative added to sample
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0000463
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -11425,9 +11440,9 @@ slots:
     description: The reason that the sample was collected
     title: purpose of sampling
     examples:
-    - value: field trial
+      - value: field trial
     keywords:
-    - purpose
+      - purpose
     string_serialization: '[active surveillance in response to an outbreak|active
       surveillance not initiated by an outbreak|clinical trial|cluster investigation|environmental
       assessment|farm sample|field trial|for cause|industry internal investigation|market
@@ -11439,9 +11454,9 @@ slots:
       variation
     title: biological sample replicate
     examples:
-    - value: 6 replicates
+      - value: 6 replicates
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0001226
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11455,9 +11470,9 @@ slots:
       of the noise associated with the equipment and the protocols
     title: technical sample replicate
     examples:
-    - value: 10 replicates
+      - value: 10 replicates
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0001227
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11471,8 +11486,8 @@ slots:
       on the building floor plans
     title: sampling room ID or name
     keywords:
-    - identifier
-    - room
+      - identifier
+      - room
     slot_uri: MIXS:0000244
     range: integer
   samp_size:
@@ -11480,12 +11495,12 @@ slots:
       sample collected
     title: amount or size of sample collected
     examples:
-    - value: 5 liter
+      - value: 5 liter
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - sample
-    - size
+      - sample
+      - size
     slot_uri: MIXS:0000001
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11501,9 +11516,9 @@ slots:
       in a cascade impactor
     title: sample size sorting method
     keywords:
-    - method
-    - sample
-    - size
+      - method
+      - sample
+      - size
     slot_uri: MIXS:0000216
     multivalued: true
     range: string
@@ -11516,11 +11531,11 @@ slots:
       or http://purl.obolibrary.org/obo/OBI_0100051)
     title: sample source material category
     examples:
-    - value: environmental (swab or sampling) [GENEPIO:0001732]
+      - value: environmental (swab or sampling) [GENEPIO:0001732]
     keywords:
-    - material
-    - sample
-    - source
+      - material
+      - sample
+      - source
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0001154
   samp_stor_device:
@@ -11531,11 +11546,11 @@ slots:
       proper descriptor is not listed please use text to describe the storage device
     title: sample storage device
     examples:
-    - value: Whirl Pak sampling bag [GENEPIO:0002122]
+      - value: Whirl Pak sampling bag [GENEPIO:0002122]
     keywords:
-    - device
-    - sample
-    - storage
+      - device
+      - sample
+      - storage
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001228
   samp_stor_media:
@@ -11547,10 +11562,10 @@ slots:
       storage media
     title: sample storage media
     examples:
-    - value: peptone water medium [MICRO:0000548]
+      - value: peptone water medium [MICRO:0000548]
     keywords:
-    - sample
-    - storage
+      - sample
+      - storage
     slot_uri: MIXS:0001229
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
@@ -11563,12 +11578,12 @@ slots:
       which the sample was stored written in ISO 8601 format
     title: sample storage duration
     examples:
-    - value: P1Y6M
+      - value: P1Y6M
     keywords:
-    - duration
-    - period
-    - sample
-    - storage
+      - duration
+      - period
+      - sample
+      - storage
     slot_uri: MIXS:0000116
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -11582,12 +11597,12 @@ slots:
     description: Location at which sample was stored, usually name of a specific freezer/room
     title: sample storage location
     examples:
-    - value: Freezer no:5
+      - value: Freezer no:5
     keywords:
-    - location
-    - sample
-    - storage
-    string_serialization: '{text}'
+      - location
+      - sample
+      - storage
+    range: string
     slot_uri: MIXS:0000755
   samp_store_sol:
     annotations:
@@ -11595,11 +11610,11 @@ slots:
     description: Solution within which sample was stored, if any
     title: sample storage solution
     examples:
-    - value: 5% ethanol
+      - value: 5% ethanol
     keywords:
-    - sample
-    - storage
-    string_serialization: '{text}'
+      - sample
+      - storage
+    range: string
     slot_uri: MIXS:0001317
   samp_store_temp:
     annotations:
@@ -11607,11 +11622,11 @@ slots:
     description: Temperature at which sample was stored, e.g. -80 degree Celsius
     title: sample storage temperature
     examples:
-    - value: -80 degree Celsius
+      - value: -80 degree Celsius
     keywords:
-    - sample
-    - storage
-    - temperature
+      - sample
+      - storage
+      - temperature
     slot_uri: MIXS:0000110
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11626,9 +11641,9 @@ slots:
       please propose entry in "additional info" field
     title: sample subtype
     examples:
-    - value: biofilm
+      - value: biofilm
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0000999
     range: SampSubtypeEnum
     recommended: true
@@ -11638,11 +11653,11 @@ slots:
       If no surface moisture is present indicate not present
     title: sample surface moisture
     examples:
-    - value: submerged
+      - value: submerged
     keywords:
-    - moisture
-    - sample
-    - surface
+      - moisture
+      - sample
+      - surface
     slot_uri: MIXS:0001256
     multivalued: true
     range: SampSurfMoistureEnum
@@ -11652,14 +11667,14 @@ slots:
       'blank sample' for negative controls
     title: taxonomy ID of DNA sample
     examples:
-    - value: Gut Metagenome [NCBITaxon:749906]
+      - value: Gut Metagenome [NCBITaxon:749906]
     in_subset:
-    - investigation
+      - investigation
     keywords:
-    - dna
-    - identifier
-    - sample
-    - taxon
+      - dna
+      - identifier
+      - sample
+      - taxon
     slot_uri: MIXS:0001320
     range: string
     required: true
@@ -11675,7 +11690,7 @@ slots:
     description: The recent and long term history of outside sampling
     title: sampling time outside
     keywords:
-    - time
+      - time
     string_serialization: '{float}'
     slot_uri: MIXS:0000196
   samp_transport_cond:
@@ -11686,11 +11701,11 @@ slots:
       was exposed to (e.g. 5.5 days; 20   C)
     title: sample transport conditions
     examples:
-    - value: 5 days;-20 degree Celsius
+      - value: 5 days;-20 degree Celsius
     keywords:
-    - condition
-    - sample
-    - transport
+      - condition
+      - sample
+      - transport
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000410
   samp_transport_cont:
@@ -11698,10 +11713,10 @@ slots:
       the location name
     title: sample transport  container
     examples:
-    - value: cooler
+      - value: cooler
     keywords:
-    - sample
-    - transport
+      - sample
+      - transport
     slot_uri: MIXS:0001230
     range: SampTransportContEnum
   samp_transport_dur:
@@ -11711,12 +11726,12 @@ slots:
       Indicate the duration for which the sample was stored written in ISO 8601 format
     title: sample transport duration
     examples:
-    - value: P10D
+      - value: P10D
     keywords:
-    - duration
-    - period
-    - sample
-    - transport
+      - duration
+      - period
+      - sample
+      - transport
     slot_uri: MIXS:0001231
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -11732,11 +11747,11 @@ slots:
       Celsius
     title: sample transport temperature
     examples:
-    - value: 4 degree Celsius
+      - value: 4 degree Celsius
     keywords:
-    - sample
-    - temperature
-    - transport
+      - sample
+      - temperature
+      - transport
     string_serialization: '{float} {unit} {text}'
     slot_uri: MIXS:0001232
   samp_tvdss:
@@ -11748,8 +11763,8 @@ slots:
       for subsurface samples e.g. 1325.75-1362.25 m
     title: sample true vertical depth subsea
     keywords:
-    - depth
-    - sample
+      - depth
+      - sample
     string_serialization: '{float}-{float} {unit}'
     slot_uri: MIXS:0000409
     recommended: true
@@ -11762,10 +11777,10 @@ slots:
       This field accepts terms listed under environmental specimen (http://purl.obolibrary.org/obo/GENEPIO_0001246)
     title: sample type
     examples:
-    - value: built environment sample [GENEPIO:0001248]
+      - value: built environment sample [GENEPIO:0001248]
     keywords:
-    - sample
-    - type
+      - sample
+      - type
     slot_uri: MIXS:0000998
     range: string
     required: true
@@ -11782,14 +11797,14 @@ slots:
       Sample Size (MIXS:0000001)'
     title: sample volume or weight for DNA extraction
     examples:
-    - value: 1500 milliliter
+      - value: 1500 milliliter
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - dna
-    - sample
-    - volume
-    - weight
+      - dna
+      - sample
+      - volume
+      - weight
     slot_uri: MIXS:0000111
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11802,17 +11817,17 @@ slots:
     description: The weather on the sampling day
     title: sampling day weather
     examples:
-    - value: foggy
+      - value: foggy
     keywords:
-    - day
-    - weather
+      - day
+      - weather
     slot_uri: MIXS:0000827
     range: SampWeatherEnum
   samp_well_name:
     description: Name of the well (e.g. BXA1123) where sample was taken
     title: sample well name
     keywords:
-    - sample
+      - sample
     slot_uri: MIXS:0000296
     range: string
     recommended: true
@@ -11837,12 +11852,12 @@ slots:
     description: Method used to free DNA from interior of the cell(s) or particle(s)
     title: single cell or viral particle lysis approach
     examples:
-    - value: enzymatic
+      - value: enzymatic
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - particle
-    - single
+      - particle
+      - single
     slot_uri: MIXS:0000076
     range: ScLysisApproachEnum
   sc_lysis_method:
@@ -11852,31 +11867,31 @@ slots:
       lysis
     title: single cell or viral particle lysis kit protocol
     examples:
-    - value: ambion single cell lysis kit
+      - value: ambion single cell lysis kit
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - kit
-    - particle
-    - protocol
-    - single
-    string_serialization: '{text}'
+      - kit
+      - particle
+      - protocol
+      - single
+    range: string
     slot_uri: MIXS:0000054
   season:
     annotations:
       Expected_value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732], winter
-          [NCIT:C94730]
+        [NCIT:C94730]
     description: The season when sampling occurred. Any of the four periods into which
       the year is divided by the equinoxes and solstices. This field accepts terms
       listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
     title: season
     comments:
-    - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
-    - would require ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:[a-zA-Z0-9]\\]$
+      - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
+      - would require ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:[a-zA-Z0-9]\\]$
     examples:
-    - value: autumn [NCIT:C94733]
+      - value: autumn [NCIT:C94733]
     keywords:
-    - season
+      - season
     string_serialization: '{termLabel} [{termID}]'
     slot_uri: MIXS:0000829
     range: string
@@ -11888,10 +11903,10 @@ slots:
       the entire treatment
     title: seasonal environment
     examples:
-    - value: rainy;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: rainy;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - environment
-    - season
+      - environment
+      - season
     slot_uri: MIXS:0001068
     multivalued: true
     range: string
@@ -11899,13 +11914,13 @@ slots:
     description: Average humidity of the region throughout the growing season
     title: mean seasonal humidity
     comments:
-    - percent or float?
+      - percent or float?
     examples:
-    - value: '0.25'
+      - value: '0.25'
     keywords:
-    - humidity
-    - mean
-    - season
+      - humidity
+      - mean
+      - season
     slot_uri: MIXS:0001148
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11921,10 +11936,10 @@ slots:
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean seasonal precipitation
     examples:
-    - value: 75 millimeters
+      - value: 75 millimeters
     keywords:
-    - mean
-    - season
+      - mean
+      - season
     slot_uri: MIXS:0000645
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11939,11 +11954,11 @@ slots:
     description: Mean seasonal temperature
     title: mean seasonal temperature
     examples:
-    - value: 18 degree Celsius
+      - value: 18 degree Celsius
     keywords:
-    - mean
-    - season
-    - temperature
+      - mean
+      - season
+      - temperature
     slot_uri: MIXS:0000643
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -11956,10 +11971,10 @@ slots:
     description: The seasons the space is occupied
     title: seasonal use
     examples:
-    - value: Winter
+      - value: Winter
     keywords:
-    - season
-    - use
+      - season
+      - use
     slot_uri: MIXS:0000830
     range: SeasonUseEnum
   secondary_treatment:
@@ -11969,18 +11984,18 @@ slots:
       the sewage
     title: secondary treatment
     keywords:
-    - secondary
-    - treatment
-    string_serialization: '{text}'
+      - secondary
+      - treatment
+    range: string
     slot_uri: MIXS:0000351
   sediment_type:
     description: Information about the sediment type based on major constituents
     title: sediment type
     examples:
-    - value: biogenous
+      - value: biogenous
     keywords:
-    - sediment
-    - type
+      - sediment
+      - type
     slot_uri: MIXS:0001078
     range: SedimentTypeEnum
   seq_meth:
@@ -11988,11 +12003,11 @@ slots:
       from the OBI list of DNA sequencers (http://purl.obolibrary.org/obo/OBI_0400103)
     title: sequencing method
     examples:
-    - value: 454 Genome Sequencer FLX [OBI:0000702]
+      - value: 454 Genome Sequencer FLX [OBI:0000702]
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - method
+      - method
     slot_uri: MIXS:0000050
     range: string
     required: true
@@ -12010,11 +12025,11 @@ slots:
       or DRA
     title: sequence quality check
     examples:
-    - value: none
+      - value: none
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - quality
+      - quality
     slot_uri: MIXS:0000051
     range: SeqQualityCheckEnum
   sequencing_kit:
@@ -12027,19 +12042,19 @@ slots:
       kit
     title: sequencing kit
     examples:
-    - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
+      - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
     keywords:
-    - kit
-    string_serialization: '{text}'
+      - kit
+    range: string
     slot_uri: MIXS:0001155
   sequencing_location:
     description: The location the sequencing run was performed. Indicate the name
       of the lab or core facility where samples were sequenced
     title: sequencing location
     examples:
-    - value: University of Maryland Genomics Resource Center
+      - value: University of Maryland Genomics Resource Center
     keywords:
-    - location
+      - location
     slot_uri: MIXS:0001156
     range: string
   serovar_or_serotype:
@@ -12049,7 +12064,7 @@ slots:
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
     title: serovar or serotype
     examples:
-    - value: Escherichia coli strain O157:H7 [NCIT:C86883]
+      - value: Escherichia coli strain O157:H7 [NCIT:C86883]
     slot_uri: MIXS:0001157
     multivalued: true
     range: string
@@ -12064,43 +12079,43 @@ slots:
     description: Type of wastewater treatment plant as municipial or industrial
     title: sewage type
     keywords:
-    - type
-    string_serialization: '{text}'
+      - type
+    range: string
     slot_uri: MIXS:0000215
   sexual_act:
     annotations:
       Expected_value: partner sex;frequency
     description: Current sexual partner and frequency of sex
     title: sexual activity
-    string_serialization: '{text}'
+    range: string
     slot_uri: MIXS:0000285
   shad_dev_water_mold:
     description: Signs of the presence of mold or mildew on the shading device
     title: shading device signs of water/mold
     examples:
-    - value: no presence of mold visible
+      - value: no presence of mold visible
     keywords:
-    - device
+      - device
     slot_uri: MIXS:0000834
     range: MoldVisibilityEnum
   shading_device_cond:
     description: The physical condition of the shading device at the time of sampling
     title: shading device condition
     examples:
-    - value: new
+      - value: new
     keywords:
-    - condition
-    - device
+      - condition
+      - device
     slot_uri: MIXS:0000831
     range: DamagedRupturedEnum
   shading_device_loc:
     description: The location of the shading device in relation to the built structure
     title: shading device location
     examples:
-    - value: exterior
+      - value: exterior
     keywords:
-    - device
-    - location
+      - device
+      - location
     slot_uri: MIXS:0000832
     range: ShadingDeviceLocEnum
   shading_device_mat:
@@ -12109,19 +12124,19 @@ slots:
     description: The material the shading device is composed of
     title: shading device material
     keywords:
-    - device
-    - material
-    string_serialization: '{text}'
+      - device
+      - material
+    range: string
     slot_uri: MIXS:0000245
   shading_device_type:
     description: The type of shading device
     title: shading device type
     examples:
-    - value: slatted aluminum
-      description: was slatted aluminum awning
+      - value: slatted aluminum
+        description: was slatted aluminum awning
     keywords:
-    - device
-    - type
+      - device
+      - type
     slot_uri: MIXS:0000835
     range: ShadingDeviceTypeEnum
   sieving:
@@ -12138,7 +12153,7 @@ slots:
     description: Concentration of silicate
     title: silicate
     examples:
-    - value: 0.05 micromole per liter
+      - value: 0.05 micromole per liter
     slot_uri: MIXS:0000184
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12152,11 +12167,11 @@ slots:
       used
     title: similarity search method
     examples:
-    - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
+      - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - method
+      - method
     slot_uri: MIXS:0000063
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -12170,12 +12185,12 @@ slots:
     description: Filtering pore size used in sample preparation
     title: size fraction selected
     examples:
-    - value: 0-0.22 micrometer
+      - value: 0-0.22 micrometer
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - fraction
-    - size
+      - fraction
+      - size
     string_serialization: '{float}-{float} {unit}'
     slot_uri: MIXS:0000017
   size_frac_low:
@@ -12185,9 +12200,9 @@ slots:
       Materials larger than the size threshold are excluded from the sample
     title: size-fraction lower threshold
     examples:
-    - value: 0.2 micrometer
+      - value: 0.2 micrometer
     keywords:
-    - lower
+      - lower
     slot_uri: MIXS:0000735
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12203,9 +12218,9 @@ slots:
       smaller than the size threshold are excluded from the sample
     title: size-fraction upper threshold
     examples:
-    - value: 20 micrometer
+      - value: 20 micrometer
     keywords:
-    - upper
+      - upper
     slot_uri: MIXS:0000736
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12223,7 +12238,7 @@ slots:
       influence soil temperature and evapotranspiration
     title: slope aspect
     keywords:
-    - slope
+      - slope
     slot_uri: MIXS:0000647
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12240,7 +12255,7 @@ slots:
       measure is usually taken with a hand level meter or clinometer
     title: slope gradient
     keywords:
-    - slope
+      - slope
     slot_uri: MIXS:0000646
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12255,7 +12270,7 @@ slots:
     description: The time activated sludge remains in reactor
     title: sludge retention time
     keywords:
-    - time
+      - time
     slot_uri: MIXS:0000669
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12268,7 +12283,7 @@ slots:
     description: Specification of smoking status
     title: smoker
     examples:
-    - value: 'yes'
+      - value: 'yes'
     slot_uri: MIXS:0000262
     range: boolean
   sodium:
@@ -12277,7 +12292,7 @@ slots:
     description: Sodium concentration in the sample
     title: sodium
     examples:
-    - value: 10.5 milligram per liter
+      - value: 10.5 milligram per liter
     slot_uri: MIXS:0000428
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12291,9 +12306,9 @@ slots:
       Preferred_unit: milliSiemens per centimeter
     title: soil conductivity
     examples:
-    - value: 10 milliSiemens per centimeter
+      - value: 10 milliSiemens per centimeter
     keywords:
-    - soil
+      - soil
     slot_uri: MIXS:0001158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12309,9 +12324,9 @@ slots:
       ENVO:00010483, environmental material
     title: soil cover
     examples:
-    - value: bare soil [ENVO01001616]
+      - value: bare soil [ENVO01001616]
     keywords:
-    - soil
+      - soil
     string_serialization: bare soil [ENVO:01001616]
     slot_uri: MIXS:0001159
   soil_horizon:
@@ -12320,19 +12335,19 @@ slots:
       above and beneath
     title: soil horizon
     examples:
-    - value: A horizon
+      - value: A horizon
     keywords:
-    - horizon
-    - soil
+      - horizon
+      - soil
     slot_uri: MIXS:0001082
     range: SoilHorizonEnum
   soil_pH:
     title: soil pH
     examples:
-    - value: '7.2'
+      - value: '7.2'
     keywords:
-    - ph
-    - soil
+      - ph
+      - soil
     slot_uri: MIXS:0001160
     range: float
   soil_porosity:
@@ -12343,11 +12358,11 @@ slots:
       by the total volume of sample
     title: soil sediment porosity
     examples:
-    - value: '0.2'
+      - value: '0.2'
     keywords:
-    - porosity
-    - sediment
-    - soil
+      - porosity
+      - sediment
+      - soil
     string_serialization: '{percentage}'
     slot_uri: MIXS:0001162
   soil_temp:
@@ -12356,10 +12371,10 @@ slots:
     description: Temperature of soil at the time of sampling
     title: soil temperature
     examples:
-    - value: 25 degrees Celsius
+      - value: 25 degrees Celsius
     keywords:
-    - soil
-    - temperature
+      - soil
+      - temperature
     slot_uri: MIXS:0001163
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12375,8 +12390,8 @@ slots:
       clay loam) optional
     title: soil texture
     keywords:
-    - soil
-    - texture
+      - soil
+      - texture
     slot_uri: MIXS:0000335
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12391,22 +12406,22 @@ slots:
       (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
     title: soil texture classification
     examples:
-    - value: silty clay loam
+      - value: silty clay loam
     keywords:
-    - classification
-    - soil
-    - texture
+      - classification
+      - soil
+      - texture
     slot_uri: MIXS:0001164
     range: SoilTextureClassEnum
   soil_texture_meth:
     description: Reference or method used in determining soil texture
     title: soil texture method
     examples:
-    - value: https://uwlab.soils.wisc.edu/wp-content/uploads/sites/17/2015/09/particle_size.pdf
+      - value: https://uwlab.soils.wisc.edu/wp-content/uploads/sites/17/2015/09/particle_size.pdf
     keywords:
-    - method
-    - soil
-    - texture
+      - method
+      - soil
+      - texture
     slot_uri: MIXS:0000336
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -12422,21 +12437,21 @@ slots:
       can be separated by pipes
     title: soil type
     examples:
-    - value: plinthosol [ENVO:00002250]
+      - value: plinthosol [ENVO:00002250]
     keywords:
-    - soil
-    - type
+      - soil
+      - type
     slot_uri: MIXS:0000332
   soil_type_meth:
     description: Reference or method used in determining soil series name or other
       lower-level classification
     title: soil type method
     examples:
-    - value: https://www.lrh.usace.army.mil/Portals/38/docs/PR/BluestoneSFEIS/Appendix%20K-Soil%20Descriptions.pdf
+      - value: https://www.lrh.usace.army.mil/Portals/38/docs/PR/BluestoneSFEIS/Appendix%20K-Soil%20Descriptions.pdf
     keywords:
-    - method
-    - soil
-    - type
+      - method
+      - soil
+      - type
     slot_uri: MIXS:0000334
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -12447,12 +12462,12 @@ slots:
   solar_irradiance:
     annotations:
       Preferred_unit: kilowatts per square meter per day, ergs per square centimeter per
-          second
+        second
     description: The amount of solar energy that arrives at a specific area of a surface
       during a specific time interval
     title: solar irradiance
     examples:
-    - value: 1.36 kilowatts per square meter per day
+      - value: 1.36 kilowatts per square meter per day
     slot_uri: MIXS:0000112
     multivalued: true
     range: string
@@ -12470,9 +12485,9 @@ slots:
       cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc
     title: soluble inorganic material
     keywords:
-    - inorganic
-    - material
-    - soluble
+      - inorganic
+      - material
+      - soluble
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000672
     multivalued: true
@@ -12484,9 +12499,9 @@ slots:
       drugs, pharmaceuticals, etc
     title: soluble organic material
     keywords:
-    - material
-    - organic
-    - soluble
+      - material
+      - organic
+      - soluble
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000673
     multivalued: true
@@ -12496,10 +12511,10 @@ slots:
     description: Concentration of soluble reactive phosphorus
     title: soluble reactive phosphorus
     examples:
-    - value: 0.1 milligram per liter
+      - value: 0.1 milligram per liter
     keywords:
-    - phosphorus
-    - soluble
+      - phosphorus
+      - soluble
     slot_uri: MIXS:0000738
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12515,11 +12530,11 @@ slots:
       of genomes, metagenomes or environmental sequences
     title: relevant standard operating procedures
     examples:
-    - value: http://press.igsb.anl.gov/earthmicrobiome/protocols-and-standards/its/
+      - value: http://press.igsb.anl.gov/earthmicrobiome/protocols-and-standards/its/
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - procedures
+      - procedures
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000090
     multivalued: true
@@ -12527,9 +12542,9 @@ slots:
     description: Method used to sort/isolate cells or particles of interest
     title: sorting technology
     examples:
-    - value: optical manipulation
+      - value: optical manipulation
     in_subset:
-    - sequencing
+      - sequencing
     slot_uri: MIXS:0000075
     range: SortTechEnum
   source_mat_id:
@@ -12550,14 +12565,14 @@ slots:
       acids were extracted (e.g. xatc123 or ark:/2154/R2)
     title: source material identifiers
     examples:
-    - value: MPI012345
+      - value: MPI012345
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - identifier
-    - material
-    - source
-    string_serialization: '{text}'
+      - identifier
+      - material
+      - source
+    range: string
     slot_uri: MIXS:0000026
     multivalued: true
   source_uvig:
@@ -12566,11 +12581,11 @@ slots:
     description: Type of dataset from which the UViG was obtained
     title: source of UViGs
     examples:
-    - value: viral fraction metagenome (virome)
+      - value: viral fraction metagenome (virome)
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - source
+      - source
     string_serialization: '[metagenome (not viral targeted)|viral fraction metagenome
       (virome)|sequence-targeted metagenome|metatranscriptome (not viral targeted)|viral
       fraction RNA metagenome (RNA virome)|sequence-targeted RNA metagenome|microbial
@@ -12581,7 +12596,7 @@ slots:
     description: Customary or normal state of the space
     title: space typical state
     examples:
-    - value: typically occupied
+      - value: typically occupied
     slot_uri: MIXS:0000770
     range: SpaceTypStateEnum
     required: true
@@ -12591,9 +12606,9 @@ slots:
       (http://purl.obolibrary.org/obo/FOODON_03510136)
     title: specific intended consumer
     examples:
-    - value: senior as food consumer [FOODON:03510254]
+      - value: senior as food consumer [FOODON:03510254]
     keywords:
-    - consumer
+      - consumer
     slot_uri: MIXS:0001234
     multivalued: true
     range: string
@@ -12608,9 +12623,9 @@ slots:
     description: Specification of special diet; can include multiple special diets
     title: special diet
     examples:
-    - value: other:vegan
+      - value: other:vegan
     keywords:
-    - diet
+      - diet
     string_serialization: '[low carb|reduced calorie|vegetarian|other(to be specified)]'
     slot_uri: MIXS:0000905
     multivalued: true
@@ -12619,7 +12634,7 @@ slots:
       conceptual, schematic, design development, construction documents'
     title: specifications
     examples:
-    - value: construction
+      - value: construction
     slot_uri: MIXS:0000836
     range: SpecificEnum
   specific_host:
@@ -12628,12 +12643,12 @@ slots:
     description: Report the host's taxonomic name and/or NCBI taxonomy ID
     title: host scientific name
     examples:
-    - value: Homo sapiens and/or 9606
+      - value: Homo sapiens and/or 9606
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     string_serialization: '{text}|{NCBI taxid}'
     slot_uri: MIXS:0000029
   specific_humidity:
@@ -12644,9 +12659,9 @@ slots:
       pound
     title: specific humidity
     examples:
-    - value: 15 per kilogram of air
+      - value: 15 per kilogram of air
     keywords:
-    - humidity
+      - humidity
     slot_uri: MIXS:0000214
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12664,10 +12679,10 @@ slots:
       accepts terms under antimicrobial phenotype (http://purl.obolibrary.org/obo/ARO_3004299)
     title: antimicrobial phenotype of spike-in bacteria
     examples:
-    - value: wild type [ARO:3004432]
+      - value: wild type [ARO:3004432]
     keywords:
-    - antimicrobial
-    - spike
+      - antimicrobial
+      - spike
     string_serialization: '{float} {unit};{termLabel} [{termID}]'
     slot_uri: MIXS:0001235
     multivalued: true
@@ -12679,9 +12694,9 @@ slots:
       class and concentration used for spike-in
     title: spike-in with antibiotics
     examples:
-    - value: Tetracycline at 5 mg/ml
+      - value: Tetracycline at 5 mg/ml
     keywords:
-    - spike
+      - spike
     string_serialization: '{text} {integer}'
     slot_uri: MIXS:0001171
     multivalued: true
@@ -12689,18 +12704,18 @@ slots:
     annotations:
       Expected_value: organism name;measurement value;enumeration
       Preferred_unit: colony forming units per milliliter; colony forming units per gram
-          of dry weight
+        of dry weight
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
       The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) should
       also be provided (example: total prokaryotes; 3.5e7 cells per ml; qPCR)'
     title: spike-in organism count
     examples:
-    - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+      - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
     keywords:
-    - count
-    - organism
-    - spike
+      - count
+      - organism
+      - spike
     string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|other]'
     slot_uri: MIXS:0001335
   spikein_growth_med:
@@ -12715,10 +12730,10 @@ slots:
       in growth media
     title: spike-in growth medium
     examples:
-    - value: LB broth [MCO:0000036]
+      - value: LB broth [MCO:0000036]
     keywords:
-    - growth
-    - spike
+      - growth
+      - spike
     slot_uri: MIXS:0001169
     multivalued: true
     range: string
@@ -12735,10 +12750,10 @@ slots:
       used for spike-in
     title: spike-in with heavy metals
     examples:
-    - value: Cd at 20 ppm
+      - value: Cd at 20 ppm
     keywords:
-    - heavy
-    - spike
+      - heavy
+      - spike
     string_serialization: '{text} {integer}'
     slot_uri: MIXS:0001172
     multivalued: true
@@ -12749,10 +12764,10 @@ slots:
       Multiple terms can be separated by pipes
     title: spike in organism
     examples:
-    - value: Listeria monocytogenes [NCIT:C86502]|28901
+      - value: Listeria monocytogenes [NCIT:C86502]|28901
     keywords:
-    - organism
-    - spike
+      - organism
+      - spike
     slot_uri: MIXS:0001167
     multivalued: true
     range: string
@@ -12770,9 +12785,9 @@ slots:
       Multiple terms can be separated by pipes
     title: spike-in bacterial serovar or serotype
     examples:
-    - value: Escherichia coli strain O157:H7 [NCIT:C86883]|83334
+      - value: Escherichia coli strain O157:H7 [NCIT:C86883]|83334
     keywords:
-    - spike
+      - spike
     string_serialization: '{termLabel} [{termID}]|{integer}'
     slot_uri: MIXS:0001168
     multivalued: true
@@ -12785,10 +12800,10 @@ slots:
       Multiple terms can be separated by pipes
     title: spike-in microbial strain
     examples:
-    - value: '169963'
+      - value: '169963'
     keywords:
-    - microbial
-    - spike
+      - microbial
+      - spike
     string_serialization: '{termLabel} [{termID}]|{integer}'
     slot_uri: MIXS:0001170
     multivalued: true
@@ -12797,10 +12812,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: source rock depositional environment
     examples:
-    - value: Marine
+      - value: Marine
     keywords:
-    - environment
-    - source
+      - environment
+      - source
     slot_uri: MIXS:0000996
     range: SrDepEnvEnum
   sr_geol_age:
@@ -12808,10 +12823,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: source rock geological age
     examples:
-    - value: Silurian
+      - value: Silurian
     keywords:
-    - age
-    - source
+      - age
+      - source
     slot_uri: MIXS:0000997
     range: GeolAgeEnum
   sr_kerog_type:
@@ -12822,10 +12837,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field'
     title: source rock kerogen type
     examples:
-    - value: Type IV
+      - value: Type IV
     keywords:
-    - source
-    - type
+      - source
+      - type
     slot_uri: MIXS:0000994
     range: SrKerogTypeEnum
   sr_lithology:
@@ -12833,10 +12848,10 @@ slots:
       If "other" is specified, please propose entry in "additional info" field
     title: source rock lithology
     examples:
-    - value: Coal
+      - value: Coal
     keywords:
-    - lithology
-    - source
+      - lithology
+      - source
     slot_uri: MIXS:0000995
     range: SrLithologyEnum
   standing_water_regm:
@@ -12846,10 +12861,10 @@ slots:
       the start and end time of the entire treatment; can include multiple regimens
     title: standing water regimen
     examples:
-    - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
-    - water
+      - regimen
+      - water
     slot_uri: MIXS:0001069
     multivalued: true
     range: string
@@ -12862,10 +12877,10 @@ slots:
       room sterilization method. Multiple terms can be separated by pipes
     title: sampling room sterilization method
     examples:
-    - value: ultraviolet radiation [ENVO:21001216]|infrared radiation [ENVO:21001214]
+      - value: ultraviolet radiation [ENVO:21001216]|infrared radiation [ENVO:21001214]
     keywords:
-    - method
-    - room
+      - method
+      - room
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001259
     multivalued: true
@@ -12876,23 +12891,23 @@ slots:
       extraction (fresh/frozen/other)
     title: storage conditions
     examples:
-    - value: -20 degree Celsius freezer;P2Y10D
+      - value: -20 degree Celsius freezer;P2Y10D
     keywords:
-    - condition
-    - storage
+      - condition
+      - storage
     string_serialization: '{text};{period}'
     slot_uri: MIXS:0000327
   study_complt_stat:
     annotations:
       Expected_value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
-          up (4)other-specify
+        up (4)other-specify
     description: Specification of study completion status, if no the reason should
       be specified
     title: study completion status
     examples:
-    - value: no;non-compliance
+      - value: no;non-compliance
     keywords:
-    - status
+      - status
     string_serialization: '{boolean};[adverse event|non-compliance|lost to follow
       up|other-specify]'
     slot_uri: MIXS:0000898
@@ -12907,7 +12922,7 @@ slots:
       be separated by pipes
     title: study design
     examples:
-    - value: in vitro design [OBI:0001285]
+      - value: in vitro design [OBI:0001285]
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001236
     multivalued: true
@@ -12918,11 +12933,11 @@ slots:
       used. Indicate the timepoint written in ISO 8601 format
     title: study incubation duration
     examples:
-    - value: PT24H
+      - value: PT24H
     keywords:
-    - duration
-    - incubation
-    - period
+      - duration
+      - incubation
+      - period
     slot_uri: MIXS:0001237
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -12937,10 +12952,10 @@ slots:
       is used
     title: study incubation temperature
     examples:
-    - value: 37 degree Celsius
+      - value: 37 degree Celsius
     keywords:
-    - incubation
-    - temperature
+      - incubation
+      - temperature
     slot_uri: MIXS:0001238
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12956,11 +12971,11 @@ slots:
       indicate the total duration of the time-course study
     title: time-course duration
     examples:
-    - value: 2 days post inoculation
+      - value: 2 days post inoculation
     keywords:
-    - duration
-    - period
-    - time
+      - duration
+      - period
+      - time
     slot_uri: MIXS:0001239
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -12980,16 +12995,16 @@ slots:
       separated by one or more pipes
     title: study treatment
     examples:
-    - value: Factor A|spike-in|levels high, medium, low
+      - value: Factor A|spike-in|levels high, medium, low
     keywords:
-    - treatment
+      - treatment
     string_serialization: '{text}|{termLabel} [{termID}]'
     slot_uri: MIXS:0001240
     multivalued: true
   subspecf_gen_lin:
     annotations:
       Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
-          e.g. serovar, biotype, ecotype, variety, cultivar
+        e.g. serovar, biotype, ecotype, variety, cultivar
     description: Information about the genetic distinctness of the sequenced organism
       below the subspecies level, e.g., serovar, serotype, biotype, ecotype, or any
       relevant genetic typing schemes like Group I plasmid. Subspecies should not
@@ -12997,11 +13012,11 @@ slots:
       name and the lineage rank separated by a colon, e.g., biovar:abc123
     title: subspecific genetic lineage
     examples:
-    - value: serovar:Newport
+      - value: serovar:Newport
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - lineage
+      - lineage
     string_serialization: '{rank name}:{text}'
     slot_uri: MIXS:0000020
   substructure_type:
@@ -13009,9 +13024,9 @@ slots:
       of the building which is built off the foundations to the ground floor level
     title: substructure type
     examples:
-    - value: basement
+      - value: basement
     keywords:
-    - type
+      - type
     slot_uri: MIXS:0000767
     multivalued: true
     range: SubstructureTypeEnum
@@ -13021,9 +13036,9 @@ slots:
     description: Concentration of sulfate in the sample
     title: sulfate
     examples:
-    - value: 5 micromole per liter
+      - value: 5 micromole per liter
     keywords:
-    - sulfate
+      - sulfate
     slot_uri: MIXS:0000423
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13038,8 +13053,8 @@ slots:
     description: Original sulfate concentration in the hydrocarbon resource
     title: sulfate in formation water
     keywords:
-    - sulfate
-    - water
+      - sulfate
+      - water
     slot_uri: MIXS:0000407
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13054,9 +13069,9 @@ slots:
     description: Concentration of sulfide in the sample
     title: sulfide
     examples:
-    - value: 2 micromole per liter
+      - value: 2 micromole per liter
     keywords:
-    - sulfide
+      - sulfide
     slot_uri: MIXS:0000424
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13069,7 +13084,7 @@ slots:
     description: Contaminant identified on surface
     title: surface-air contaminant
     examples:
-    - value: radon
+      - value: radon
     slot_uri: MIXS:0000759
     multivalued: true
     range: SurfAirContEnum
@@ -13080,12 +13095,12 @@ slots:
     description: 'Surfaces: water activity as a function of air and material moisture'
     title: surface humidity
     comments:
-    - percent or float?
+      - percent or float?
     examples:
-    - value: '0.1'
+      - value: '0.1'
     keywords:
-    - humidity
-    - surface
+      - humidity
+      - surface
     slot_uri: MIXS:0000123
     range: float
     recommended: true
@@ -13099,10 +13114,10 @@ slots:
     description: Surface materials at the point of sampling
     title: surface material
     examples:
-    - value: wood
+      - value: wood
     keywords:
-    - material
-    - surface
+      - material
+      - surface
     slot_uri: MIXS:0000758
     range: SurfMaterialEnum
   surf_moisture:
@@ -13111,10 +13126,10 @@ slots:
     description: Water held on a surface
     title: surface moisture
     examples:
-    - value: 0.01 gram per square meter
+      - value: 0.01 gram per square meter
     keywords:
-    - moisture
-    - surface
+      - moisture
+      - surface
     slot_uri: MIXS:0000128
     range: string
     recommended: true
@@ -13128,11 +13143,11 @@ slots:
     description: ph measurement of surface
     title: surface moisture pH
     examples:
-    - value: '7'
+      - value: '7'
     keywords:
-    - moisture
-    - ph
-    - surface
+      - moisture
+      - ph
+      - surface
     slot_uri: MIXS:0000760
     range: float
     recommended: true
@@ -13142,10 +13157,10 @@ slots:
     description: Temperature of the surface at the time of sampling
     title: surface temperature
     examples:
-    - value: 15 degree Celsius
+      - value: 15 degree Celsius
     keywords:
-    - surface
-    - temperature
+      - surface
+      - temperature
     slot_uri: MIXS:0000125
     range: string
     recommended: true
@@ -13161,11 +13176,11 @@ slots:
     description: Concentration of suspended particulate matter
     title: suspended particulate matter
     examples:
-    - value: 0.5 milligram per liter
+      - value: 0.5 milligram per liter
     keywords:
-    - particle
-    - particulate
-    - suspended
+      - particle
+      - particulate
+      - suspended
     slot_uri: MIXS:0000741
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13178,13 +13193,13 @@ slots:
     annotations:
       Expected_value: suspended solid name;measurement value
       Preferred_unit: gram, microgram, milligram per liter, mole per liter, gram per liter,
-          part per million
+        part per million
     description: Concentration of substances including a wide variety of material,
       such as silt, decaying plant and animal matter; can include multiple substances
     title: suspended solids
     keywords:
-    - solids
-    - suspended
+      - solids
+      - suspended
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000150
     multivalued: true
@@ -13196,14 +13211,14 @@ slots:
       multiple different hosts over the course of their normal life cycle
     title: symbiotic host organism life cycle type
     examples:
-    - value: complex life cycle
+      - value: complex life cycle
     keywords:
-    - host
-    - host.
-    - life
-    - organism
-    - symbiosis
-    - type
+      - host
+      - host.
+      - life
+      - organism
+      - symbiosis
+      - type
     slot_uri: MIXS:0001300
     range: SymLifeCycleTypeEnum
     required: true
@@ -13211,11 +13226,11 @@ slots:
     description: Role of the host in the life cycle of the symbiotic organism
     title: host of the symbiont role
     examples:
-    - value: intermediate
+      - value: intermediate
     keywords:
-    - host
-    - host.
-    - symbiosis
+      - host
+      - host.
+      - symbiosis
     slot_uri: MIXS:0001303
     range: SymbiontHostRoleEnum
     recommended: true
@@ -13228,8 +13243,8 @@ slots:
       oil. (source: https://en.wikipedia.org/wiki/Total_acid_number)'
     title: total acid number
     keywords:
-    - number
-    - total
+      - number
+      - total
     slot_uri: MIXS:0000120
     range: string
     recommended: true
@@ -13243,11 +13258,11 @@ slots:
     description: Targeted gene or locus name for marker gene studies
     title: target gene
     examples:
-    - value: 16S rRNA, 18S rRNA, nif, amoA, rpo
+      - value: 16S rRNA, 18S rRNA, nif, amoA, rpo
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - target
+      - target
     slot_uri: MIXS:0000044
     range: string
   target_subfragment:
@@ -13255,11 +13270,11 @@ slots:
       special regions on marker genes like V6 on 16S rRNA
     title: target subfragment
     examples:
-    - value: V6, V9, ITS
+      - value: V6, V9, ITS
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - target
+      - target
     slot_uri: MIXS:0000045
     range: string
   tax_class:
@@ -13267,13 +13282,13 @@ slots:
       used, classification rank, and thresholds used to classify new genomes
     title: taxonomic classification
     examples:
-    - value: vConTACT vContact2 (references from NCBI RefSeq v83, genus rank classification,
-        default parameters)
+      - value: vConTACT vContact2 (references from NCBI RefSeq v83, genus rank classification,
+          default parameters)
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - classification
-    - taxon
+      - classification
+      - taxon
     slot_uri: MIXS:0000064
     range: string
   tax_ident:
@@ -13281,14 +13296,14 @@ slots:
       SAG or MAG
     title: taxonomic identity marker
     examples:
-    - value: other
-      description: was other <colon> rpoB gene
+      - value: other
+        description: was other <colon> rpoB gene
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - identifier
-    - marker
-    - taxon
+      - identifier
+      - marker
+      - taxon
     slot_uri: MIXS:0000053
     range: TaxIdentEnum
   temp:
@@ -13297,11 +13312,11 @@ slots:
     description: Temperature of the sample at the time of sampling
     title: temperature
     examples:
-    - value: 25 degree Celsius
+      - value: 25 degree Celsius
     in_subset:
-    - environment
+      - environment
     keywords:
-    - temperature
+      - temperature
     slot_uri: MIXS:0000113
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13316,10 +13331,10 @@ slots:
     description: The recorded temperature value at sampling time outside
     title: temperature outside house
     examples:
-    - value: 5 degree Celsius
+      - value: 5 degree Celsius
     keywords:
-    - house
-    - temperature
+      - house
+      - temperature
     slot_uri: MIXS:0000197
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13335,23 +13350,23 @@ slots:
       quality before it is discharged to the receiving environment
     title: tertiary treatment
     keywords:
-    - treatment
-    string_serialization: '{text}'
+      - treatment
+    range: string
     slot_uri: MIXS:0000352
   tidal_stage:
     description: Stage of tide
     title: tidal stage
     examples:
-    - value: high tide
+      - value: high tide
     slot_uri: MIXS:0000750
     range: TidalStageEnum
   tillage:
     description: Note method(s) used for tilling
     title: history/tillage
     examples:
-    - value: chisel
+      - value: chisel
     keywords:
-    - history
+      - history
     slot_uri: MIXS:0001081
     multivalued: true
     range: TillageEnum
@@ -13359,12 +13374,12 @@ slots:
     description: Specification of the time since last toothbrushing
     title: time since last toothbrushing
     comments:
-    - P2H45M does not match ^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d+[HMS])(\\d+H)?(\\d+M)?(\\d+S)?)?$
-    - problematic ISO 8601 period validation
+      - P2H45M does not match ^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d+[HMS])(\\d+H)?(\\d+M)?(\\d+S)?)?$
+      - problematic ISO 8601 period validation
     examples:
-    - value: PT2H45M
+      - value: PT2H45M
     keywords:
-    - time
+      - time
     slot_uri: MIXS:0000924
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -13376,9 +13391,9 @@ slots:
     description: Specification of the time since last wash
     title: time since last wash
     examples:
-    - value: P1D
+      - value: P1D
     keywords:
-    - time
+      - time
     slot_uri: MIXS:0000943
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -13394,9 +13409,9 @@ slots:
       written in ISO 8601 format
     title: timepoint
     examples:
-    - value: PT24H
+      - value: PT24H
     keywords:
-    - time
+      - time
     slot_uri: MIXS:0001173
     range: string
     pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
@@ -13408,10 +13423,10 @@ slots:
     description: Description of plant tissue culture growth media used
     title: tissue culture growth media
     examples:
-    - value: https://link.springer.com/content/pdf/10.1007/BF02796489.pdf
+      - value: https://link.springer.com/content/pdf/10.1007/BF02796489.pdf
     keywords:
-    - culture
-    - growth
+      - culture
+      - growth
     slot_uri: MIXS:0001070
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -13437,8 +13452,8 @@ slots:
     description: Total carbon content
     title: total carbon
     keywords:
-    - carbon
-    - total
+      - carbon
+      - total
     slot_uri: MIXS:0000525
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13453,11 +13468,11 @@ slots:
     description: Measurement of total depth of water column
     title: total depth of water column
     examples:
-    - value: 500 meter
+      - value: 500 meter
     keywords:
-    - depth
-    - total
-    - water
+      - depth
+      - total
+      - water
     slot_uri: MIXS:0000634
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13473,11 +13488,11 @@ slots:
       by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen'
     title: total dissolved nitrogen
     examples:
-    - value: 40 microgram per liter
+      - value: 40 microgram per liter
     keywords:
-    - dissolved
-    - nitrogen
-    - total
+      - dissolved
+      - nitrogen
+      - total
     slot_uri: MIXS:0000744
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13492,11 +13507,11 @@ slots:
     description: Total inorganic nitrogen content
     title: total inorganic nitrogen
     examples:
-    - value: 40 microgram per liter
+      - value: 40 microgram per liter
     keywords:
-    - inorganic
-    - nitrogen
-    - total
+      - inorganic
+      - nitrogen
+      - total
     slot_uri: MIXS:0000745
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13511,7 +13526,7 @@ slots:
     description: Concentration of total iron in the sample
     title: total iron
     keywords:
-    - total
+      - total
     slot_uri: MIXS:0000105
     range: string
     recommended: true
@@ -13529,11 +13544,11 @@ slots:
       without filtering, reported as nitrogen'
     title: total nitrogen concentration
     examples:
-    - value: 50 micromole per liter
+      - value: 50 micromole per liter
     keywords:
-    - concentration
-    - nitrogen
-    - total
+      - concentration
+      - nitrogen
+      - total
     slot_uri: MIXS:0000102
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13546,12 +13561,12 @@ slots:
     description: Reference or method used in determining the total nitrogen
     title: total nitrogen content method
     examples:
-    - value: https://currentprotocols.onlinelibrary.wiley.com/doi/abs/10.1002/0471142913.fab0102s00
+      - value: https://currentprotocols.onlinelibrary.wiley.com/doi/abs/10.1002/0471142913.fab0102s00
     keywords:
-    - content
-    - method
-    - nitrogen
-    - total
+      - content
+      - method
+      - nitrogen
+      - total
     slot_uri: MIXS:0000338
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -13563,11 +13578,11 @@ slots:
     description: Total nitrogen content of the sample
     title: total nitrogen content
     examples:
-    - value: 35 milligrams Nitrogen per kilogram of soil
+      - value: 35 milligrams Nitrogen per kilogram of soil
     keywords:
-    - content
-    - nitrogen
-    - total
+      - content
+      - nitrogen
+      - total
     slot_uri: MIXS:0000530
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13580,12 +13595,12 @@ slots:
     description: Reference or method used in determining total organic carbon
     title: total organic carbon method
     examples:
-    - value: https://www.epa.gov/sites/production/files/2015-12/documents/9060a.pdf
+      - value: https://www.epa.gov/sites/production/files/2015-12/documents/9060a.pdf
     keywords:
-    - carbon
-    - method
-    - organic
-    - total
+      - carbon
+      - method
+      - organic
+      - total
     slot_uri: MIXS:0000337
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -13599,11 +13614,11 @@ slots:
     description: Total organic carbon content
     title: total organic carbon
     examples:
-    - value: '0.02'
+      - value: '0.02'
     keywords:
-    - carbon
-    - organic
-    - total
+      - carbon
+      - organic
+      - total
     slot_uri: MIXS:0000533
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13618,12 +13633,12 @@ slots:
     description: Total particulate carbon content
     title: total particulate carbon
     examples:
-    - value: 35 micromole per liter
+      - value: 35 micromole per liter
     keywords:
-    - carbon
-    - particle
-    - particulate
-    - total
+      - carbon
+      - particle
+      - particulate
+      - total
     slot_uri: MIXS:0000747
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13639,10 +13654,10 @@ slots:
       phosphorus = total dissolved phosphorus + particulate phosphorus'
     title: total phosphorus
     examples:
-    - value: 0.03 milligram per liter
+      - value: 0.03 milligram per liter
     keywords:
-    - phosphorus
-    - total
+      - phosphorus
+      - total
     slot_uri: MIXS:0000117
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13657,8 +13672,8 @@ slots:
     description: Total amount or concentration of phosphate
     title: total phosphate
     keywords:
-    - phosphate
-    - total
+      - phosphate
+      - total
     slot_uri: MIXS:0000689
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13673,8 +13688,8 @@ slots:
     description: Concentration of total sulfur in the sample
     title: total sulfur
     keywords:
-    - sulfur
-    - total
+      - sulfur
+      - total
     slot_uri: MIXS:0000419
     range: string
     recommended: true
@@ -13688,30 +13703,30 @@ slots:
     description: The subway line name
     title: train line
     examples:
-    - value: red
+      - value: red
     keywords:
-    - train
+      - train
     slot_uri: MIXS:0000837
     range: TrainLineEnum
   train_stat_loc:
     description: The train station collection location
     title: train station collection location
     examples:
-    - value: forest hills
+      - value: forest hills
     keywords:
-    - location
-    - train
+      - location
+      - train
     slot_uri: MIXS:0000838
     range: TrainStatLocEnum
   train_stop_loc:
     description: The train stop collection location
     title: train stop collection location
     examples:
-    - value: end
+      - value: end
     keywords:
-    - location
-    - stop
-    - train
+      - location
+      - stop
+      - train
     slot_uri: MIXS:0000839
     range: TrainStopLocEnum
   travel_out_six_month:
@@ -13721,19 +13736,19 @@ slots:
       can include multiple travels
     title: travel outside the country in last six months
     keywords:
-    - months
-    string_serialization: '{text}'
+      - months
+    range: string
     slot_uri: MIXS:0000268
     multivalued: true
   trna_ext_software:
     description: Tools used for tRNA identification
     title: tRNA extraction software
     examples:
-    - value: infernal;v2;default parameters
+      - value: infernal;v2;default parameters
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - software
+      - software
     slot_uri: MIXS:0000068
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -13747,11 +13762,11 @@ slots:
     description: The total number of tRNAs identified from the SAG or MAG
     title: number of standard tRNAs extracted
     examples:
-    - value: '18'
+      - value: '18'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - number
+      - number
     string_serialization: '{integer}'
     slot_uri: MIXS:0000067
   trophic_level:
@@ -13759,11 +13774,11 @@ slots:
       can be a range of producers (e.g. chemolithotroph)
     title: trophic level
     examples:
-    - value: heterotroph
+      - value: heterotroph
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - level
+      - level
     slot_uri: MIXS:0000032
     range: TrophicLevelEnum
   turbidity:
@@ -13771,7 +13786,7 @@ slots:
       individual particles
     title: turbidity
     examples:
-    - value: 0.3 nephelometric turbidity units
+      - value: 0.3 nephelometric turbidity units
     slot_uri: MIXS:0000191
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13787,10 +13802,10 @@ slots:
       the original pressure was measured (e.g. 1578 m)
     title: depth (TVDSS) of hydrocarbon resource pressure
     keywords:
-    - depth
-    - hydrocarbon
-    - pressure
-    - resource
+      - depth
+      - hydrocarbon
+      - pressure
+      - resource
     slot_uri: MIXS:0000397
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13806,10 +13821,10 @@ slots:
       the original temperature was measured (e.g. 1345 m)
     title: depth (TVDSS) of hydrocarbon resource temperature
     keywords:
-    - depth
-    - hydrocarbon
-    - resource
-    - temperature
+      - depth
+      - hydrocarbon
+      - resource
+      - temperature
     slot_uri: MIXS:0000394
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13822,18 +13837,18 @@ slots:
     description: Specification of twin sibling presence
     title: twin sibling presence
     examples:
-    - value: 'yes'
+      - value: 'yes'
     keywords:
-    - presence
+      - presence
     slot_uri: MIXS:0000326
     range: boolean
   typ_occup_density:
     description: Customary or normal density of occupants
     title: typical occupant density
     examples:
-    - value: '25'
+      - value: '25'
     keywords:
-    - density
+      - density
     slot_uri: MIXS:0000771
     range: float
     required: true
@@ -13842,10 +13857,10 @@ slots:
       host organism being sampled and its respective host
     title: type of symbiosis
     examples:
-    - value: parasitic
+      - value: parasitic
     keywords:
-    - symbiosis
-    - type
+      - symbiosis
+      - type
     slot_uri: MIXS:0001307
     range: TypeOfSymbiosisEnum
     recommended: true
@@ -13853,9 +13868,9 @@ slots:
     description: Specification of urine collection method
     title: urine/collection method
     examples:
-    - value: catheter
+      - value: catheter
     keywords:
-    - method
+      - method
     slot_uri: MIXS:0000899
     range: UrineCollectMethEnum
   urobiom_sex:
@@ -13864,8 +13879,8 @@ slots:
     description: Physical sex of the host
     title: host sex
     keywords:
-    - host
-    - host.
+      - host
+      - host.
     slot_uri: MIXS:0000862
     range: UrobiomSexEnum
   urogenit_disord:
@@ -13875,7 +13890,7 @@ slots:
       system disease (https://disease-ontology.org/?id=DOID:18)
     title: urogenital disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000289
     multivalued: true
     range: string
@@ -13885,7 +13900,7 @@ slots:
       urinary system disease (https://disease-ontology.org/?id=DOID:18)
     title: urine/urogenital tract disorder
     keywords:
-    - disorder
+      - disorder
     slot_uri: MIXS:0000278
     multivalued: true
     range: string
@@ -13895,9 +13910,9 @@ slots:
     description: Ventilation rate of the system in the sampled premises
     title: ventilation rate
     examples:
-    - value: 750 cubic meter per minute
+      - value: 750 cubic meter per minute
     keywords:
-    - rate
+      - rate
     slot_uri: MIXS:0000114
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13912,10 +13927,10 @@ slots:
     description: Ventilation system used in the sampled premises
     title: ventilation type
     examples:
-    - value: Operable windows
+      - value: Operable windows
     keywords:
-    - type
-    string_serialization: '{text}'
+      - type
+    range: string
     slot_uri: MIXS:0000756
     multivalued: true
   vfa:
@@ -13938,7 +13953,7 @@ slots:
     description: Original volatile fatty acid concentration in the hydrocarbon resource
     title: vfa in formation water
     keywords:
-    - water
+      - water
     slot_uri: MIXS:0000408
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -13954,30 +13969,30 @@ slots:
       or protocol name including version number, parameters, and cutoffs used
     title: viral identification software
     examples:
-    - value: VirSorter; 1.0.4; Virome database, category 2
+      - value: VirSorter; 1.0.4; Virome database, category 2
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - identifier
-    - software
+      - identifier
+      - software
     string_serialization: '{software};{version};{parameters}'
     slot_uri: MIXS:0000081
   virus_enrich_appr:
     description: List of approaches used to enrich the sample for viruses, if any
     title: virus enrichment approach
     examples:
-    - value: filtration
-      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
-    - value: FeCl Precipitation
-      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
-    - value: ultracentrifugation
-      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
-    - value: DNAse
-      description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: filtration
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: FeCl Precipitation
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: ultracentrifugation
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
     in_subset:
-    - nucleic acid sequence source
+      - nucleic acid sequence source
     keywords:
-    - enrichment
+      - enrichment
     slot_uri: MIXS:0000036
     range: VirusEnrichApprEnum
   vis_media:
@@ -13986,7 +14001,7 @@ slots:
     description: The building visual media
     title: visual media
     examples:
-    - value: 3D scans
+      - value: 3D scans
     string_serialization: '[photos|videos|commonly of the building|site context (adjacent
       buildings, vegetation, terrain, streets)|interiors|equipment|3D scans]'
     slot_uri: MIXS:0000840
@@ -14008,9 +14023,9 @@ slots:
       numeric values preceded by name of compound
     title: volatile organic compounds
     examples:
-    - value: formaldehyde;500 nanogram per liter
+      - value: formaldehyde;500 nanogram per liter
     keywords:
-    - organic
+      - organic
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000115
     multivalued: true
@@ -14020,8 +14035,8 @@ slots:
     description: The total area of the sampled room's walls
     title: wall area
     keywords:
-    - area
-    - wall
+      - area
+      - wall
     slot_uri: MIXS:0000198
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14035,20 +14050,20 @@ slots:
       building elements and fire-resistance rating
     title: wall construction type
     examples:
-    - value: fire resistive
+      - value: fire resistive
     keywords:
-    - type
-    - wall
+      - type
+      - wall
     slot_uri: MIXS:0000841
     range: WallConstTypeEnum
   wall_finish_mat:
     description: The material utilized to finish the outer most layer of the wall
     title: wall finish material
     examples:
-    - value: wood
+      - value: wood
     keywords:
-    - material
-    - wall
+      - material
+      - wall
     slot_uri: MIXS:0000842
     range: WallFinishMatEnum
   wall_height:
@@ -14057,8 +14072,8 @@ slots:
     description: The average height of the walls in the sampled room
     title: wall height
     keywords:
-    - height
-    - wall
+      - height
+      - wall
     slot_uri: MIXS:0000221
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14071,31 +14086,31 @@ slots:
     description: The relative location of the wall within the room
     title: wall location
     examples:
-    - value: north
+      - value: north
     keywords:
-    - location
-    - wall
+      - location
+      - wall
     slot_uri: MIXS:0000843
     range: CompassDirections8Enum
   wall_surf_treatment:
     description: The surface treatment of interior wall
     title: wall surface treatment
     examples:
-    - value: paneling
+      - value: paneling
     keywords:
-    - surface
-    - treatment
-    - wall
+      - surface
+      - treatment
+      - wall
     slot_uri: MIXS:0000845
     range: WallSurfTreatmentEnum
   wall_texture:
     description: The feel, appearance, or consistency of a wall surface
     title: wall texture
     examples:
-    - value: popcorn
+      - value: popcorn
     keywords:
-    - texture
-    - wall
+      - texture
+      - wall
     slot_uri: MIXS:0000846
     range: CeilingWallTextureEnum
   wall_thermal_mass:
@@ -14106,8 +14121,8 @@ slots:
       only with paint
     title: wall thermal mass
     keywords:
-    - mass
-    - wall
+      - mass
+      - wall
     slot_uri: MIXS:0000222
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14120,9 +14135,9 @@ slots:
     description: Signs of the presence of mold or mildew on a wall
     title: wall signs of water/mold
     examples:
-    - value: no presence of mold visible
+      - value: no presence of mold visible
     keywords:
-    - wall
+      - wall
     slot_uri: MIXS:0000844
     range: MoldVisibilityEnum
   wastewater_type:
@@ -14132,16 +14147,16 @@ slots:
       etc
     title: wastewater type
     keywords:
-    - type
-    string_serialization: '{text}'
+      - type
+    range: string
     slot_uri: MIXS:0000353
   water_cont_soil_meth:
     description: Reference or method used in determining the water content of soil
     title: water content method
     keywords:
-    - content
-    - method
-    - water
+      - content
+      - method
+      - water
     slot_uri: MIXS:0000323
     range: string
     pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
@@ -14155,8 +14170,8 @@ slots:
     description: Water content measurement
     title: water content
     keywords:
-    - content
-    - water
+      - content
+      - water
     slot_uri: MIXS:0000185
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14171,9 +14186,9 @@ slots:
     description: Measurement of magnitude and direction of flow within a fluid
     title: water current
     examples:
-    - value: 10 cubic meter per second
+      - value: 10 cubic meter per second
     keywords:
-    - water
+      - water
     slot_uri: MIXS:0000203
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14189,11 +14204,11 @@ slots:
       of the combined streams
     title: water cut
     comments:
-    - percent or float?
+      - percent or float?
     examples:
-    - value: 45%
+      - value: 45%
     keywords:
-    - water
+      - water
     slot_uri: MIXS:0000454
     range: string
     required: true
@@ -14209,9 +14224,9 @@ slots:
     description: The size of the water feature
     title: water feature size
     keywords:
-    - feature
-    - size
-    - water
+      - feature
+      - size
+      - water
     slot_uri: MIXS:0000223
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14224,11 +14239,11 @@ slots:
     description: The type of water feature present within the building being sampled
     title: water feature type
     examples:
-    - value: stream
+      - value: stream
     keywords:
-    - feature
-    - type
-    - water
+      - feature
+      - type
+      - water
     slot_uri: MIXS:0000847
     range: WaterFeatTypeEnum
   water_frequency:
@@ -14238,20 +14253,20 @@ slots:
     description: Number of water delivery events within a given period of time
     title: water delivery frequency
     examples:
-    - value: 2 per day
+      - value: 2 per day
     keywords:
-    - delivery
-    - frequency
-    - water
+      - delivery
+      - frequency
+      - water
     string_serialization: '{float}{unit}'
     slot_uri: MIXS:0001174
   water_pH:
     title: water pH
     examples:
-    - value: '7.2'
+      - value: '7.2'
     keywords:
-    - ph
-    - water
+      - ph
+      - water
     slot_uri: MIXS:0001175
     range: float
   water_prod_rate:
@@ -14260,9 +14275,9 @@ slots:
     description: Water production rates per well (e.g. 987 m3 / day)
     title: water production rate
     keywords:
-    - production
-    - rate
-    - water
+      - production
+      - rate
+      - water
     slot_uri: MIXS:0000453
     range: string
     recommended: true
@@ -14281,14 +14296,14 @@ slots:
       terms can be separated by pipes
     title: environmental feature adjacent water source
     examples:
-    - value: feedlot [ENVO:01000627]
+      - value: feedlot [ENVO:01000627]
     keywords:
-    - adjacent
-    - environmental
-    - feature
-    - source
-    - water
-    string_serialization: '{text}'
+      - adjacent
+      - environmental
+      - feature
+      - source
+      - water
+    range: string
     slot_uri: MIXS:0001122
     multivalued: true
   water_source_shared:
@@ -14298,10 +14313,10 @@ slots:
       can be separated by one or more pipes
     title: water source shared
     examples:
-    - value: no sharing
+      - value: no sharing
     keywords:
-    - source
-    - water
+      - source
+      - water
     string_serialization: '[multiple users, agricutural|multiple users, other|no sharing]'
     slot_uri: MIXS:0001176
     multivalued: true
@@ -14314,11 +14329,11 @@ slots:
       the entire treatment; can include multiple regimens
     title: water temperature regimen
     examples:
-    - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
-    - temperature
-    - water
+      - regimen
+      - temperature
+      - water
     slot_uri: MIXS:0000590
     multivalued: true
     range: string
@@ -14331,10 +14346,10 @@ slots:
       include multiple regimens
     title: watering regimen
     examples:
-    - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+      - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
-    - regimen
-    - water
+      - regimen
+      - water
     slot_uri: MIXS:0000591
     multivalued: true
     range: string
@@ -14342,7 +14357,7 @@ slots:
     description: The day of the week when sampling occurred
     title: weekday
     examples:
-    - value: Sunday
+      - value: Sunday
     slot_uri: MIXS:0000848
     range: WeekdayEnum
   weight_loss_3_month:
@@ -14353,19 +14368,19 @@ slots:
       be further specified to include amount of weight loss
     title: weight loss in last three months
     examples:
-    - value: yes;5 kilogram
+      - value: yes;5 kilogram
     keywords:
-    - months
-    - weight
+      - months
+      - weight
     string_serialization: '{boolean};{float} {unit}'
     slot_uri: MIXS:0000295
   wga_amp_appr:
     description: Method used to amplify genomic DNA in preparation for sequencing
     title: WGA amplification approach
     examples:
-    - value: mda based
+      - value: mda based
     in_subset:
-    - sequencing
+      - sequencing
     slot_uri: MIXS:0000055
     range: WgaAmpApprEnum
   wga_amp_kit:
@@ -14374,12 +14389,12 @@ slots:
     description: Kit used to amplify genomic DNA in preparation for sequencing
     title: WGA amplification kit
     examples:
-    - value: qiagen repli-g
+      - value: qiagen repli-g
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - kit
-    string_serialization: '{text}'
+      - kit
+    range: string
     slot_uri: MIXS:0000006
   win:
     description: 'A unique identifier of a well or wellbore. This is part of the Global
@@ -14388,8 +14403,8 @@ slots:
       systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)'
     title: well identification number
     keywords:
-    - identifier
-    - number
+      - identifier
+      - number
     slot_uri: MIXS:0000297
     range: string
     recommended: true
@@ -14399,16 +14414,16 @@ slots:
     description: Wind direction is the direction from which a wind originates
     title: wind direction
     keywords:
-    - direction
-    - wind
+      - direction
+      - wind
     slot_uri: MIXS:0000757
     range: string
   wind_speed:
     description: speed of wind measured at the time of sampling
     title: wind speed
     keywords:
-    - speed
-    - wind
+      - speed
+      - wind
     slot_uri: MIXS:0000118
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
@@ -14421,56 +14436,56 @@ slots:
     description: The physical condition of the window at the time of sampling
     title: window condition
     examples:
-    - value: rupture
+      - value: rupture
     keywords:
-    - condition
-    - window
+      - condition
+      - window
     slot_uri: MIXS:0000849
     range: DamagedRupturedEnum
   window_cover:
     description: The type of window covering
     title: window covering
     examples:
-    - value: curtains
+      - value: curtains
     keywords:
-    - window
+      - window
     slot_uri: MIXS:0000850
     range: WindowCoverEnum
   window_horiz_pos:
     description: The horizontal position of the window on the wall
     title: window horizontal position
     examples:
-    - value: middle
+      - value: middle
     keywords:
-    - window
+      - window
     slot_uri: MIXS:0000851
     range: WindowHorizPosEnum
   window_loc:
     description: The relative location of the window within the room
     title: window location
     examples:
-    - value: west
+      - value: west
     keywords:
-    - location
-    - window
+      - location
+      - window
     slot_uri: MIXS:0000852
     range: CompassDirections8Enum
   window_mat:
     description: The type of material used to finish a window
     title: window material
     examples:
-    - value: wood
+      - value: wood
     keywords:
-    - material
-    - window
+      - material
+      - window
     slot_uri: MIXS:0000853
     range: WindowMatEnum
   window_open_freq:
     description: The number of times windows are opened per week
     title: window open frequency
     keywords:
-    - frequency
-    - window
+      - frequency
+      - window
     slot_uri: MIXS:0000246
     range: integer
   window_size:
@@ -14480,7 +14495,7 @@ slots:
     description: The window's length and width
     title: window area/size
     keywords:
-    - window
+      - window
     string_serialization: '{float} {unit} x {float} {unit}'
     slot_uri: MIXS:0000224
   window_status:
@@ -14488,61 +14503,61 @@ slots:
       testing
     title: window status
     examples:
-    - value: open
+      - value: open
     keywords:
-    - status
-    - window
+      - status
+      - window
     slot_uri: MIXS:0000855
     range: WindowStatusEnum
   window_type:
     description: The type of windows
     title: window type
     examples:
-    - value: fixed window
+      - value: fixed window
     keywords:
-    - type
-    - window
+      - type
+      - window
     slot_uri: MIXS:0000856
     range: WindowTypeEnum
   window_vert_pos:
     description: The vertical position of the window on the wall
     title: window vertical position
     examples:
-    - value: middle
+      - value: middle
     keywords:
-    - window
+      - window
     slot_uri: MIXS:0000857
     range: WindowVertPosEnum
   window_water_mold:
     description: Signs of the presence of mold or mildew on the window
     title: window signs of water/mold
     examples:
-    - value: no presence of mold visible
+      - value: no presence of mold visible
     keywords:
-    - window
+      - window
     slot_uri: MIXS:0000854
     range: MoldVisibilityEnum
   x16s_recover:
     description: Can a 16S gene be recovered from the submitted SAG or MAG?
     title: 16S recovered
     examples:
-    - value: 'yes'
+      - value: 'yes'
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - recover
+      - recover
     slot_uri: MIXS:0000065
     range: boolean
   x16s_recover_software:
     description: Tools used for 16S rRNA gene extraction
     title: 16S recovery software
     examples:
-    - value: rambl;v2;default parameters
+      - value: rambl;v2;default parameters
     in_subset:
-    - sequencing
+      - sequencing
     keywords:
-    - recover
-    - software
+      - recover
+      - software
     slot_uri: MIXS:0000066
     range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
@@ -14569,69 +14584,69 @@ classes:
     description: 'Minimal Information about a Genome Sequence: cultured bacteria/archaea'
     title: MIGS bacteria
     aliases:
-    - migs_ba
+      - migs_ba
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - assembly_name
-    - temp
-    - compl_score
-    - nucl_acid_ext
-    - samp_size
-    - isol_growth_condt
-    - alt
-    - source_mat_id
-    - extrachrom_elements
-    - estimated_size
-    - samp_vol_we_dna_ext
-    - pathogenicity
-    - lib_reads_seqd
-    - rel_to_oxygen
-    - encoded_traits
-    - samp_collect_device
-    - number_contig
-    - biotic_relationship
-    - num_replicons
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - host_spec_range
-    - neg_cont_type
-    - adapters
-    - assembly_software
-    - tax_ident
-    - annot
-    - trophic_level
-    - pos_cont_type
-    - subspecf_gen_lin
-    - feat_pred
-    - env_local_scale
-    - compl_software
-    - samp_mat_process
-    - sim_search_meth
-    - host_disease_stat
-    - depth
-    - samp_collect_method
-    - specific_host
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - extrachrom_elements
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - pathogenicity
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - encoded_traits
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - num_replicons
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - trophic_level
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -14649,7 +14664,7 @@ classes:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -14657,7 +14672,7 @@ classes:
         recommended: true
       host_disease_stat:
         examples:
-        - value: rabies [DOID:11260]
+          - value: rabies [DOID:11260]
         recommended: true
       isol_growth_condt:
         required: true
@@ -14677,10 +14692,10 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -14700,69 +14715,69 @@ classes:
     description: 'Minimal Information about a Genome Sequence: eukaryote'
     title: MIGS eukaryote
     aliases:
-    - migs_eu
+      - migs_eu
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - assembly_name
-    - temp
-    - compl_score
-    - nucl_acid_ext
-    - samp_size
-    - isol_growth_condt
-    - alt
-    - estimated_size
-    - extrachrom_elements
-    - source_mat_id
-    - samp_vol_we_dna_ext
-    - ploidy
-    - pathogenicity
-    - lib_reads_seqd
-    - propagation
-    - samp_collect_device
-    - number_contig
-    - biotic_relationship
-    - num_replicons
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - host_spec_range
-    - neg_cont_type
-    - adapters
-    - assembly_software
-    - tax_ident
-    - annot
-    - trophic_level
-    - pos_cont_type
-    - subspecf_gen_lin
-    - feat_pred
-    - env_local_scale
-    - compl_software
-    - samp_mat_process
-    - sim_search_meth
-    - host_disease_stat
-    - depth
-    - samp_collect_method
-    - specific_host
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - estimated_size
+      - extrachrom_elements
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - ploidy
+      - pathogenicity
+      - lib_reads_seqd
+      - propagation
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - num_replicons
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - trophic_level
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -14778,13 +14793,13 @@ classes:
         required: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
       host_disease_stat:
         examples:
-        - value: rabies [DOID:11260]
+          - value: rabies [DOID:11260]
       isol_growth_condt:
         required: true
       nucl_acid_amp:
@@ -14799,10 +14814,10 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -14820,60 +14835,60 @@ classes:
     description: 'Minimal Information about a Genome Sequence: organelle'
     title: MIGS org
     aliases:
-    - migs_org
+      - migs_org
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - assembly_name
-    - temp
-    - compl_score
-    - nucl_acid_ext
-    - samp_size
-    - isol_growth_condt
-    - alt
-    - source_mat_id
-    - extrachrom_elements
-    - estimated_size
-    - samp_vol_we_dna_ext
-    - lib_reads_seqd
-    - samp_collect_device
-    - number_contig
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - adapters
-    - neg_cont_type
-    - assembly_software
-    - tax_ident
-    - annot
-    - pos_cont_type
-    - subspecf_gen_lin
-    - feat_pred
-    - env_local_scale
-    - compl_software
-    - samp_mat_process
-    - sim_search_meth
-    - depth
-    - samp_collect_method
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - extrachrom_elements
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - samp_collect_device
+      - number_contig
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -14887,7 +14902,7 @@ classes:
         required: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -14901,10 +14916,10 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -14920,63 +14935,63 @@ classes:
     description: 'Minimal Information about a Genome Sequence: plasmid'
     title: MIGS pl
     aliases:
-    - migs_pl
+      - migs_pl
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - assembly_name
-    - temp
-    - compl_score
-    - nucl_acid_ext
-    - samp_size
-    - isol_growth_condt
-    - alt
-    - source_mat_id
-    - estimated_size
-    - samp_vol_we_dna_ext
-    - lib_reads_seqd
-    - encoded_traits
-    - propagation
-    - samp_collect_device
-    - number_contig
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - host_spec_range
-    - neg_cont_type
-    - adapters
-    - assembly_software
-    - tax_ident
-    - annot
-    - pos_cont_type
-    - subspecf_gen_lin
-    - feat_pred
-    - env_local_scale
-    - compl_software
-    - samp_mat_process
-    - sim_search_meth
-    - depth
-    - samp_collect_method
-    - specific_host
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - encoded_traits
+      - propagation
+      - samp_collect_device
+      - number_contig
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -14990,7 +15005,7 @@ classes:
         required: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15006,10 +15021,10 @@ classes:
         required: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -15027,68 +15042,68 @@ classes:
     description: 'Minimal Information about a Genome Sequence: virus'
     title: MIGS virus
     aliases:
-    - migs_vi
+      - migs_vi
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - assembly_name
-    - temp
-    - compl_score
-    - nucl_acid_ext
-    - samp_size
-    - isol_growth_condt
-    - alt
-    - source_mat_id
-    - estimated_size
-    - samp_vol_we_dna_ext
-    - pathogenicity
-    - lib_reads_seqd
-    - encoded_traits
-    - propagation
-    - samp_collect_device
-    - number_contig
-    - biotic_relationship
-    - num_replicons
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - host_spec_range
-    - neg_cont_type
-    - virus_enrich_appr
-    - adapters
-    - assembly_software
-    - tax_ident
-    - annot
-    - pos_cont_type
-    - subspecf_gen_lin
-    - feat_pred
-    - env_local_scale
-    - compl_software
-    - samp_mat_process
-    - sim_search_meth
-    - host_disease_stat
-    - depth
-    - samp_collect_method
-    - specific_host
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - pathogenicity
+      - lib_reads_seqd
+      - encoded_traits
+      - propagation
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - num_replicons
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - virus_enrich_appr
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15102,7 +15117,7 @@ classes:
         required: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15110,7 +15125,7 @@ classes:
         recommended: true
       host_disease_stat:
         examples:
-        - value: rabies [DOID:11260]
+          - value: rabies [DOID:11260]
         recommended: true
       host_spec_range:
         recommended: true
@@ -15128,10 +15143,10 @@ classes:
         required: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
       sop:
         recommended: true
       source_mat_id:
@@ -15151,72 +15166,72 @@ classes:
     description: Minimum Information About a Metagenome-Assembled Genome
     title: MIMAG
     aliases:
-    - mimag
+      - mimag
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - size_frac
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - contam_screen_input
-    - mid
-    - assembly_name
-    - temp
-    - compl_score
-    - trnas
-    - mag_cov_software
-    - nucl_acid_ext
-    - samp_size
-    - alt
-    - bin_param
-    - bin_software
-    - source_mat_id
-    - samp_vol_we_dna_ext
-    - lib_reads_seqd
-    - rel_to_oxygen
-    - reassembly_bin
-    - decontam_software
-    - samp_collect_device
-    - number_contig
-    - trna_ext_software
-    - lib_layout
-    - contam_screen_param
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - adapters
-    - neg_cont_type
-    - assembly_software
-    - tax_ident
-    - contam_score
-    - annot
-    - x16s_recover_software
-    - x16s_recover
-    - pos_cont_type
-    - feat_pred
-    - compl_software
-    - env_local_scale
-    - samp_mat_process
-    - sim_search_meth
-    - depth
-    - samp_collect_method
-    - compl_appr
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - size_frac
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - contam_screen_input
+      - mid
+      - assembly_name
+      - temp
+      - compl_score
+      - trnas
+      - mag_cov_software
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - bin_param
+      - bin_software
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - reassembly_bin
+      - decontam_software
+      - samp_collect_device
+      - number_contig
+      - trna_ext_software
+      - lib_layout
+      - contam_screen_param
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - tax_ident
+      - contam_score
+      - annot
+      - x16s_recover_software
+      - x16s_recover
+      - pos_cont_type
+      - feat_pred
+      - compl_software
+      - env_local_scale
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - compl_appr
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15240,7 +15255,7 @@ classes:
         required: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15264,11 +15279,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
@@ -15287,53 +15302,53 @@ classes:
     description: 'Minimal Information about a Marker Sequence: specimen'
     title: MIMARKS specimen
     comments:
-    - for marker gene sequences from cultured or voucher-identifiable specimens
+      - for marker gene sequences from cultured or voucher-identifiable specimens
     aliases:
-    - mimarks_c
-    - MIMARKS-SU
-    - MIMARKS-specimen
+      - mimarks_c
+      - MIMARKS-SU
+      - MIMARKS-specimen
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - pcr_primers
-    - nucl_acid_amp
-    - target_subfragment
-    - temp
-    - pcr_cond
-    - nucl_acid_ext
-    - samp_size
-    - isol_growth_condt
-    - alt
-    - source_mat_id
-    - extrachrom_elements
-    - samp_vol_we_dna_ext
-    - rel_to_oxygen
-    - samp_collect_device
-    - biotic_relationship
-    - seq_quality_check
-    - project_name
-    - neg_cont_type
-    - chimera_check
-    - trophic_level
-    - pos_cont_type
-    - subspecf_gen_lin
-    - env_local_scale
-    - samp_mat_process
-    - depth
-    - samp_collect_method
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - experimental_factor
-    - target_gene
-    - associated_resource
-    - sop
+      - samp_name
+      - pcr_primers
+      - nucl_acid_amp
+      - target_subfragment
+      - temp
+      - pcr_cond
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - extrachrom_elements
+      - samp_vol_we_dna_ext
+      - rel_to_oxygen
+      - samp_collect_device
+      - biotic_relationship
+      - seq_quality_check
+      - project_name
+      - neg_cont_type
+      - chimera_check
+      - trophic_level
+      - pos_cont_type
+      - subspecf_gen_lin
+      - env_local_scale
+      - samp_mat_process
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - experimental_factor
+      - target_gene
+      - associated_resource
+      - sop
     slot_usage:
       alt:
         recommended: true
@@ -15343,7 +15358,7 @@ classes:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15361,10 +15376,10 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
       samp_mat_process:
         recommended: true
       seq_quality_check:
@@ -15388,57 +15403,57 @@ classes:
     description: 'Minimal Information about a Marker Sequence: survey'
     title: MIMARKS survey
     comments:
-    - for marker gene sequences obtained directly from the environment
+      - for marker gene sequences obtained directly from the environment
     aliases:
-    - mimarks_s
-    - MIMARKS-SP
-    - MIMARKS-survey
+      - mimarks_s
+      - MIMARKS-SP
+      - MIMARKS-survey
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - pcr_primers
-    - size_frac
-    - lib_screen
-    - nucl_acid_amp
-    - lib_size
-    - target_subfragment
-    - mid
-    - temp
-    - nucl_acid_ext
-    - samp_size
-    - alt
-    - source_mat_id
-    - samp_vol_we_dna_ext
-    - lib_reads_seqd
-    - rel_to_oxygen
-    - samp_collect_device
-    - seq_quality_check
-    - lib_layout
-    - env_broad_scale
-    - project_name
-    - lib_vector
-    - adapters
-    - neg_cont_type
-    - assembly_software
-    - chimera_check
-    - pos_cont_type
-    - env_local_scale
-    - samp_mat_process
-    - depth
-    - samp_collect_method
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - pcr_cond
-    - experimental_factor
-    - target_gene
-    - associated_resource
-    - sop
+      - samp_name
+      - pcr_primers
+      - size_frac
+      - lib_screen
+      - nucl_acid_amp
+      - lib_size
+      - target_subfragment
+      - mid
+      - temp
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - samp_collect_device
+      - seq_quality_check
+      - lib_layout
+      - env_broad_scale
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - chimera_check
+      - pos_cont_type
+      - env_local_scale
+      - samp_mat_process
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - pcr_cond
+      - experimental_factor
+      - target_gene
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15450,7 +15465,7 @@ classes:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15478,11 +15493,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
@@ -15505,56 +15520,56 @@ classes:
     description: Metagenome or Environmental
     title: MIMS
     aliases:
-    - mims
+      - mims
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - size_frac
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - mid
-    - assembly_name
-    - temp
-    - nucl_acid_ext
-    - samp_size
-    - alt
-    - source_mat_id
-    - samp_vol_we_dna_ext
-    - lib_reads_seqd
-    - rel_to_oxygen
-    - samp_collect_device
-    - number_contig
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - adapters
-    - neg_cont_type
-    - assembly_software
-    - annot
-    - pos_cont_type
-    - feat_pred
-    - env_local_scale
-    - samp_mat_process
-    - sim_search_meth
-    - depth
-    - samp_collect_method
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - size_frac
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - mid
+      - assembly_name
+      - temp
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - samp_collect_device
+      - number_contig
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - annot
+      - pos_cont_type
+      - feat_pred
+      - env_local_scale
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15570,7 +15585,7 @@ classes:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15596,11 +15611,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
@@ -15617,73 +15632,73 @@ classes:
     description: Minimum Information About a Single Amplified Genome
     title: Minimum Information About a Single Amplified Genome
     aliases:
-    - misag
+      - misag
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - size_frac
-    - lib_screen
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - contam_screen_input
-    - mid
-    - assembly_name
-    - temp
-    - compl_score
-    - trnas
-    - nucl_acid_ext
-    - samp_size
-    - alt
-    - source_mat_id
-    - samp_vol_we_dna_ext
-    - lib_reads_seqd
-    - rel_to_oxygen
-    - wga_amp_kit
-    - decontam_software
-    - samp_collect_device
-    - number_contig
-    - trna_ext_software
-    - sc_lysis_method
-    - lib_layout
-    - contam_screen_param
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - adapters
-    - neg_cont_type
-    - assembly_software
-    - tax_ident
-    - contam_score
-    - annot
-    - x16s_recover_software
-    - x16s_recover
-    - pos_cont_type
-    - feat_pred
-    - compl_software
-    - env_local_scale
-    - sort_tech
-    - samp_mat_process
-    - sim_search_meth
-    - depth
-    - samp_collect_method
-    - wga_amp_appr
-    - compl_appr
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - sc_lysis_approach
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - associated_resource
-    - sop
+      - samp_name
+      - size_frac
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - contam_screen_input
+      - mid
+      - assembly_name
+      - temp
+      - compl_score
+      - trnas
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - wga_amp_kit
+      - decontam_software
+      - samp_collect_device
+      - number_contig
+      - trna_ext_software
+      - sc_lysis_method
+      - lib_layout
+      - contam_screen_param
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - tax_ident
+      - contam_score
+      - annot
+      - x16s_recover_software
+      - x16s_recover
+      - pos_cont_type
+      - feat_pred
+      - compl_software
+      - env_local_scale
+      - sort_tech
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - wga_amp_appr
+      - compl_appr
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - sc_lysis_approach
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15703,7 +15718,7 @@ classes:
         required: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -15727,11 +15742,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
@@ -15756,87 +15771,87 @@ classes:
     description: Minimum Information About an Uncultivated Virus Genome
     title: Minimum Information About an Uncultivated Virus Genome
     aliases:
-    - miuvig
+      - miuvig
     is_a: Checklist
     mixin: true
     slots:
-    - samp_name
-    - size_frac
-    - lib_screen
-    - source_uvig
-    - ref_db
-    - nucl_acid_amp
-    - lib_size
-    - mid
-    - assembly_name
-    - temp
-    - compl_score
-    - trnas
-    - nucl_acid_ext
-    - samp_size
-    - alt
-    - estimated_size
-    - source_mat_id
-    - samp_vol_we_dna_ext
-    - pathogenicity
-    - lib_reads_seqd
-    - samp_collect_device
-    - number_contig
-    - biotic_relationship
-    - trna_ext_software
-    - lib_layout
-    - assembly_qual
-    - ref_biomaterial
-    - project_name
-    - lib_vector
-    - host_spec_range
-    - neg_cont_type
-    - virus_enrich_appr
-    - adapters
-    - assembly_software
-    - tax_ident
-    - annot
-    - pos_cont_type
-    - feat_pred
-    - compl_software
-    - env_local_scale
-    - samp_mat_process
-    - sim_search_meth
-    - host_disease_stat
-    - depth
-    - samp_collect_method
-    - compl_appr
-    - specific_host
-    - env_medium
-    - samp_taxon_id
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - lat_lon
-    - elev
-    - env_broad_scale
-    - tax_class
-    - experimental_factor
-    - sort_tech
-    - sc_lysis_approach
-    - sc_lysis_method
-    - wga_amp_appr
-    - wga_amp_kit
-    - bin_param
-    - bin_software
-    - reassembly_bin
-    - mag_cov_software
-    - vir_ident_software
-    - pred_genome_type
-    - pred_genome_struc
-    - detec_type
-    - otu_class_appr
-    - otu_seq_comp_appr
-    - otu_db
-    - host_pred_appr
-    - host_pred_est_acc
-    - associated_resource
-    - sop
+      - samp_name
+      - size_frac
+      - lib_screen
+      - source_uvig
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - mid
+      - assembly_name
+      - temp
+      - compl_score
+      - trnas
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - estimated_size
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - pathogenicity
+      - lib_reads_seqd
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - trna_ext_software
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - virus_enrich_appr
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - feat_pred
+      - compl_software
+      - env_local_scale
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - compl_appr
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - sort_tech
+      - sc_lysis_approach
+      - sc_lysis_method
+      - wga_amp_appr
+      - wga_amp_kit
+      - bin_param
+      - bin_software
+      - reassembly_bin
+      - mag_cov_software
+      - vir_ident_software
+      - pred_genome_type
+      - pred_genome_struc
+      - detec_type
+      - otu_class_appr
+      - otu_seq_comp_appr
+      - otu_db
+      - host_pred_appr
+      - host_pred_est_acc
+      - associated_resource
+      - sop
     slot_usage:
       adapters:
         recommended: true
@@ -15858,7 +15873,7 @@ classes:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       detec_type:
         required: true
@@ -15870,7 +15885,7 @@ classes:
         recommended: true
       host_disease_stat:
         examples:
-        - value: rabies [DOID:11260]
+          - value: rabies [DOID:11260]
         recommended: true
       host_pred_appr:
         recommended: true
@@ -15910,11 +15925,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
         recommended: true
       samp_collect_method:
         examples:
-        - value: swabbing
+          - value: swabbing
         recommended: true
       samp_mat_process:
         recommended: true
@@ -15958,166 +15973,166 @@ classes:
     title: agriculture
     is_a: Extension
     slots:
-    - plant_growth_med
-    - photosynt_activ
-    - photosynt_activ_meth
-    - samp_collect_method
-    - enrichment_protocol
-    - library_prep_kit
-    - sequencing_location
-    - soil_temp
-    - soil_pH
-    - soil_conductivity
-    - rel_location
-    - soil_cover
-    - porosity
-    - soil_texture
-    - soil_texture_meth
-    - host_symbiont
-    - host_disease_stat
-    - pres_animal_insect
-    - plant_water_method
-    - anim_water_method
-    - farm_water_source
-    - water_source_shared
-    - water_pH
-    - elev
-    - season
-    - solar_irradiance
-    - crop_yield
-    - season_humidity
-    - humidity
-    - adjacent_environment
-    - chem_administration
-    - food_prod
-    - lot_number
-    - fertilizer_admin
-    - samp_store_temp
-    - food_trav_mode
-    - food_trav_vehic
-    - farm_equip_san
-    - farm_equip
-    - farm_equip_shared
-    - food_harvest_proc
-    - plant_struc
-    - host_dry_mass
-    - ances_data
-    - genetic_mod
-    - food_product_type
-    - food_source
-    - spikein_strain
-    - organism_count
-    - size_frac_low
-    - size_frac_up
-    - cult_isol_date
-    - samp_pooling
-    - root_med_macronutr
-    - root_med_carbon
-    - root_med_ph
-    - depth
-    - specific_host
-    - pathogenicity
-    - biotic_relationship
-    - water_temp_regm
-    - watering_regm
-    - standing_water_regm
-    - gaseous_environment
-    - fungicide_regm
-    - climate_environment
-    - herbicide_regm
-    - non_min_nutr_regm
-    - pesticide_regm
-    - ph_regm
-    - salt_regm
-    - season_environment
-    - temp
-    - perturbation
-    - isol_growth_condt
-    - samp_store_dur
-    - samp_store_loc
-    - samp_collect_device
-    - samp_mat_process
-    - host_age
-    - host_common_name
-    - host_genotype
-    - host_height
-    - host_subspecf_genlin
-    - host_length
-    - host_life_stage
-    - host_phenotype
-    - host_taxid
-    - host_tot_mass
-    - host_spec_range
-    - trophic_level
-    - plant_product
-    - samp_size
-    - oxy_stat_samp
-    - seq_meth
-    - samp_vol_we_dna_ext
-    - pcr_primers
-    - nucl_acid_ext
-    - nucl_acid_amp
-    - lib_size
-    - lib_reads_seqd
-    - lib_layout
-    - lib_vector
-    - lib_screen
-    - target_gene
-    - target_subfragment
-    - mid
-    - adapters
-    - pcr_cond
-    - seq_quality_check
-    - chimera_check
-    - assembly_name
-    - assembly_qual
-    - assembly_software
-    - annot
-    - associated_resource
-    - sop
-    - source_mat_id
-    - fao_class
-    - local_class
-    - local_class_meth
-    - soil_type
-    - soil_type_meth
-    - soil_horizon
-    - horizon_meth
-    - link_class_info
-    - previous_land_use
-    - prev_land_use_meth
-    - crop_rotation
-    - agrochem_addition
-    - tillage
-    - fire
-    - flooding
-    - extreme_event
-    - link_climate_info
-    - annual_temp
-    - season_temp
-    - annual_precpt
-    - season_precpt
-    - cur_land_use
-    - slope_gradient
-    - slope_aspect
-    - profile_position
-    - drainage_class
-    - store_cond
-    - ph_meth
-    - cur_vegetation
-    - cur_vegetation_meth
-    - tot_org_carb
-    - tot_org_c_meth
-    - tot_nitro_content
-    - tot_nitro_cont_meth
-    - microbial_biomass
-    - micro_biomass_meth
-    - heavy_metals_meth
-    - tot_carb
-    - tot_phosphate
-    - sieving
-    - pool_dna_extracts
-    - misc_param
+      - plant_growth_med
+      - photosynt_activ
+      - photosynt_activ_meth
+      - samp_collect_method
+      - enrichment_protocol
+      - library_prep_kit
+      - sequencing_location
+      - soil_temp
+      - soil_pH
+      - soil_conductivity
+      - rel_location
+      - soil_cover
+      - porosity
+      - soil_texture
+      - soil_texture_meth
+      - host_symbiont
+      - host_disease_stat
+      - pres_animal_insect
+      - plant_water_method
+      - anim_water_method
+      - farm_water_source
+      - water_source_shared
+      - water_pH
+      - elev
+      - season
+      - solar_irradiance
+      - crop_yield
+      - season_humidity
+      - humidity
+      - adjacent_environment
+      - chem_administration
+      - food_prod
+      - lot_number
+      - fertilizer_admin
+      - samp_store_temp
+      - food_trav_mode
+      - food_trav_vehic
+      - farm_equip_san
+      - farm_equip
+      - farm_equip_shared
+      - food_harvest_proc
+      - plant_struc
+      - host_dry_mass
+      - ances_data
+      - genetic_mod
+      - food_product_type
+      - food_source
+      - spikein_strain
+      - organism_count
+      - size_frac_low
+      - size_frac_up
+      - cult_isol_date
+      - samp_pooling
+      - root_med_macronutr
+      - root_med_carbon
+      - root_med_ph
+      - depth
+      - specific_host
+      - pathogenicity
+      - biotic_relationship
+      - water_temp_regm
+      - watering_regm
+      - standing_water_regm
+      - gaseous_environment
+      - fungicide_regm
+      - climate_environment
+      - herbicide_regm
+      - non_min_nutr_regm
+      - pesticide_regm
+      - ph_regm
+      - salt_regm
+      - season_environment
+      - temp
+      - perturbation
+      - isol_growth_condt
+      - samp_store_dur
+      - samp_store_loc
+      - samp_collect_device
+      - samp_mat_process
+      - host_age
+      - host_common_name
+      - host_genotype
+      - host_height
+      - host_subspecf_genlin
+      - host_length
+      - host_life_stage
+      - host_phenotype
+      - host_taxid
+      - host_tot_mass
+      - host_spec_range
+      - trophic_level
+      - plant_product
+      - samp_size
+      - oxy_stat_samp
+      - seq_meth
+      - samp_vol_we_dna_ext
+      - pcr_primers
+      - nucl_acid_ext
+      - nucl_acid_amp
+      - lib_size
+      - lib_reads_seqd
+      - lib_layout
+      - lib_vector
+      - lib_screen
+      - target_gene
+      - target_subfragment
+      - mid
+      - adapters
+      - pcr_cond
+      - seq_quality_check
+      - chimera_check
+      - assembly_name
+      - assembly_qual
+      - assembly_software
+      - annot
+      - associated_resource
+      - sop
+      - source_mat_id
+      - fao_class
+      - local_class
+      - local_class_meth
+      - soil_type
+      - soil_type_meth
+      - soil_horizon
+      - horizon_meth
+      - link_class_info
+      - previous_land_use
+      - prev_land_use_meth
+      - crop_rotation
+      - agrochem_addition
+      - tillage
+      - fire
+      - flooding
+      - extreme_event
+      - link_climate_info
+      - annual_temp
+      - season_temp
+      - annual_precpt
+      - season_precpt
+      - cur_land_use
+      - slope_gradient
+      - slope_aspect
+      - profile_position
+      - drainage_class
+      - store_cond
+      - ph_meth
+      - cur_vegetation
+      - cur_vegetation_meth
+      - tot_org_carb
+      - tot_org_c_meth
+      - tot_nitro_content
+      - tot_nitro_cont_meth
+      - microbial_biomass
+      - micro_biomass_meth
+      - heavy_metals_meth
+      - tot_carb
+      - tot_phosphate
+      - sieving
+      - pool_dna_extracts
+      - misc_param
     slot_usage:
       adapters:
         required: true
@@ -16143,7 +16158,7 @@ classes:
         recommended: true
       depth:
         examples:
-        - value: 5 cm
+          - value: 5 cm
         recommended: true
       drainage_class:
         recommended: true
@@ -16159,10 +16174,10 @@ classes:
         recommended: true
       food_product_type:
         examples:
-        - value: delicatessen salad; FOODON:03316276
+          - value: delicatessen salad; FOODON:03316276
       food_source:
         examples:
-        - value: red swamp crayfish; FOODON:03412231
+          - value: red swamp crayfish; FOODON:03412231
         required: true
       fungicide_regm:
         string_serialization: '{text};{float} {unit};{period};{interval};{period}'
@@ -16184,7 +16199,7 @@ classes:
         required: true
       host_disease_stat:
         examples:
-        - value: downy mildew
+          - value: downy mildew
         recommended: true
       host_genotype:
         required: true
@@ -16200,17 +16215,17 @@ classes:
         required: true
       host_symbiont:
         examples:
-        - value: Paragordius varius
+          - value: Paragordius varius
       host_taxid:
         examples:
-        - value: '9606'
+          - value: '9606'
         string_serialization: '{integer}'
         required: true
       host_tot_mass:
         required: true
       humidity:
         examples:
-        - value: 30% relative humidity
+          - value: 30% relative humidity
         recommended: true
       lib_layout:
         recommended: true
@@ -16222,7 +16237,7 @@ classes:
         required: true
       library_prep_kit:
         examples:
-        - value: llumina DNA Prep, (M) Tagmentation
+          - value: llumina DNA Prep, (M) Tagmentation
       local_class:
         recommended: true
       local_class_meth:
@@ -16242,7 +16257,7 @@ classes:
         required: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         recommended: true
       oxy_stat_samp:
         recommended: true
@@ -16264,7 +16279,7 @@ classes:
         recommended: true
       plant_growth_med:
         examples:
-        - value: hydroponic plant culture media [EO:0007067]
+          - value: hydroponic plant culture media [EO:0007067]
       plant_product:
         recommended: true
       plant_struc:
@@ -16285,11 +16300,11 @@ classes:
         recommended: true
       samp_collect_device:
         examples:
-        - value: biopsy, niskin bottle, push core
+          - value: biopsy, niskin bottle, push core
         required: true
       samp_collect_method:
         examples:
-        - value: environmental swab sampling
+          - value: environmental swab sampling
       samp_mat_process:
         required: true
       samp_pooling:
@@ -16320,7 +16335,6 @@ classes:
       soil_pH:
         description: pH of some soil.
       soil_type:
-        string_serialization: '{text}'
         required: true
       soil_type_meth:
         required: true
@@ -16373,35 +16387,35 @@ classes:
     title: air
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - alt
-    - elev
-    - barometric_press
-    - carb_dioxide
-    - carb_monoxide
-    - chem_administration
-    - humidity
-    - methane
-    - organism_count
-    - oxygen
-    - oxy_stat_samp
-    - perturbation
-    - pollutants
-    - air_PM_concen
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - solar_irradiance
-    - temp
-    - ventilation_rate
-    - ventilation_type
-    - volatile_org_comp
-    - wind_direction
-    - wind_speed
-    - misc_param
+      - samp_name
+      - project_name
+      - alt
+      - elev
+      - barometric_press
+      - carb_dioxide
+      - carb_monoxide
+      - chem_administration
+      - humidity
+      - methane
+      - organism_count
+      - oxygen
+      - oxy_stat_samp
+      - perturbation
+      - pollutants
+      - air_PM_concen
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - solar_irradiance
+      - temp
+      - ventilation_rate
+      - ventilation_type
+      - volatile_org_comp
+      - wind_direction
+      - wind_speed
+      - misc_param
     slot_usage:
       alt:
         required: true
@@ -16409,19 +16423,19 @@ classes:
         recommended: true
       humidity:
         examples:
-        - value: 25 gram per cubic meter
+          - value: 25 gram per cubic meter
       methane:
         examples:
-        - value: 1800 parts per billion
+          - value: 1800 parts per billion
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       wind_direction:
         examples:
-        - value: Northwest
+          - value: Northwest
       wind_speed:
         examples:
-        - value: 21 kilometer per hour
+          - value: 21 kilometer per hour
     class_uri: MIXS:0016000
     aliases:
       - MIxS-air
@@ -16435,176 +16449,176 @@ classes:
     title: built environment
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - surf_material
-    - surf_air_cont
-    - rel_air_humidity
-    - abs_air_humidity
-    - surf_humidity
-    - air_temp
-    - surf_temp
-    - surf_moisture_ph
-    - build_occup_type
-    - surf_moisture
-    - dew_point
-    - carb_dioxide
-    - ventilation_type
-    - organism_count
-    - indoor_space
-    - indoor_surf
-    - filter_type
-    - heat_cool_type
-    - substructure_type
-    - building_setting
-    - light_type
-    - samp_sort_meth
-    - space_typ_state
-    - typ_occup_density
-    - occup_samp
-    - occup_density_samp
-    - address
-    - adj_room
-    - aero_struc
-    - amount_light
-    - arch_struc
-    - avg_occup
-    - avg_dew_point
-    - avg_temp
-    - bathroom_count
-    - bedroom_count
-    - built_struc_age
-    - built_struc_set
-    - built_struc_type
-    - ceil_area
-    - ceil_cond
-    - ceil_finish_mat
-    - ceil_water_mold
-    - ceil_struc
-    - ceil_texture
-    - ceil_thermal_mass
-    - ceil_type
-    - cool_syst_id
-    - date_last_rain
-    - build_docs
-    - door_size
-    - door_cond
-    - door_direct
-    - door_loc
-    - door_mat
-    - door_move
-    - door_water_mold
-    - door_type
-    - door_comp_type
-    - door_type_metal
-    - door_type_wood
-    - drawings
-    - elevator
-    - escalator
-    - exp_duct
-    - exp_pipe
-    - ext_door
-    - fireplace_type
-    - floor_age
-    - floor_area
-    - floor_cond
-    - floor_count
-    - floor_finish_mat
-    - floor_water_mold
-    - floor_struc
-    - floor_thermal_mass
-    - freq_clean
-    - freq_cook
-    - furniture
-    - gender_restroom
-    - hall_count
-    - handidness
-    - heat_deliv_loc
-    - heat_sys_deliv_meth
-    - heat_system_id
-    - height_carper_fiber
-    - inside_lux
-    - int_wall_cond
-    - last_clean
-    - max_occup
-    - mech_struc
-    - number_plants
-    - number_pets
-    - number_resident
-    - occup_document
-    - ext_wall_orient
-    - ext_window_orient
-    - rel_humidity_out
-    - pres_animal_insect
-    - quad_pos
-    - rel_samp_loc
-    - room_air_exch_rate
-    - room_architec_elem
-    - room_condt
-    - room_count
-    - room_dim
-    - room_door_dist
-    - room_loc
-    - room_moist_dam_hist
-    - room_net_area
-    - room_occup
-    - room_samp_pos
-    - room_type
-    - room_vol
-    - room_window_count
-    - room_connected
-    - room_hallway
-    - room_door_share
-    - room_wall_share
-    - samp_weather
-    - samp_floor
-    - samp_room_id
-    - samp_time_out
-    - season
-    - season_use
-    - shading_device_cond
-    - shading_device_loc
-    - shading_device_mat
-    - shad_dev_water_mold
-    - shading_device_type
-    - specific_humidity
-    - specific
-    - temp_out
-    - train_line
-    - train_stat_loc
-    - train_stop_loc
-    - vis_media
-    - wall_area
-    - wall_const_type
-    - wall_finish_mat
-    - wall_height
-    - wall_loc
-    - wall_water_mold
-    - wall_surf_treatment
-    - wall_texture
-    - wall_thermal_mass
-    - water_feat_size
-    - water_feat_type
-    - weekday
-    - window_size
-    - window_cond
-    - window_cover
-    - window_horiz_pos
-    - window_loc
-    - window_mat
-    - window_open_freq
-    - window_water_mold
-    - window_status
-    - window_type
-    - window_vert_pos
+      - samp_name
+      - project_name
+      - surf_material
+      - surf_air_cont
+      - rel_air_humidity
+      - abs_air_humidity
+      - surf_humidity
+      - air_temp
+      - surf_temp
+      - surf_moisture_ph
+      - build_occup_type
+      - surf_moisture
+      - dew_point
+      - carb_dioxide
+      - ventilation_type
+      - organism_count
+      - indoor_space
+      - indoor_surf
+      - filter_type
+      - heat_cool_type
+      - substructure_type
+      - building_setting
+      - light_type
+      - samp_sort_meth
+      - space_typ_state
+      - typ_occup_density
+      - occup_samp
+      - occup_density_samp
+      - address
+      - adj_room
+      - aero_struc
+      - amount_light
+      - arch_struc
+      - avg_occup
+      - avg_dew_point
+      - avg_temp
+      - bathroom_count
+      - bedroom_count
+      - built_struc_age
+      - built_struc_set
+      - built_struc_type
+      - ceil_area
+      - ceil_cond
+      - ceil_finish_mat
+      - ceil_water_mold
+      - ceil_struc
+      - ceil_texture
+      - ceil_thermal_mass
+      - ceil_type
+      - cool_syst_id
+      - date_last_rain
+      - build_docs
+      - door_size
+      - door_cond
+      - door_direct
+      - door_loc
+      - door_mat
+      - door_move
+      - door_water_mold
+      - door_type
+      - door_comp_type
+      - door_type_metal
+      - door_type_wood
+      - drawings
+      - elevator
+      - escalator
+      - exp_duct
+      - exp_pipe
+      - ext_door
+      - fireplace_type
+      - floor_age
+      - floor_area
+      - floor_cond
+      - floor_count
+      - floor_finish_mat
+      - floor_water_mold
+      - floor_struc
+      - floor_thermal_mass
+      - freq_clean
+      - freq_cook
+      - furniture
+      - gender_restroom
+      - hall_count
+      - handidness
+      - heat_deliv_loc
+      - heat_sys_deliv_meth
+      - heat_system_id
+      - height_carper_fiber
+      - inside_lux
+      - int_wall_cond
+      - last_clean
+      - max_occup
+      - mech_struc
+      - number_plants
+      - number_pets
+      - number_resident
+      - occup_document
+      - ext_wall_orient
+      - ext_window_orient
+      - rel_humidity_out
+      - pres_animal_insect
+      - quad_pos
+      - rel_samp_loc
+      - room_air_exch_rate
+      - room_architec_elem
+      - room_condt
+      - room_count
+      - room_dim
+      - room_door_dist
+      - room_loc
+      - room_moist_dam_hist
+      - room_net_area
+      - room_occup
+      - room_samp_pos
+      - room_type
+      - room_vol
+      - room_window_count
+      - room_connected
+      - room_hallway
+      - room_door_share
+      - room_wall_share
+      - samp_weather
+      - samp_floor
+      - samp_room_id
+      - samp_time_out
+      - season
+      - season_use
+      - shading_device_cond
+      - shading_device_loc
+      - shading_device_mat
+      - shad_dev_water_mold
+      - shading_device_type
+      - specific_humidity
+      - specific
+      - temp_out
+      - train_line
+      - train_stat_loc
+      - train_stop_loc
+      - vis_media
+      - wall_area
+      - wall_const_type
+      - wall_finish_mat
+      - wall_height
+      - wall_loc
+      - wall_water_mold
+      - wall_surf_treatment
+      - wall_texture
+      - wall_thermal_mass
+      - water_feat_size
+      - water_feat_type
+      - weekday
+      - window_size
+      - window_cond
+      - window_cover
+      - window_horiz_pos
+      - window_loc
+      - window_mat
+      - window_open_freq
+      - window_water_mold
+      - window_status
+      - window_type
+      - window_vert_pos
     slot_usage:
       air_temp:
         examples:
-        - value: 20 degree Celsius
+          - value: 20 degree Celsius
         required: true
       avg_occup:
         examples:
-        - value: '2'
+          - value: '2'
       carb_dioxide:
         required: true
       freq_clean:
@@ -16614,7 +16628,7 @@ classes:
         recommended: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         required: true
       surf_material:
         required: true
@@ -16631,144 +16645,144 @@ classes:
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from farm animals and their feed.
     comments:
-      - This extension is intended to work alongside the other food extensions 
-        (farm environment, food production facility, and human foods) for capturing contextual data 
+      - This extension is intended to work alongside the other food extensions
+        (farm environment, food production facility, and human foods) for capturing contextual data
         across the food supply-chain environment.
     title: food-animal and animal feed
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - lat_lon
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - samp_size
-    - samp_collect_device
-    - experimental_factor
-    - nucl_acid_ext
-    - organism_count
-    - spikein_count
-    - samp_store_temp
-    - samp_store_dur
-    - samp_vol_we_dna_ext
-    - pool_dna_extracts
-    - temp
-    - samp_store_loc
-    - samp_transport_cont
-    - perturbation
-    - coll_site_geo_feat
-    - food_origin
-    - food_prod
-    - food_product_type
-    - food_source
-    - IFSAC_category
-    - intended_consumer
-    - samp_purpose
-    - animal_am
-    - animal_am_dur
-    - animal_am_freq
-    - animal_am_route
-    - animal_am_use
-    - animal_body_cond
-    - animal_diet
-    - animal_feed_equip
-    - animal_group_size
-    - animal_housing
-    - animal_sex
-    - bacterial_density
-    - cons_food_stor_dur
-    - cons_food_stor_temp
-    - cons_purch_date
-    - cons_qty_purchased
-    - cult_isol_date
-    - cult_result
-    - cult_result_org
-    - cult_target
-    - enrichment_protocol
-    - food_additive
-    - food_contact_surf
-    - food_contain_wrap
-    - food_cooking_proc
-    - food_dis_point
-    - food_dis_point_city
-    - food_ingredient
-    - food_pack_capacity
-    - food_pack_integrity
-    - food_pack_medium
-    - food_preserv_proc
-    - food_prior_contact
-    - food_prod_synonym
-    - food_product_qual
-    - food_quality_date
-    - food_source_age
-    - food_trace_list
-    - food_trav_mode
-    - food_trav_vehic
-    - food_treat_proc
-    - HACCP_term
-    - library_prep_kit
-    - lot_number
-    - microb_cult_med
-    - part_plant_animal
-    - repository_name
-    - samp_collect_method
-    - samp_pooling
-    - samp_rep_biol
-    - samp_rep_tech
-    - samp_source_mat_cat
-    - samp_stor_device
-    - samp_stor_media
-    - samp_transport_dur
-    - samp_transport_temp
-    - sequencing_kit
-    - sequencing_location
-    - serovar_or_serotype
-    - spikein_AMR
-    - spikein_antibiotic
-    - spikein_growth_med
-    - spikein_metal
-    - spikein_org
-    - spikein_serovar
-    - spikein_strain
-    - study_design
-    - study_inc_dur
-    - study_inc_temp
-    - study_timecourse
-    - study_tmnt
-    - timepoint
-    - misc_param
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - experimental_factor
+      - nucl_acid_ext
+      - organism_count
+      - spikein_count
+      - samp_store_temp
+      - samp_store_dur
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - temp
+      - samp_store_loc
+      - samp_transport_cont
+      - perturbation
+      - coll_site_geo_feat
+      - food_origin
+      - food_prod
+      - food_product_type
+      - food_source
+      - IFSAC_category
+      - intended_consumer
+      - samp_purpose
+      - animal_am
+      - animal_am_dur
+      - animal_am_freq
+      - animal_am_route
+      - animal_am_use
+      - animal_body_cond
+      - animal_diet
+      - animal_feed_equip
+      - animal_group_size
+      - animal_housing
+      - animal_sex
+      - bacterial_density
+      - cons_food_stor_dur
+      - cons_food_stor_temp
+      - cons_purch_date
+      - cons_qty_purchased
+      - cult_isol_date
+      - cult_result
+      - cult_result_org
+      - cult_target
+      - enrichment_protocol
+      - food_additive
+      - food_contact_surf
+      - food_contain_wrap
+      - food_cooking_proc
+      - food_dis_point
+      - food_dis_point_city
+      - food_ingredient
+      - food_pack_capacity
+      - food_pack_integrity
+      - food_pack_medium
+      - food_preserv_proc
+      - food_prior_contact
+      - food_prod_synonym
+      - food_product_qual
+      - food_quality_date
+      - food_source_age
+      - food_trace_list
+      - food_trav_mode
+      - food_trav_vehic
+      - food_treat_proc
+      - HACCP_term
+      - library_prep_kit
+      - lot_number
+      - microb_cult_med
+      - part_plant_animal
+      - repository_name
+      - samp_collect_method
+      - samp_pooling
+      - samp_rep_biol
+      - samp_rep_tech
+      - samp_source_mat_cat
+      - samp_stor_device
+      - samp_stor_media
+      - samp_transport_dur
+      - samp_transport_temp
+      - sequencing_kit
+      - sequencing_location
+      - serovar_or_serotype
+      - spikein_AMR
+      - spikein_antibiotic
+      - spikein_growth_med
+      - spikein_metal
+      - spikein_org
+      - spikein_serovar
+      - spikein_strain
+      - study_design
+      - study_inc_dur
+      - study_inc_temp
+      - study_timecourse
+      - study_tmnt
+      - timepoint
+      - misc_param
     slot_usage:
       food_origin:
         required: true
       food_pack_medium:
         examples:
-        - value: packed in fruit juice [FOODON:03480039]
+          - value: packed in fruit juice [FOODON:03480039]
       food_prod:
         required: true
       food_product_type:
         examples:
-        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-        - value: giant tiger prawn [FOODON:03412612]
+          - value: giant tiger prawn [FOODON:03412612]
       intended_consumer:
         required: true
       library_prep_kit:
         examples:
-        - value: Illumina DNA Prep
+          - value: Illumina DNA Prep
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       pool_dna_extracts:
         string_serialization: '{boolean},{integer}'
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: environmental swab sampling
+          - value: environmental swab sampling
       samp_purpose:
         required: true
     class_uri: MIXS:0016019
@@ -16781,152 +16795,152 @@ classes:
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from the farm environment, including soil, manure, and food harvesting equipment.
     comments:
-      - This extension is intended to work alongside the other food extensions 
-        (animals and animal feed, food production facility, and human foods) 
+      - This extension is intended to work alongside the other food extensions
+        (animals and animal feed, food production facility, and human foods)
         for capturing contextual data across the food supply-chain environment.
     title: food-farm environment
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - lat_lon
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - samp_size
-    - samp_collect_device
-    - nucl_acid_ext
-    - humidity
-    - organism_count
-    - spikein_count
-    - samp_store_temp
-    - solar_irradiance
-    - ventilation_rate
-    - samp_store_dur
-    - wind_speed
-    - salinity
-    - samp_vol_we_dna_ext
-    - previous_land_use
-    - crop_rotation
-    - soil_type_meth
-    - tot_org_c_meth
-    - tot_nitro_cont_meth
-    - host_age
-    - host_dry_mass
-    - host_height
-    - host_length
-    - host_tot_mass
-    - root_med_carbon
-    - root_med_macronutr
-    - root_med_micronutr
-    - depth
-    - season_temp
-    - season_precpt
-    - tot_org_carb
-    - tot_nitro_content
-    - conduc
-    - turbidity
-    - size_frac_low
-    - size_frac_up
-    - temp
-    - ventilation_type
-    - wind_direction
-    - genetic_mod
-    - host_phenotype
-    - ph
-    - ances_data
-    - biotic_regm
-    - chem_administration
-    - growth_habit
-    - host_disease_stat
-    - host_genotype
-    - host_taxid
-    - mechanical_damage
-    - perturbation
-    - root_cond
-    - root_med_ph
-    - tillage
-    - ph_meth
-    - growth_medium
-    - season
-    - food_product_type
-    - samp_type
-    - farm_water_source
-    - plant_water_method
-    - air_PM_concen
-    - animal_feed_equip
-    - animal_intrusion
-    - anim_water_method
-    - crop_yield
-    - cult_result
-    - cult_result_org
-    - cult_target
-    - plant_part_maturity
-    - adjacent_environment
-    - water_source_adjac
-    - farm_equip_shared
-    - farm_equip_san
-    - farm_equip_san_freq
-    - farm_equip
-    - fertilizer_admin
-    - fertilizer_date
-    - animal_group_size
-    - animal_diet
-    - food_contact_surf
-    - food_contain_wrap
-    - food_harvest_proc
-    - food_pack_medium
-    - food_preserv_proc
-    - food_prod_char
-    - prod_label_claims
-    - food_trav_mode
-    - food_trav_vehic
-    - food_source
-    - food_treat_proc
-    - extr_weather_event
-    - date_extr_weath
-    - host_subspecf_genlin
-    - intended_consumer
-    - library_prep_kit
-    - air_flow_impede
-    - lot_number
-    - season_humidity
-    - part_plant_animal
-    - plant_growth_med
-    - plant_reprod_crop
-    - samp_purpose
-    - repository_name
-    - samp_pooling
-    - samp_source_mat_cat
-    - sequencing_kit
-    - sequencing_location
-    - serovar_or_serotype
-    - soil_conductivity
-    - soil_cover
-    - soil_pH
-    - rel_location
-    - soil_porosity
-    - soil_temp
-    - soil_texture_class
-    - soil_texture_meth
-    - soil_type
-    - spikein_org
-    - spikein_serovar
-    - spikein_growth_med
-    - spikein_strain
-    - spikein_antibiotic
-    - spikein_metal
-    - timepoint
-    - water_frequency
-    - water_pH
-    - water_source_shared
-    - enrichment_protocol
-    - food_quality_date
-    - IFSAC_category
-    - animal_housing
-    - cult_isol_date
-    - food_clean_proc
-    - misc_param
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - nucl_acid_ext
+      - humidity
+      - organism_count
+      - spikein_count
+      - samp_store_temp
+      - solar_irradiance
+      - ventilation_rate
+      - samp_store_dur
+      - wind_speed
+      - salinity
+      - samp_vol_we_dna_ext
+      - previous_land_use
+      - crop_rotation
+      - soil_type_meth
+      - tot_org_c_meth
+      - tot_nitro_cont_meth
+      - host_age
+      - host_dry_mass
+      - host_height
+      - host_length
+      - host_tot_mass
+      - root_med_carbon
+      - root_med_macronutr
+      - root_med_micronutr
+      - depth
+      - season_temp
+      - season_precpt
+      - tot_org_carb
+      - tot_nitro_content
+      - conduc
+      - turbidity
+      - size_frac_low
+      - size_frac_up
+      - temp
+      - ventilation_type
+      - wind_direction
+      - genetic_mod
+      - host_phenotype
+      - ph
+      - ances_data
+      - biotic_regm
+      - chem_administration
+      - growth_habit
+      - host_disease_stat
+      - host_genotype
+      - host_taxid
+      - mechanical_damage
+      - perturbation
+      - root_cond
+      - root_med_ph
+      - tillage
+      - ph_meth
+      - growth_medium
+      - season
+      - food_product_type
+      - samp_type
+      - farm_water_source
+      - plant_water_method
+      - air_PM_concen
+      - animal_feed_equip
+      - animal_intrusion
+      - anim_water_method
+      - crop_yield
+      - cult_result
+      - cult_result_org
+      - cult_target
+      - plant_part_maturity
+      - adjacent_environment
+      - water_source_adjac
+      - farm_equip_shared
+      - farm_equip_san
+      - farm_equip_san_freq
+      - farm_equip
+      - fertilizer_admin
+      - fertilizer_date
+      - animal_group_size
+      - animal_diet
+      - food_contact_surf
+      - food_contain_wrap
+      - food_harvest_proc
+      - food_pack_medium
+      - food_preserv_proc
+      - food_prod_char
+      - prod_label_claims
+      - food_trav_mode
+      - food_trav_vehic
+      - food_source
+      - food_treat_proc
+      - extr_weather_event
+      - date_extr_weath
+      - host_subspecf_genlin
+      - intended_consumer
+      - library_prep_kit
+      - air_flow_impede
+      - lot_number
+      - season_humidity
+      - part_plant_animal
+      - plant_growth_med
+      - plant_reprod_crop
+      - samp_purpose
+      - repository_name
+      - samp_pooling
+      - samp_source_mat_cat
+      - sequencing_kit
+      - sequencing_location
+      - serovar_or_serotype
+      - soil_conductivity
+      - soil_cover
+      - soil_pH
+      - rel_location
+      - soil_porosity
+      - soil_temp
+      - soil_texture_class
+      - soil_texture_meth
+      - soil_type
+      - spikein_org
+      - spikein_serovar
+      - spikein_growth_med
+      - spikein_strain
+      - spikein_antibiotic
+      - spikein_metal
+      - timepoint
+      - water_frequency
+      - water_pH
+      - water_source_shared
+      - enrichment_protocol
+      - food_quality_date
+      - IFSAC_category
+      - animal_housing
+      - cult_isol_date
+      - food_clean_proc
+      - misc_param
     slot_usage:
       biotic_regm:
         required: true
@@ -16936,56 +16950,56 @@ classes:
         string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         required: true
       food_pack_medium:
         examples:
-        - value: vacuum-packed [FOODON:03480027]
+          - value: vacuum-packed [FOODON:03480027]
       food_product_type:
         examples:
-        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-        - value: giant tiger prawn [FOODON:03412612]
+          - value: giant tiger prawn [FOODON:03412612]
       host_age:
         examples:
-        - value: 10 days
+          - value: 10 days
       host_disease_stat:
         examples:
-        - value: downy mildew
+          - value: downy mildew
         recommended: true
       host_genotype:
         examples:
-        - value: Ts
+          - value: Ts
       host_height:
         examples:
-        - value: 1 meter
+          - value: 1 meter
       host_phenotype:
         examples:
-        - value: seed pod; green [PATO:0000320]
+          - value: seed pod; green [PATO:0000320]
       host_taxid:
         examples:
-        - value: '4530'
+          - value: '4530'
         string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
-        - value: 2500 gram
+          - value: 2500 gram
       humidity:
         examples:
-        - value: 30% relative humidity
+          - value: 30% relative humidity
       library_prep_kit:
         examples:
-        - value: Illumina DNA Prep
+          - value: Illumina DNA Prep
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       plant_growth_med:
         examples:
-        - value: soil
+          - value: soil
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       soil_conductivity:
         description: Conductivity of soil at time of sampling.
       soil_pH:
@@ -16997,10 +17011,10 @@ classes:
           aqueous phase of the fluid.
       wind_direction:
         examples:
-        - value: 0 degrees; Northwest
+          - value: 0 degrees; Northwest
       wind_speed:
         examples:
-        - value: 1.6 kilometers per hour
+          - value: 1.6 kilometers per hour
     class_uri: MIXS:0016020
     aliases:
       - MIxS-Food (farm environment)
@@ -17011,150 +17025,148 @@ classes:
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from food production facilities.
     comments:
-      - This extension is intended to work alongside the other food extensions 
-        (animals and animal feed, farm environment, and human foods) 
+      - This extension is intended to work alongside the other food extensions
+        (animals and animal feed, farm environment, and human foods)
         for capturing contextual data across the food supply-chain environment.
     title: food-food production facility
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - lat_lon
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - samp_size
-    - samp_collect_device
-    - experimental_factor
-    - nucl_acid_ext
-    - organism_count
-    - samp_store_temp
-    - samp_store_dur
-    - air_temp
-    - room_dim
-    - freq_clean
-    - samp_room_id
-    - samp_vol_we_dna_ext
-    - pool_dna_extracts
-    - samp_store_loc
-    - surf_material
-    - indoor_surf
-    - avg_occup
-    - samp_floor
-    - genetic_mod
-    - coll_site_geo_feat
-    - samp_source_mat_cat
-    - samp_type
-    - samp_stor_media
-    - samp_stor_device
-    - food_product_type
-    - IFSAC_category
-    - food_product_qual
-    - food_contact_surf
-    - facility_type
-    - food_trav_mode
-    - food_trav_vehic
-    - samp_transport_dur
-    - samp_transport_temp
-    - samp_collect_method
-    - num_samp_collect
-    - lot_number
-    - hygienic_area
-    - env_monitoring_zone
-    - area_samp_size
-    - samp_surf_moisture
-    - samp_loc_condition
-    - biocide_used
-    - ster_meth_samp_room
-    - enrichment_protocol
-    - cult_target
-    - microb_cult_med
-    - timepoint
-    - bacterial_density
-    - cult_isol_date
-    - cult_result
-    - cult_result_org
-    - subspecf_gen_lin
-    - samp_pooling
-    - samp_purpose
-    - samp_rep_tech
-    - samp_rep_biol
-    - samp_transport_cont
-    - study_design
-    - nucl_acid_ext_kit
-    - library_prep_kit
-    - sequencing_kit
-    - sequencing_location
-    - study_inc_temp
-    - study_inc_dur
-    - study_timecourse
-    - study_tmnt
-    - food_source
-    - food_dis_point
-    - food_dis_point_city
-    - food_origin
-    - food_prod_synonym
-    - food_additive
-    - food_trace_list
-    - part_plant_animal
-    - food_ingredient
-    - spec_intended_cons
-    - HACCP_term
-    - dietary_claim_use
-    - food_allergen_label
-    - food_prod_char
-    - prod_label_claims
-    - food_name_status
-    - food_preserv_proc
-    - food_cooking_proc
-    - food_treat_proc
-    - food_contain_wrap
-    - food_pack_capacity
-    - food_pack_medium
-    - food_prior_contact
-    - food_prod
-    - food_quality_date
-    - repository_name
-    - intended_consumer
-    - food_pack_integrity
-    - misc_param
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - experimental_factor
+      - nucl_acid_ext
+      - organism_count
+      - samp_store_temp
+      - samp_store_dur
+      - air_temp
+      - room_dim
+      - freq_clean
+      - samp_room_id
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - samp_store_loc
+      - surf_material
+      - indoor_surf
+      - avg_occup
+      - samp_floor
+      - genetic_mod
+      - coll_site_geo_feat
+      - samp_source_mat_cat
+      - samp_type
+      - samp_stor_media
+      - samp_stor_device
+      - food_product_type
+      - IFSAC_category
+      - food_product_qual
+      - food_contact_surf
+      - facility_type
+      - food_trav_mode
+      - food_trav_vehic
+      - samp_transport_dur
+      - samp_transport_temp
+      - samp_collect_method
+      - num_samp_collect
+      - lot_number
+      - hygienic_area
+      - env_monitoring_zone
+      - area_samp_size
+      - samp_surf_moisture
+      - samp_loc_condition
+      - biocide_used
+      - ster_meth_samp_room
+      - enrichment_protocol
+      - cult_target
+      - microb_cult_med
+      - timepoint
+      - bacterial_density
+      - cult_isol_date
+      - cult_result
+      - cult_result_org
+      - subspecf_gen_lin
+      - samp_pooling
+      - samp_purpose
+      - samp_rep_tech
+      - samp_rep_biol
+      - samp_transport_cont
+      - study_design
+      - nucl_acid_ext_kit
+      - library_prep_kit
+      - sequencing_kit
+      - sequencing_location
+      - study_inc_temp
+      - study_inc_dur
+      - study_timecourse
+      - study_tmnt
+      - food_source
+      - food_dis_point
+      - food_dis_point_city
+      - food_origin
+      - food_prod_synonym
+      - food_additive
+      - food_trace_list
+      - part_plant_animal
+      - food_ingredient
+      - spec_intended_cons
+      - HACCP_term
+      - dietary_claim_use
+      - food_allergen_label
+      - food_prod_char
+      - prod_label_claims
+      - food_name_status
+      - food_preserv_proc
+      - food_cooking_proc
+      - food_treat_proc
+      - food_contain_wrap
+      - food_pack_capacity
+      - food_pack_medium
+      - food_prior_contact
+      - food_prod
+      - food_quality_date
+      - repository_name
+      - intended_consumer
+      - food_pack_integrity
+      - misc_param
     slot_usage:
       air_temp:
         examples:
-        - value: 4 degree Celsius
+          - value: 4 degree Celsius
       avg_occup:
         examples:
-        - value: '6'
+          - value: '6'
       food_contact_surf:
         required: true
       food_pack_medium:
         examples:
-        - value: vacuum-packed [FOODON:03480027]
+          - value: vacuum-packed [FOODON:03480027]
       food_product_qual:
         required: true
       food_product_type:
         examples:
-        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-        - value: giant tiger prawn [FOODON:03412612]
-      freq_clean:
-        string_serialization: '{text}'
+          - value: giant tiger prawn [FOODON:03412612]
       library_prep_kit:
         examples:
-        - value: Illumina DNA Prep
+          - value: Illumina DNA Prep
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       pool_dna_extracts:
         string_serialization: '{boolean},{integer}'
       samp_collect_device:
         examples:
-        - value: biopsy, niskin bottle, push core
+          - value: biopsy, niskin bottle, push core
       samp_collect_method:
         examples:
-        - value: environmental swab sampling
+          - value: environmental swab sampling
       samp_source_mat_cat:
         required: true
       samp_stor_device:
@@ -17171,146 +17183,146 @@ classes:
       A collection of terms appropriate when collecting samples and performing sequencing of samples 
       obtained from human food products.
     comments:
-      - This extension is intended to work alongside the other food extensions 
-        (animals and animal feed, farm environment, and food production facilities) 
+      - This extension is intended to work alongside the other food extensions
+        (animals and animal feed, farm environment, and food production facilities)
         for capturing contextual data across the food supply-chain environment.
     title: food-human foods
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - lat_lon
-    - geo_loc_name
-    - collection_date
-    - seq_meth
-    - samp_size
-    - samp_collect_device
-    - experimental_factor
-    - nucl_acid_ext
-    - organism_count
-    - spikein_count
-    - samp_store_temp
-    - samp_store_dur
-    - samp_vol_we_dna_ext
-    - pool_dna_extracts
-    - temp
-    - samp_store_loc
-    - genetic_mod
-    - perturbation
-    - coll_site_geo_feat
-    - food_product_type
-    - IFSAC_category
-    - ferm_chem_add
-    - ferm_chem_add_perc
-    - ferm_headspace_oxy
-    - ferm_medium
-    - ferm_pH
-    - ferm_rel_humidity
-    - ferm_temp
-    - ferm_time
-    - ferm_vessel
-    - bacterial_density
-    - cons_food_stor_dur
-    - cons_food_stor_temp
-    - cons_purch_date
-    - cons_qty_purchased
-    - cult_isol_date
-    - cult_result
-    - cult_result_org
-    - cult_target
-    - dietary_claim_use
-    - enrichment_protocol
-    - food_additive
-    - food_allergen_label
-    - food_contact_surf
-    - food_contain_wrap
-    - food_cooking_proc
-    - food_dis_point
-    - food_ingredient
-    - food_name_status
-    - food_origin
-    - food_pack_capacity
-    - food_pack_integrity
-    - food_pack_medium
-    - food_preserv_proc
-    - food_prior_contact
-    - food_prod
-    - food_prod_synonym
-    - food_product_qual
-    - food_quality_date
-    - food_source
-    - food_trace_list
-    - food_trav_mode
-    - food_trav_vehic
-    - food_treat_proc
-    - HACCP_term
-    - intended_consumer
-    - library_prep_kit
-    - lot_number
-    - microb_cult_med
-    - microb_start
-    - microb_start_count
-    - microb_start_inoc
-    - microb_start_prep
-    - microb_start_source
-    - microb_start_taxID
-    - nucl_acid_ext_kit
-    - num_samp_collect
-    - part_plant_animal
-    - repository_name
-    - samp_collect_method
-    - samp_pooling
-    - samp_rep_biol
-    - samp_rep_tech
-    - samp_source_mat_cat
-    - samp_stor_device
-    - samp_stor_media
-    - samp_transport_cont
-    - samp_transport_dur
-    - samp_transport_temp
-    - samp_purpose
-    - sequencing_kit
-    - sequencing_location
-    - serovar_or_serotype
-    - spikein_AMR
-    - spikein_antibiotic
-    - spikein_growth_med
-    - spikein_metal
-    - spikein_org
-    - spikein_serovar
-    - spikein_strain
-    - study_design
-    - study_inc_dur
-    - study_inc_temp
-    - study_timecourse
-    - study_tmnt
-    - timepoint
-    - misc_param
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - experimental_factor
+      - nucl_acid_ext
+      - organism_count
+      - spikein_count
+      - samp_store_temp
+      - samp_store_dur
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - temp
+      - samp_store_loc
+      - genetic_mod
+      - perturbation
+      - coll_site_geo_feat
+      - food_product_type
+      - IFSAC_category
+      - ferm_chem_add
+      - ferm_chem_add_perc
+      - ferm_headspace_oxy
+      - ferm_medium
+      - ferm_pH
+      - ferm_rel_humidity
+      - ferm_temp
+      - ferm_time
+      - ferm_vessel
+      - bacterial_density
+      - cons_food_stor_dur
+      - cons_food_stor_temp
+      - cons_purch_date
+      - cons_qty_purchased
+      - cult_isol_date
+      - cult_result
+      - cult_result_org
+      - cult_target
+      - dietary_claim_use
+      - enrichment_protocol
+      - food_additive
+      - food_allergen_label
+      - food_contact_surf
+      - food_contain_wrap
+      - food_cooking_proc
+      - food_dis_point
+      - food_ingredient
+      - food_name_status
+      - food_origin
+      - food_pack_capacity
+      - food_pack_integrity
+      - food_pack_medium
+      - food_preserv_proc
+      - food_prior_contact
+      - food_prod
+      - food_prod_synonym
+      - food_product_qual
+      - food_quality_date
+      - food_source
+      - food_trace_list
+      - food_trav_mode
+      - food_trav_vehic
+      - food_treat_proc
+      - HACCP_term
+      - intended_consumer
+      - library_prep_kit
+      - lot_number
+      - microb_cult_med
+      - microb_start
+      - microb_start_count
+      - microb_start_inoc
+      - microb_start_prep
+      - microb_start_source
+      - microb_start_taxID
+      - nucl_acid_ext_kit
+      - num_samp_collect
+      - part_plant_animal
+      - repository_name
+      - samp_collect_method
+      - samp_pooling
+      - samp_rep_biol
+      - samp_rep_tech
+      - samp_source_mat_cat
+      - samp_stor_device
+      - samp_stor_media
+      - samp_transport_cont
+      - samp_transport_dur
+      - samp_transport_temp
+      - samp_purpose
+      - sequencing_kit
+      - sequencing_location
+      - serovar_or_serotype
+      - spikein_AMR
+      - spikein_antibiotic
+      - spikein_growth_med
+      - spikein_metal
+      - spikein_org
+      - spikein_serovar
+      - spikein_strain
+      - study_design
+      - study_inc_dur
+      - study_inc_temp
+      - study_timecourse
+      - study_tmnt
+      - timepoint
+      - misc_param
     slot_usage:
       food_pack_medium:
         examples:
-        - value: vacuum-packed[FOODON:03480027]
+          - value: vacuum-packed[FOODON:03480027]
       food_product_type:
         examples:
-        - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
         required: true
       food_source:
         examples:
-        - value: giant tiger prawn [FOODON:03412612]
+          - value: giant tiger prawn [FOODON:03412612]
       library_prep_kit:
         examples:
-        - value: Illumina DNA Prep
+          - value: Illumina DNA Prep
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
       pool_dna_extracts:
         string_serialization: '{boolean},{integer}'
       samp_collect_device:
         examples:
-        - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
       samp_collect_method:
         examples:
-        - value: environmental swab sampling
+          - value: environmental swab sampling
     class_uri: MIXS:0016022
     aliases:
       - MIxS-Food (human foods)
@@ -17321,131 +17333,131 @@ classes:
       A collection of terms appropriate when collecting samples and sequencing samples 
       obtained from a non-human host, to examine the host-associated microbiome or genome.
     comments:
-      - This is a very broad package, intended to capture many kinds of sequences derived 
-        from the bodies of or derived from an organism. Where possible, please use a more specific package. 
+      - This is a very broad package, intended to capture many kinds of sequences derived
+        from the bodies of or derived from an organism. Where possible, please use a more specific package.
         For example, consider using food-animal and animal feed extension for sampling of farm animals reared for consumption.
-        For human stool microbiomes, consider MIxS-human-gut. 
-        Incidental associations of environmental material with an organism may also be better served by other packages. 
-        For example, nucleic acids derived from soil that was sampled from the hoof of a cow may be better described 
-        by terms from the soil extension; 
+        For human stool microbiomes, consider MIxS-human-gut.
+        Incidental associations of environmental material with an organism may also be better served by other packages.
+        For example, nucleic acids derived from soil that was sampled from the hoof of a cow may be better described
+        by terms from the soil extension;
         however, soil embedded in a wound on a cow’s leg would be best described by terms in this extension
     title: host-associated
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - alt
-    - depth
-    - elev
-    - ances_data
-    - biol_stat
-    - genetic_mod
-    - host_common_name
-    - samp_capt_status
-    - samp_dis_stage
-    - host_taxid
-    - host_subject_id
-    - host_age
-    - host_life_stage
-    - host_sex
-    - host_disease_stat
-    - chem_administration
-    - host_body_habitat
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_length
-    - host_diet
-    - host_last_meal
-    - host_growth_cond
-    - host_substrate
-    - host_fam_rel
-    - host_subspecf_genlin
-    - host_genotype
-    - host_phenotype
-    - host_body_temp
-    - host_dry_mass
-    - blood_press_diast
-    - blood_press_syst
-    - host_color
-    - host_shape
-    - gravidity
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_vol_we_dna_ext
-    - samp_store_temp
-    - samp_store_dur
-    - samp_store_loc
-    - host_symbiont
-    - misc_param
+      - samp_name
+      - project_name
+      - alt
+      - depth
+      - elev
+      - ances_data
+      - biol_stat
+      - genetic_mod
+      - host_common_name
+      - samp_capt_status
+      - samp_dis_stage
+      - host_taxid
+      - host_subject_id
+      - host_age
+      - host_life_stage
+      - host_sex
+      - host_disease_stat
+      - chem_administration
+      - host_body_habitat
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_length
+      - host_diet
+      - host_last_meal
+      - host_growth_cond
+      - host_substrate
+      - host_fam_rel
+      - host_subspecf_genlin
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_dry_mass
+      - blood_press_diast
+      - blood_press_syst
+      - host_color
+      - host_shape
+      - gravidity
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - host_symbiont
+      - misc_param
     slot_usage:
       alt:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
       host_age:
         examples:
-        - value: 10 days
+          - value: 10 days
       host_body_habitat:
         examples:
-        - value: nasopharynx
+          - value: nasopharynx
       host_body_site:
         examples:
-        - value: gill [UBERON:0002535]
+          - value: gill [UBERON:0002535]
       host_body_temp:
         examples:
-        - value: 15 degree Celsius
+          - value: 15 degree Celsius
       host_common_name:
         examples:
-        - value: human
+          - value: human
       host_diet:
         examples:
-        - value: herbivore
+          - value: herbivore
       host_disease_stat:
         examples:
-        - value: rabies [DOID:11260]
+          - value: rabies [DOID:11260]
       host_fam_rel:
         examples:
-        - value: offspring;Mussel25
+          - value: offspring;Mussel25
       host_genotype:
         examples:
-        - value: C57BL/6
+          - value: C57BL/6
       host_height:
         examples:
-        - value: 0.1 meter
+          - value: 0.1 meter
       host_last_meal:
         examples:
-        - value: corn feed;P2H
+          - value: corn feed;P2H
       host_life_stage:
         examples:
-        - value: adult
+          - value: adult
       host_phenotype:
         examples:
-        - value: elongated [PATO:0001154]
+          - value: elongated [PATO:0001154]
       host_subject_id:
         examples:
-        - value: MPI123
+          - value: MPI123
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_taxid:
         examples:
-        - value: '7955'
+          - value: '7955'
         string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
-        - value: 2500 gram
+          - value: 2500 gram
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016002
     aliases:
       - MIxS-host-associated
@@ -17461,102 +17473,102 @@ classes:
     title: human-associated
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - host_subject_id
-    - host_age
-    - host_sex
-    - host_disease_stat
-    - ihmc_medication_code
-    - chem_administration
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_diet
-    - host_last_meal
-    - host_fam_rel
-    - host_genotype
-    - host_phenotype
-    - host_body_temp
-    - smoker
-    - host_hiv_stat
-    - drug_usage
-    - host_body_mass_index
-    - diet_last_six_month
-    - weight_loss_3_month
-    - ethnicity
-    - host_occupation
-    - pet_farm_animal
-    - travel_out_six_month
-    - twin_sibling
-    - medic_hist_perform
-    - study_complt_stat
-    - pulmonary_disord
-    - nose_throat_disord
-    - blood_blood_disord
-    - host_pulse
-    - gestation_state
-    - maternal_health_stat
-    - foetal_health_stat
-    - amniotic_fluid_color
-    - kidney_disord
-    - urogenit_tract_disor
-    - urine_collect_meth
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_vol_we_dna_ext
-    - samp_store_temp
-    - samp_store_dur
-    - host_symbiont
-    - samp_store_loc
-    - misc_param
+      - samp_name
+      - project_name
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - smoker
+      - host_hiv_stat
+      - drug_usage
+      - host_body_mass_index
+      - diet_last_six_month
+      - weight_loss_3_month
+      - ethnicity
+      - host_occupation
+      - pet_farm_animal
+      - travel_out_six_month
+      - twin_sibling
+      - medic_hist_perform
+      - study_complt_stat
+      - pulmonary_disord
+      - nose_throat_disord
+      - blood_blood_disord
+      - host_pulse
+      - gestation_state
+      - maternal_health_stat
+      - foetal_health_stat
+      - amniotic_fluid_color
+      - kidney_disord
+      - urogenit_tract_disor
+      - urine_collect_meth
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - host_symbiont
+      - samp_store_loc
+      - misc_param
     slot_usage:
       host_age:
         examples:
-        - value: 30 years
+          - value: 30 years
       host_body_site:
         examples:
-        - value: Lung parenchyma [fma27360]
+          - value: Lung parenchyma [fma27360]
       host_body_temp:
         examples:
-        - value: 36.5 degree Celsius
+          - value: 36.5 degree Celsius
       host_diet:
         examples:
-        - value: high-fat
+          - value: high-fat
       host_disease_stat:
         examples:
-        - value: measles [DOID:8622]
+          - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-        - value: mother;ID298
+          - value: mother;ID298
       host_genotype:
         examples:
-        - value: ST1
+          - value: ST1
       host_height:
         examples:
-        - value: 1.75 meter
+          - value: 1.75 meter
       host_last_meal:
         examples:
-        - value: french fries;P5H30M
+          - value: french fries;P5H30M
       host_phenotype:
         examples:
-        - value: Tinnitus [HP:0000360]
+          - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-        - value: MPI123
+          - value: MPI123
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_tot_mass:
         examples:
-        - value: 65 kilogram
+          - value: 65 kilogram
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016003
     aliases:
       - MIxS-human-associated
@@ -17569,86 +17581,86 @@ classes:
     title: human-gut
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - gastrointest_disord
-    - liver_disord
-    - special_diet
-    - host_subject_id
-    - host_age
-    - host_sex
-    - host_disease_stat
-    - ihmc_medication_code
-    - chem_administration
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_diet
-    - host_last_meal
-    - host_fam_rel
-    - host_genotype
-    - host_phenotype
-    - host_body_temp
-    - host_body_mass_index
-    - ethnicity
-    - host_occupation
-    - medic_hist_perform
-    - host_pulse
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - samp_store_dur
-    - host_symbiont
-    - samp_store_loc
-    - misc_param
+      - samp_name
+      - project_name
+      - gastrointest_disord
+      - liver_disord
+      - special_diet
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - samp_store_dur
+      - host_symbiont
+      - samp_store_loc
+      - misc_param
     slot_usage:
       host_age:
         examples:
-        - value: 30 years
+          - value: 30 years
       host_body_site:
         examples:
-        - value: Wall of gut [fma45653]
+          - value: Wall of gut [fma45653]
       host_body_temp:
         examples:
-        - value: 36.5 degree Celsius
+          - value: 36.5 degree Celsius
       host_diet:
         examples:
-        - value: high-fat
+          - value: high-fat
       host_disease_stat:
         examples:
-        - value: measles [DOID:8622]
+          - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-        - value: mother;ID298
+          - value: mother;ID298
       host_genotype:
         examples:
-        - value: ST1
+          - value: ST1
       host_height:
         examples:
-        - value: 1.75 meter
+          - value: 1.75 meter
       host_last_meal:
         examples:
-        - value: french fries;P5H30M
+          - value: french fries;P5H30M
       host_phenotype:
         examples:
-        - value: Tinnitus [HP:0000360]
+          - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-        - value: MPI123
+          - value: MPI123
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_tot_mass:
         examples:
-        - value: 65 kilogram
+          - value: 65 kilogram
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016004
     aliases:
       - MIxS-human-gut
@@ -17661,85 +17673,85 @@ classes:
     title: human-oral
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - nose_mouth_teeth_throat_disord
-    - time_last_toothbrush
-    - host_subject_id
-    - host_age
-    - host_sex
-    - host_disease_stat
-    - ihmc_medication_code
-    - chem_administration
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_diet
-    - host_last_meal
-    - host_fam_rel
-    - host_genotype
-    - host_phenotype
-    - host_body_temp
-    - host_body_mass_index
-    - ethnicity
-    - host_occupation
-    - medic_hist_perform
-    - host_pulse
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_vol_we_dna_ext
-    - samp_store_temp
-    - samp_store_dur
-    - host_symbiont
-    - samp_store_loc
-    - misc_param
+      - samp_name
+      - project_name
+      - nose_mouth_teeth_throat_disord
+      - time_last_toothbrush
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - host_symbiont
+      - samp_store_loc
+      - misc_param
     slot_usage:
       host_age:
         examples:
-        - value: 30 years
+          - value: 30 years
       host_body_site:
         examples:
-        - value: Epithelium of tongue [fma284658]
+          - value: Epithelium of tongue [fma284658]
       host_body_temp:
         examples:
-        - value: 36.5 degree Celsius
+          - value: 36.5 degree Celsius
       host_diet:
         examples:
-        - value: high-fat
+          - value: high-fat
       host_disease_stat:
         examples:
-        - value: measles [DOID:8622]
+          - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-        - value: mother;ID298
+          - value: mother;ID298
       host_genotype:
         examples:
-        - value: ST1
+          - value: ST1
       host_height:
         examples:
-        - value: 1.75 meter
+          - value: 1.75 meter
       host_last_meal:
         examples:
-        - value: french fries;P5H30M
+          - value: french fries;P5H30M
       host_phenotype:
         examples:
-        - value: Tinnitus [HP:0000360]
+          - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-        - value: MPI123
+          - value: MPI123
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_tot_mass:
         examples:
-        - value: 65 kilogram
+          - value: 65 kilogram
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016005
     aliases:
       - MIxS-human-oral
@@ -17753,86 +17765,86 @@ classes:
     title: human-skin
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - dermatology_disord
-    - time_since_last_wash
-    - dominant_hand
-    - host_subject_id
-    - host_age
-    - host_sex
-    - host_disease_stat
-    - ihmc_medication_code
-    - chem_administration
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_diet
-    - host_last_meal
-    - host_fam_rel
-    - host_genotype
-    - host_phenotype
-    - host_body_temp
-    - host_body_mass_index
-    - ethnicity
-    - host_occupation
-    - medic_hist_perform
-    - host_pulse
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_vol_we_dna_ext
-    - samp_store_temp
-    - samp_store_dur
-    - samp_store_loc
-    - host_symbiont
-    - misc_param
+      - samp_name
+      - project_name
+      - dermatology_disord
+      - time_since_last_wash
+      - dominant_hand
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - host_symbiont
+      - misc_param
     slot_usage:
       host_age:
         examples:
-        - value: 30 years
+          - value: 30 years
       host_body_site:
         examples:
-        - value: Skin of palm of left hand [fma38303]
+          - value: Skin of palm of left hand [fma38303]
       host_body_temp:
         examples:
-        - value: 36.5 degree Celsius
+          - value: 36.5 degree Celsius
       host_diet:
         examples:
-        - value: high-fat
+          - value: high-fat
       host_disease_stat:
         examples:
-        - value: measles [DOID:8622]
+          - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-        - value: mother;ID298
+          - value: mother;ID298
       host_genotype:
         examples:
-        - value: ST1
+          - value: ST1
       host_height:
         examples:
-        - value: 1.75 meter
+          - value: 1.75 meter
       host_last_meal:
         examples:
-        - value: french fries;P5H30M
+          - value: french fries;P5H30M
       host_phenotype:
         examples:
-        - value: Tinnitus [HP:0000360]
+          - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-        - value: MPI123
+          - value: MPI123
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_tot_mass:
         examples:
-        - value: 65 kilogram
+          - value: 65 kilogram
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016006
     aliases:
       - MIxS-human-skin
@@ -17845,93 +17857,93 @@ classes:
     title: human-vaginal
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - menarche
-    - sexual_act
-    - pregnancy
-    - douche
-    - birth_control
-    - menopause
-    - hrt
-    - hysterectomy
-    - gynecologic_disord
-    - urogenit_disord
-    - host_subject_id
-    - host_age
-    - host_sex
-    - host_disease_stat
-    - ihmc_medication_code
-    - chem_administration
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_diet
-    - host_last_meal
-    - host_fam_rel
-    - host_genotype
-    - host_phenotype
-    - host_body_temp
-    - host_body_mass_index
-    - ethnicity
-    - host_occupation
-    - medic_hist_perform
-    - host_pulse
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_vol_we_dna_ext
-    - samp_store_temp
-    - samp_store_loc
-    - samp_store_dur
-    - host_symbiont
-    - misc_param
+      - samp_name
+      - project_name
+      - menarche
+      - sexual_act
+      - pregnancy
+      - douche
+      - birth_control
+      - menopause
+      - hrt
+      - hysterectomy
+      - gynecologic_disord
+      - urogenit_disord
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_loc
+      - samp_store_dur
+      - host_symbiont
+      - misc_param
     slot_usage:
       host_age:
         examples:
-        - value: 30 years
+          - value: 30 years
       host_body_site:
         examples:
-        - value: Ectocervix [fma86484]
+          - value: Ectocervix [fma86484]
       host_body_temp:
         examples:
-        - value: 36.5 degree Celsius
+          - value: 36.5 degree Celsius
       host_diet:
         examples:
-        - value: high-fat
+          - value: high-fat
       host_disease_stat:
         examples:
-        - value: measles [DOID:8622]
+          - value: measles [DOID:8622]
       host_fam_rel:
         examples:
-        - value: mother;ID298
+          - value: mother;ID298
       host_genotype:
         examples:
-        - value: ST1
+          - value: ST1
       host_height:
         examples:
-        - value: 1.75 meter
+          - value: 1.75 meter
       host_last_meal:
         examples:
-        - value: french fries;P5H30M
+          - value: french fries;P5H30M
       host_phenotype:
         examples:
-        - value: Tinnitus [HP:0000360]
+          - value: Tinnitus [HP:0000360]
       host_subject_id:
         examples:
-        - value: MPI123
+          - value: MPI123
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_tot_mass:
         examples:
-        - value: 65 kilogram
+          - value: 65 kilogram
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016007
     aliases:
       - MIxS-human-vaginal
@@ -17944,94 +17956,94 @@ classes:
     title: hydrocarbon resources-cores
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - hcr
-    - hc_produced
-    - basin
-    - field
-    - reservoir
-    - hcr_temp
-    - tvdss_of_hcr_temp
-    - hcr_pressure
-    - tvdss_of_hcr_press
-    - permeability
-    - porosity
-    - lithology
-    - depos_env
-    - hcr_geol_age
-    - owc_tvdss
-    - hcr_fw_salinity
-    - sulfate_fw
-    - vfa_fw
-    - sr_kerog_type
-    - sr_lithology
-    - sr_dep_env
-    - sr_geol_age
-    - samp_well_name
-    - win
-    - samp_type
-    - samp_subtype
-    - temp
-    - pressure
-    - samp_tvdss
-    - samp_md
-    - elev
-    - oxy_stat_samp
-    - samp_transport_cond
-    - samp_store_temp
-    - samp_store_dur
-    - samp_store_loc
-    - samp_vol_we_dna_ext
-    - organism_count
-    - org_count_qpcr_info
-    - ph
-    - salinity
-    - alkalinity
-    - alkalinity_method
-    - sulfate
-    - sulfide
-    - tot_sulfur
-    - nitrate
-    - nitrite
-    - ammonium
-    - tot_nitro
-    - diss_iron
-    - sodium
-    - chloride
-    - potassium
-    - magnesium
-    - calcium
-    - tot_iron
-    - diss_org_carb
-    - diss_inorg_carb
-    - diss_inorg_phosp
-    - tot_phosp
-    - suspend_solids
-    - density
-    - diss_carb_dioxide
-    - diss_oxygen_fluid
-    - vfa
-    - benzene
-    - toluene
-    - ethylbenzene
-    - xylene
-    - api
-    - tan
-    - viscosity
-    - pour_point
-    - saturates_pc
-    - aromatics_pc
-    - resins_pc
-    - asphaltenes_pc
-    - misc_param
-    - additional_info
+      - samp_name
+      - project_name
+      - hcr
+      - hc_produced
+      - basin
+      - field
+      - reservoir
+      - hcr_temp
+      - tvdss_of_hcr_temp
+      - hcr_pressure
+      - tvdss_of_hcr_press
+      - permeability
+      - porosity
+      - lithology
+      - depos_env
+      - hcr_geol_age
+      - owc_tvdss
+      - hcr_fw_salinity
+      - sulfate_fw
+      - vfa_fw
+      - sr_kerog_type
+      - sr_lithology
+      - sr_dep_env
+      - sr_geol_age
+      - samp_well_name
+      - win
+      - samp_type
+      - samp_subtype
+      - temp
+      - pressure
+      - samp_tvdss
+      - samp_md
+      - elev
+      - oxy_stat_samp
+      - samp_transport_cond
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - samp_vol_we_dna_ext
+      - organism_count
+      - org_count_qpcr_info
+      - ph
+      - salinity
+      - alkalinity
+      - alkalinity_method
+      - sulfate
+      - sulfide
+      - tot_sulfur
+      - nitrate
+      - nitrite
+      - ammonium
+      - tot_nitro
+      - diss_iron
+      - sodium
+      - chloride
+      - potassium
+      - magnesium
+      - calcium
+      - tot_iron
+      - diss_org_carb
+      - diss_inorg_carb
+      - diss_inorg_phosp
+      - tot_phosp
+      - suspend_solids
+      - density
+      - diss_carb_dioxide
+      - diss_oxygen_fluid
+      - vfa
+      - benzene
+      - toluene
+      - ethylbenzene
+      - xylene
+      - api
+      - tan
+      - viscosity
+      - pour_point
+      - saturates_pc
+      - aromatics_pc
+      - resins_pc
+      - asphaltenes_pc
+      - misc_param
+      - additional_info
     slot_usage:
       ammonium:
         recommended: true
       depos_env:
         examples:
-        - value: Continental - Alluvial
+          - value: Continental - Alluvial
       diss_inorg_phosp:
         recommended: true
       hcr_temp:
@@ -18042,7 +18054,7 @@ classes:
         recommended: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         recommended: true
       ph:
         recommended: true
@@ -18070,98 +18082,98 @@ classes:
     title: hydrocarbon resources-fluids/swabs
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - hcr
-    - hc_produced
-    - basin
-    - field
-    - reservoir
-    - hcr_temp
-    - tvdss_of_hcr_temp
-    - hcr_pressure
-    - tvdss_of_hcr_press
-    - lithology
-    - depos_env
-    - hcr_geol_age
-    - hcr_fw_salinity
-    - sulfate_fw
-    - vfa_fw
-    - prod_start_date
-    - prod_rate
-    - water_prod_rate
-    - water_cut
-    - iwf
-    - add_recov_method
-    - iw_bt_date_well
-    - biocide
-    - biocide_admin_method
-    - chem_treatment
-    - chem_treat_method
-    - samp_loc_corr_rate
-    - samp_well_name
-    - win
-    - samp_type
-    - samp_subtype
-    - samp_collect_point
-    - temp
-    - pressure
-    - oxy_stat_samp
-    - samp_preserv
-    - samp_transport_cond
-    - samp_store_temp
-    - samp_store_dur
-    - samp_store_loc
-    - samp_vol_we_dna_ext
-    - organism_count
-    - org_count_qpcr_info
-    - ph
-    - salinity
-    - alkalinity
-    - alkalinity_method
-    - sulfate
-    - sulfide
-    - tot_sulfur
-    - nitrate
-    - nitrite
-    - ammonium
-    - tot_nitro
-    - diss_iron
-    - sodium
-    - chloride
-    - potassium
-    - magnesium
-    - calcium
-    - tot_iron
-    - diss_org_carb
-    - diss_inorg_carb
-    - diss_inorg_phosp
-    - tot_phosp
-    - suspend_solids
-    - density
-    - diss_carb_dioxide
-    - diss_oxygen_fluid
-    - vfa
-    - benzene
-    - toluene
-    - ethylbenzene
-    - xylene
-    - api
-    - tan
-    - viscosity
-    - pour_point
-    - saturates_pc
-    - aromatics_pc
-    - resins_pc
-    - asphaltenes_pc
-    - misc_param
-    - additional_info
+      - samp_name
+      - project_name
+      - hcr
+      - hc_produced
+      - basin
+      - field
+      - reservoir
+      - hcr_temp
+      - tvdss_of_hcr_temp
+      - hcr_pressure
+      - tvdss_of_hcr_press
+      - lithology
+      - depos_env
+      - hcr_geol_age
+      - hcr_fw_salinity
+      - sulfate_fw
+      - vfa_fw
+      - prod_start_date
+      - prod_rate
+      - water_prod_rate
+      - water_cut
+      - iwf
+      - add_recov_method
+      - iw_bt_date_well
+      - biocide
+      - biocide_admin_method
+      - chem_treatment
+      - chem_treat_method
+      - samp_loc_corr_rate
+      - samp_well_name
+      - win
+      - samp_type
+      - samp_subtype
+      - samp_collect_point
+      - temp
+      - pressure
+      - oxy_stat_samp
+      - samp_preserv
+      - samp_transport_cond
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - samp_vol_we_dna_ext
+      - organism_count
+      - org_count_qpcr_info
+      - ph
+      - salinity
+      - alkalinity
+      - alkalinity_method
+      - sulfate
+      - sulfide
+      - tot_sulfur
+      - nitrate
+      - nitrite
+      - ammonium
+      - tot_nitro
+      - diss_iron
+      - sodium
+      - chloride
+      - potassium
+      - magnesium
+      - calcium
+      - tot_iron
+      - diss_org_carb
+      - diss_inorg_carb
+      - diss_inorg_phosp
+      - tot_phosp
+      - suspend_solids
+      - density
+      - diss_carb_dioxide
+      - diss_oxygen_fluid
+      - vfa
+      - benzene
+      - toluene
+      - ethylbenzene
+      - xylene
+      - api
+      - tan
+      - viscosity
+      - pour_point
+      - saturates_pc
+      - aromatics_pc
+      - resins_pc
+      - asphaltenes_pc
+      - misc_param
+      - additional_info
     slot_usage:
       ammonium:
         recommended: true
       depos_env:
         examples:
-        - value: Marine - Reef
+          - value: Marine - Reef
       diss_inorg_phosp:
         recommended: true
       hcr_temp:
@@ -18172,7 +18184,7 @@ classes:
         recommended: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
         recommended: true
       ph:
         recommended: true
@@ -18200,83 +18212,83 @@ classes:
     title: microbial mat/biofilm
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - depth
-    - elev
-    - alkalinity
-    - alkyl_diethers
-    - aminopept_act
-    - ammonium
-    - bacteria_carb_prod
-    - biomass
-    - bishomohopanol
-    - bromide
-    - calcium
-    - carb_nitro_ratio
-    - chem_administration
-    - chloride
-    - chlorophyll
-    - diether_lipids
-    - diss_carb_dioxide
-    - diss_hydrogen
-    - diss_inorg_carb
-    - diss_org_carb
-    - diss_org_nitro
-    - diss_oxygen
-    - glucosidase_act
-    - magnesium
-    - mean_frict_vel
-    - mean_peak_frict_vel
-    - methane
-    - misc_param
-    - n_alkanes
-    - nitrate
-    - nitrite
-    - nitro
-    - org_carb
-    - org_matter
-    - org_nitro
-    - organism_count
-    - oxy_stat_samp
-    - ph
-    - part_org_carb
-    - perturbation
-    - petroleum_hydrocarb
-    - phaeopigments
-    - phosphate
-    - phosplipid_fatt_acid
-    - potassium
-    - pressure
-    - redox_potential
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - silicate
-    - sodium
-    - sulfate
-    - sulfide
-    - temp
-    - tot_carb
-    - tot_nitro_content
-    - tot_org_carb
-    - turbidity
-    - water_content
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - alkalinity
+      - alkyl_diethers
+      - aminopept_act
+      - ammonium
+      - bacteria_carb_prod
+      - biomass
+      - bishomohopanol
+      - bromide
+      - calcium
+      - carb_nitro_ratio
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_org_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - glucosidase_act
+      - magnesium
+      - mean_frict_vel
+      - mean_peak_frict_vel
+      - methane
+      - misc_param
+      - n_alkanes
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - part_org_carb
+      - perturbation
+      - petroleum_hydrocarb
+      - phaeopigments
+      - phosphate
+      - phosplipid_fatt_acid
+      - potassium
+      - pressure
+      - redox_potential
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - silicate
+      - sodium
+      - sulfate
+      - sulfide
+      - temp
+      - tot_carb
+      - tot_nitro_content
+      - tot_org_carb
+      - turbidity
+      - water_content
     slot_usage:
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
       methane:
         examples:
-        - value: 0.15 micromole per liter
+          - value: 0.15 micromole per liter
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016008
@@ -18291,64 +18303,64 @@ classes:
     title: miscellaneous natural or artificial environment
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - alt
-    - depth
-    - elev
-    - alkalinity
-    - ammonium
-    - biomass
-    - bromide
-    - calcium
-    - chem_administration
-    - chloride
-    - chlorophyll
-    - density
-    - diether_lipids
-    - diss_carb_dioxide
-    - diss_hydrogen
-    - diss_inorg_carb
-    - diss_org_nitro
-    - diss_oxygen
-    - misc_param
-    - nitrate
-    - nitrite
-    - nitro
-    - org_carb
-    - org_matter
-    - org_nitro
-    - organism_count
-    - oxy_stat_samp
-    - ph
-    - perturbation
-    - phosphate
-    - phosplipid_fatt_acid
-    - potassium
-    - pressure
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - silicate
-    - sodium
-    - sulfate
-    - sulfide
-    - temp
-    - water_current
+      - samp_name
+      - project_name
+      - alt
+      - depth
+      - elev
+      - alkalinity
+      - ammonium
+      - biomass
+      - bromide
+      - calcium
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - density
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - misc_param
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - perturbation
+      - phosphate
+      - phosplipid_fatt_acid
+      - potassium
+      - pressure
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - silicate
+      - sodium
+      - sulfate
+      - sulfide
+      - temp
+      - water_current
     slot_usage:
       alt:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016009
     aliases:
       - MIxS-miscellaneous natural or artificial environment
@@ -18359,87 +18371,87 @@ classes:
     title: plant-associated
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - depth
-    - elev
-    - air_temp_regm
-    - ances_data
-    - antibiotic_regm
-    - biol_stat
-    - biotic_regm
-    - chem_administration
-    - chem_mutagen
-    - climate_environment
-    - cult_root_med
-    - fertilizer_regm
-    - fungicide_regm
-    - gaseous_environment
-    - genetic_mod
-    - gravity
-    - growth_facil
-    - growth_habit
-    - growth_hormone_regm
-    - herbicide_regm
-    - host_age
-    - host_common_name
-    - host_disease_stat
-    - host_dry_mass
-    - host_genotype
-    - host_height
-    - host_subspecf_genlin
-    - host_length
-    - host_life_stage
-    - host_phenotype
-    - host_taxid
-    - host_tot_mass
-    - host_wet_mass
-    - humidity_regm
-    - light_regm
-    - mechanical_damage
-    - mineral_nutr_regm
-    - misc_param
-    - non_min_nutr_regm
-    - organism_count
-    - oxy_stat_samp
-    - ph_regm
-    - perturbation
-    - pesticide_regm
-    - plant_growth_med
-    - plant_product
-    - plant_sex
-    - plant_struc
-    - radiation_regm
-    - rainfall_regm
-    - root_cond
-    - root_med_carbon
-    - root_med_macronutr
-    - root_med_micronutr
-    - root_med_suppl
-    - root_med_ph
-    - root_med_regl
-    - root_med_solid
-    - salt_regm
-    - samp_capt_status
-    - samp_dis_stage
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - season_environment
-    - standing_water_regm
-    - temp
-    - tiss_cult_growth_med
-    - water_temp_regm
-    - watering_regm
-    - host_symbiont
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - air_temp_regm
+      - ances_data
+      - antibiotic_regm
+      - biol_stat
+      - biotic_regm
+      - chem_administration
+      - chem_mutagen
+      - climate_environment
+      - cult_root_med
+      - fertilizer_regm
+      - fungicide_regm
+      - gaseous_environment
+      - genetic_mod
+      - gravity
+      - growth_facil
+      - growth_habit
+      - growth_hormone_regm
+      - herbicide_regm
+      - host_age
+      - host_common_name
+      - host_disease_stat
+      - host_dry_mass
+      - host_genotype
+      - host_height
+      - host_subspecf_genlin
+      - host_length
+      - host_life_stage
+      - host_phenotype
+      - host_taxid
+      - host_tot_mass
+      - host_wet_mass
+      - humidity_regm
+      - light_regm
+      - mechanical_damage
+      - mineral_nutr_regm
+      - misc_param
+      - non_min_nutr_regm
+      - organism_count
+      - oxy_stat_samp
+      - ph_regm
+      - perturbation
+      - pesticide_regm
+      - plant_growth_med
+      - plant_product
+      - plant_sex
+      - plant_struc
+      - radiation_regm
+      - rainfall_regm
+      - root_cond
+      - root_med_carbon
+      - root_med_macronutr
+      - root_med_micronutr
+      - root_med_suppl
+      - root_med_ph
+      - root_med_regl
+      - root_med_solid
+      - salt_regm
+      - samp_capt_status
+      - samp_dis_stage
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - season_environment
+      - standing_water_regm
+      - temp
+      - tiss_cult_growth_med
+      - water_temp_regm
+      - watering_regm
+      - host_symbiont
     slot_usage:
       climate_environment:
         string_serialization: '{text};{Rn/start_time/end_time/duration}'
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
@@ -18451,47 +18463,47 @@ classes:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       host_age:
         examples:
-        - value: 10 days
+          - value: 10 days
       host_common_name:
         examples:
-        - value: rice
+          - value: rice
       host_disease_stat:
         examples:
-        - value: downy mildew
+          - value: downy mildew
       host_genotype:
         examples:
-        - value: Ts
+          - value: Ts
       host_height:
         examples:
-        - value: 1 meter
+          - value: 1 meter
       host_life_stage:
         examples:
-        - value: adult
+          - value: adult
       host_phenotype:
         examples:
-        - value: seed pod; green [PATO:0000320]
+          - value: seed pod; green [PATO:0000320]
       host_symbiont:
         examples:
-        - value: flukeworms
+          - value: flukeworms
       host_taxid:
         examples:
-        - value: '4530'
+          - value: '4530'
         string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
-        - value: 2500 gram
+          - value: 2500 gram
       non_min_nutr_regm:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       pesticide_regm:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       ph_regm:
         string_serialization: '{float};{Rn/start_time/end_time/duration}'
       plant_growth_med:
         examples:
-        - value: hydroponic plant culture media [EO:0007067]
+          - value: hydroponic plant culture media [EO:0007067]
       salt_regm:
         string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
       season_environment:
@@ -18516,89 +18528,89 @@ classes:
     title: sediment
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - depth
-    - elev
-    - alkalinity
-    - alkyl_diethers
-    - aminopept_act
-    - ammonium
-    - bacteria_carb_prod
-    - biomass
-    - bishomohopanol
-    - bromide
-    - calcium
-    - carb_nitro_ratio
-    - chem_administration
-    - chloride
-    - chlorophyll
-    - density
-    - diether_lipids
-    - diss_carb_dioxide
-    - diss_hydrogen
-    - diss_inorg_carb
-    - diss_org_carb
-    - diss_org_nitro
-    - diss_oxygen
-    - glucosidase_act
-    - magnesium
-    - mean_frict_vel
-    - mean_peak_frict_vel
-    - methane
-    - misc_param
-    - n_alkanes
-    - nitrate
-    - nitrite
-    - nitro
-    - org_carb
-    - org_matter
-    - org_nitro
-    - organism_count
-    - oxy_stat_samp
-    - ph
-    - particle_class
-    - part_org_carb
-    - perturbation
-    - petroleum_hydrocarb
-    - phaeopigments
-    - phosphate
-    - phosplipid_fatt_acid
-    - porosity
-    - potassium
-    - pressure
-    - redox_potential
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - sediment_type
-    - silicate
-    - sodium
-    - sulfate
-    - sulfide
-    - temp
-    - tidal_stage
-    - tot_carb
-    - tot_depth_water_col
-    - tot_nitro_content
-    - tot_org_carb
-    - turbidity
-    - water_content
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - alkalinity
+      - alkyl_diethers
+      - aminopept_act
+      - ammonium
+      - bacteria_carb_prod
+      - biomass
+      - bishomohopanol
+      - bromide
+      - calcium
+      - carb_nitro_ratio
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - density
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_org_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - glucosidase_act
+      - magnesium
+      - mean_frict_vel
+      - mean_peak_frict_vel
+      - methane
+      - misc_param
+      - n_alkanes
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - particle_class
+      - part_org_carb
+      - perturbation
+      - petroleum_hydrocarb
+      - phaeopigments
+      - phosphate
+      - phosplipid_fatt_acid
+      - porosity
+      - potassium
+      - pressure
+      - redox_potential
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - sediment_type
+      - silicate
+      - sodium
+      - sulfate
+      - sulfide
+      - temp
+      - tidal_stage
+      - tot_carb
+      - tot_depth_water_col
+      - tot_nitro_content
+      - tot_org_carb
+      - turbidity
+      - water_content
     slot_usage:
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         required: true
       elev:
         recommended: true
       methane:
         examples:
-        - value: 0.15 micromole per liter
+          - value: 0.15 micromole per liter
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016011
@@ -18615,69 +18627,69 @@ classes:
     title: soil
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - depth
-    - elev
-    - cur_land_use
-    - cur_vegetation
-    - cur_vegetation_meth
-    - previous_land_use
-    - prev_land_use_meth
-    - crop_rotation
-    - agrochem_addition
-    - tillage
-    - fire
-    - flooding
-    - extreme_event
-    - soil_horizon
-    - horizon_meth
-    - sieving
-    - water_content
-    - water_cont_soil_meth
-    - samp_vol_we_dna_ext
-    - pool_dna_extracts
-    - store_cond
-    - link_climate_info
-    - annual_temp
-    - season_temp
-    - annual_precpt
-    - season_precpt
-    - link_class_info
-    - fao_class
-    - local_class
-    - local_class_meth
-    - org_nitro
-    - temp
-    - soil_type
-    - soil_type_meth
-    - slope_gradient
-    - slope_aspect
-    - profile_position
-    - drainage_class
-    - soil_texture
-    - soil_texture_meth
-    - ph
-    - ph_meth
-    - org_matter
-    - tot_org_carb
-    - tot_org_c_meth
-    - tot_nitro_content
-    - tot_nitro_cont_meth
-    - microbial_biomass
-    - micro_biomass_meth
-    - link_addit_analys
-    - heavy_metals
-    - heavy_metals_meth
-    - al_sat
-    - al_sat_meth
-    - misc_param
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - cur_land_use
+      - cur_vegetation
+      - cur_vegetation_meth
+      - previous_land_use
+      - prev_land_use_meth
+      - crop_rotation
+      - agrochem_addition
+      - tillage
+      - fire
+      - flooding
+      - extreme_event
+      - soil_horizon
+      - horizon_meth
+      - sieving
+      - water_content
+      - water_cont_soil_meth
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - store_cond
+      - link_climate_info
+      - annual_temp
+      - season_temp
+      - annual_precpt
+      - season_precpt
+      - link_class_info
+      - fao_class
+      - local_class
+      - local_class_meth
+      - org_nitro
+      - temp
+      - soil_type
+      - soil_type_meth
+      - slope_gradient
+      - slope_aspect
+      - profile_position
+      - drainage_class
+      - soil_texture
+      - soil_texture_meth
+      - ph
+      - ph_meth
+      - org_matter
+      - tot_org_carb
+      - tot_org_c_meth
+      - tot_nitro_content
+      - tot_nitro_cont_meth
+      - microbial_biomass
+      - micro_biomass_meth
+      - link_addit_analys
+      - heavy_metals
+      - heavy_metals_meth
+      - al_sat
+      - al_sat_meth
+      - misc_param
     slot_usage:
       crop_rotation:
         string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         required: true
       elev:
         required: true
@@ -18701,116 +18713,116 @@ classes:
     title: symbiont-associated
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - lat_lon
-    - geo_loc_name
-    - collection_date
-    - alt
-    - depth
-    - elev
-    - host_subject_id
-    - host_common_name
-    - host_taxid
-    - source_mat_id
-    - host_dependence
-    - type_of_symbiosis
-    - sym_life_cycle_type
-    - host_life_stage
-    - host_age
-    - urobiom_sex
-    - mode_transmission
-    - route_transmission
-    - host_body_habitat
-    - host_body_site
-    - host_body_product
-    - host_tot_mass
-    - host_height
-    - host_length
-    - host_growth_cond
-    - host_substrate
-    - host_fam_rel
-    - host_infra_spec_name
-    - host_infra_spec_rank
-    - host_genotype
-    - host_phenotype
-    - host_dry_mass
-    - host_color
-    - host_shape
-    - gravidity
-    - host_number
-    - host_symbiont
-    - host_specificity
-    - symbiont_host_role
-    - host_cellular_loc
-    - association_duration
-    - host_of_host_coinf
-    - host_of_host_name
-    - host_of_host_env_loc
-    - host_of_host_env_med
-    - host_of_host_taxid
-    - host_of_host_sub_id
-    - host_of_host_disease
-    - host_of_host_fam_rel
-    - host_of_host_infname
-    - host_of_host_infrank
-    - host_of_host_geno
-    - host_of_host_pheno
-    - host_of_host_gravid
-    - host_of_host_totmass
-    - chem_administration
-    - perturbation
-    - salinity
-    - oxy_stat_samp
-    - temp
-    - organism_count
-    - samp_vol_we_dna_ext
-    - samp_store_temp
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_sol
-    - misc_param
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - alt
+      - depth
+      - elev
+      - host_subject_id
+      - host_common_name
+      - host_taxid
+      - source_mat_id
+      - host_dependence
+      - type_of_symbiosis
+      - sym_life_cycle_type
+      - host_life_stage
+      - host_age
+      - urobiom_sex
+      - mode_transmission
+      - route_transmission
+      - host_body_habitat
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_length
+      - host_growth_cond
+      - host_substrate
+      - host_fam_rel
+      - host_infra_spec_name
+      - host_infra_spec_rank
+      - host_genotype
+      - host_phenotype
+      - host_dry_mass
+      - host_color
+      - host_shape
+      - gravidity
+      - host_number
+      - host_symbiont
+      - host_specificity
+      - symbiont_host_role
+      - host_cellular_loc
+      - association_duration
+      - host_of_host_coinf
+      - host_of_host_name
+      - host_of_host_env_loc
+      - host_of_host_env_med
+      - host_of_host_taxid
+      - host_of_host_sub_id
+      - host_of_host_disease
+      - host_of_host_fam_rel
+      - host_of_host_infname
+      - host_of_host_infrank
+      - host_of_host_geno
+      - host_of_host_pheno
+      - host_of_host_gravid
+      - host_of_host_totmass
+      - chem_administration
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_sol
+      - misc_param
     slot_usage:
       alt:
         recommended: true
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       elev:
         recommended: true
       host_body_habitat:
         examples:
-        - value: anterior end of a tapeworm
+          - value: anterior end of a tapeworm
       host_body_site:
         examples:
-        - value: scolex [UBERON:0015119]
+          - value: scolex [UBERON:0015119]
       host_common_name:
         examples:
-        - value: trematode
+          - value: trematode
       host_fam_rel:
         examples:
-        - value: clone;P15
+          - value: clone;P15
       host_life_stage:
         examples:
-        - value: redia
+          - value: redia
         required: true
       host_phenotype:
         examples:
-        - value: soldier
+          - value: soldier
       host_subject_id:
         examples:
-        - value: P14
+          - value: P14
       host_symbiont:
         examples:
-        - value: Paragordius varius
+          - value: Paragordius varius
       host_taxid:
         examples:
-        - value: '395013'
+          - value: '395013'
         string_serialization: '{integer}'
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016023
     aliases:
       - MIxS-SA (symbiont-associated)
@@ -18823,54 +18835,54 @@ classes:
     title: wastewater/sludge
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - depth
-    - alkalinity
-    - biochem_oxygen_dem
-    - chem_administration
-    - chem_oxygen_dem
-    - efficiency_percent
-    - emulsions
-    - gaseous_substances
-    - indust_eff_percent
-    - inorg_particles
-    - misc_param
-    - nitrate
-    - org_particles
-    - organism_count
-    - oxy_stat_samp
-    - ph
-    - perturbation
-    - phosphate
-    - pre_treatment
-    - primary_treatment
-    - reactor_type
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - secondary_treatment
-    - sewage_type
-    - sludge_retent_time
-    - sodium
-    - soluble_inorg_mat
-    - soluble_org_mat
-    - suspend_solids
-    - temp
-    - tertiary_treatment
-    - tot_nitro
-    - tot_phosphate
-    - wastewater_type
+      - samp_name
+      - project_name
+      - depth
+      - alkalinity
+      - biochem_oxygen_dem
+      - chem_administration
+      - chem_oxygen_dem
+      - efficiency_percent
+      - emulsions
+      - gaseous_substances
+      - indust_eff_percent
+      - inorg_particles
+      - misc_param
+      - nitrate
+      - org_particles
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - perturbation
+      - phosphate
+      - pre_treatment
+      - primary_treatment
+      - reactor_type
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - secondary_treatment
+      - sewage_type
+      - sludge_retent_time
+      - sodium
+      - soluble_inorg_mat
+      - soluble_org_mat
+      - suspend_solids
+      - temp
+      - tertiary_treatment
+      - tot_nitro
+      - tot_phosphate
+      - wastewater_type
     slot_usage:
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         recommended: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016013
     aliases:
       - MIxS-wastewater/sludge
@@ -18883,101 +18895,101 @@ classes:
     title: water
     is_a: Extension
     slots:
-    - samp_name
-    - project_name
-    - depth
-    - elev
-    - alkalinity
-    - alkalinity_method
-    - alkyl_diethers
-    - aminopept_act
-    - ammonium
-    - atmospheric_data
-    - bacteria_carb_prod
-    - bac_prod
-    - bac_resp
-    - biomass
-    - bishomohopanol
-    - bromide
-    - calcium
-    - carb_nitro_ratio
-    - chem_administration
-    - chloride
-    - chlorophyll
-    - conduc
-    - density
-    - diether_lipids
-    - diss_carb_dioxide
-    - diss_hydrogen
-    - diss_inorg_carb
-    - diss_inorg_nitro
-    - diss_inorg_phosp
-    - diss_org_carb
-    - diss_org_nitro
-    - diss_oxygen
-    - down_par
-    - fluor
-    - glucosidase_act
-    - light_intensity
-    - magnesium
-    - mean_frict_vel
-    - mean_peak_frict_vel
-    - misc_param
-    - n_alkanes
-    - nitrate
-    - nitrite
-    - nitro
-    - org_carb
-    - org_matter
-    - org_nitro
-    - organism_count
-    - oxy_stat_samp
-    - ph
-    - part_org_carb
-    - part_org_nitro
-    - perturbation
-    - petroleum_hydrocarb
-    - phaeopigments
-    - phosphate
-    - phosplipid_fatt_acid
-    - photon_flux
-    - potassium
-    - pressure
-    - primary_prod
-    - redox_potential
-    - salinity
-    - samp_store_dur
-    - samp_store_loc
-    - samp_store_temp
-    - samp_vol_we_dna_ext
-    - silicate
-    - size_frac_low
-    - size_frac_up
-    - sodium
-    - soluble_react_phosp
-    - sulfate
-    - sulfide
-    - suspend_part_matter
-    - temp
-    - tidal_stage
-    - tot_depth_water_col
-    - tot_diss_nitro
-    - tot_inorg_nitro
-    - tot_nitro
-    - tot_part_carb
-    - tot_phosp
-    - turbidity
-    - water_current
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - alkalinity
+      - alkalinity_method
+      - alkyl_diethers
+      - aminopept_act
+      - ammonium
+      - atmospheric_data
+      - bacteria_carb_prod
+      - bac_prod
+      - bac_resp
+      - biomass
+      - bishomohopanol
+      - bromide
+      - calcium
+      - carb_nitro_ratio
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - conduc
+      - density
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_inorg_nitro
+      - diss_inorg_phosp
+      - diss_org_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - down_par
+      - fluor
+      - glucosidase_act
+      - light_intensity
+      - magnesium
+      - mean_frict_vel
+      - mean_peak_frict_vel
+      - misc_param
+      - n_alkanes
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - part_org_carb
+      - part_org_nitro
+      - perturbation
+      - petroleum_hydrocarb
+      - phaeopigments
+      - phosphate
+      - phosplipid_fatt_acid
+      - photon_flux
+      - potassium
+      - pressure
+      - primary_prod
+      - redox_potential
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - silicate
+      - size_frac_low
+      - size_frac_up
+      - sodium
+      - soluble_react_phosp
+      - sulfate
+      - sulfide
+      - suspend_part_matter
+      - temp
+      - tidal_stage
+      - tot_depth_water_col
+      - tot_diss_nitro
+      - tot_inorg_nitro
+      - tot_nitro
+      - tot_part_carb
+      - tot_phosp
+      - turbidity
+      - water_current
     slot_usage:
       depth:
         examples:
-        - value: 10 meter
+          - value: 10 meter
         required: true
       elev:
         recommended: true
       organism_count:
         examples:
-        - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016014
     aliases:
       - MIxS-water
@@ -18992,2811 +19004,2820 @@ classes:
     description: A collection of recommended metadata terms (slots) developed by community
       experts, describing the specific context under which a sample was collected.
     aliases:
-    - EnvironmentalPackage
+      - EnvironmentalPackage
   MixsCompliantData:
     description: A collection of Data that comply with some combination of a MIxS
       checklist and environmental extension
     title: MIxS compliant data
     slots:
-    - migs_ba_data
-    - agriculture_data
-    - migs_ba_agriculture_data
-    - air_data
-    - migs_ba_air_data
-    - built_environment_data
-    - migs_ba_built_environment_data
-    - food_animal_and_animal_feed_data
-    - migs_ba_food_animal_and_animal_feed_data
-    - food_farm_environment_data
-    - migs_ba_food_farm_environment_data
-    - food_food_production_facility_data
-    - migs_ba_food_food_production_facility_data
-    - food_human_foods_data
-    - migs_ba_food_human_foods_data
-    - host_associated_data
-    - migs_ba_host_associated_data
-    - human_associated_data
-    - migs_ba_human_associated_data
-    - human_gut_data
-    - migs_ba_human_gut_data
-    - human_oral_data
-    - migs_ba_human_oral_data
-    - human_skin_data
-    - migs_ba_human_skin_data
-    - human_vaginal_data
-    - migs_ba_human_vaginal_data
-    - hydrocarbon_resources_cores_data
-    - migs_ba_hydrocarbon_resources_cores_data
-    - hydrocarbon_resources_fluids_swabs_data
-    - migs_ba_hydrocarbon_resources_fluids_swabs_data
-    - microbial_mat_biofilm_data
-    - migs_ba_microbial_mat_biofilm_data
-    - miscellaneous_natural_or_artificial_environment_data
-    - migs_ba_miscellaneous_natural_or_artificial_environment_data
-    - plant_associated_data
-    - migs_ba_plant_associated_data
-    - sediment_data
-    - migs_ba_sediment_data
-    - soil_data
-    - migs_ba_soil_data
-    - symbiont_associated_data
-    - migs_ba_symbiont_associated_data
-    - wastewater_sludge_data
-    - migs_ba_wastewater_sludge_data
-    - water_data
-    - migs_ba_water_data
-    - migs_eu_data
-    - migs_eu_agriculture_data
-    - migs_eu_air_data
-    - migs_eu_built_environment_data
-    - migs_eu_food_animal_and_animal_feed_data
-    - migs_eu_food_farm_environment_data
-    - migs_eu_food_food_production_facility_data
-    - migs_eu_food_human_foods_data
-    - migs_eu_host_associated_data
-    - migs_eu_human_associated_data
-    - migs_eu_human_gut_data
-    - migs_eu_human_oral_data
-    - migs_eu_human_skin_data
-    - migs_eu_human_vaginal_data
-    - migs_eu_hydrocarbon_resources_cores_data
-    - migs_eu_hydrocarbon_resources_fluids_swabs_data
-    - migs_eu_microbial_mat_biofilm_data
-    - migs_eu_miscellaneous_natural_or_artificial_environment_data
-    - migs_eu_plant_associated_data
-    - migs_eu_sediment_data
-    - migs_eu_soil_data
-    - migs_eu_symbiont_associated_data
-    - migs_eu_wastewater_sludge_data
-    - migs_eu_water_data
-    - migs_org_data
-    - migs_org_agriculture_data
-    - migs_org_air_data
-    - migs_org_built_environment_data
-    - migs_org_food_animal_and_animal_feed_data
-    - migs_org_food_farm_environment_data
-    - migs_org_food_food_production_facility_data
-    - migs_org_food_human_foods_data
-    - migs_org_host_associated_data
-    - migs_org_human_associated_data
-    - migs_org_human_gut_data
-    - migs_org_human_oral_data
-    - migs_org_human_skin_data
-    - migs_org_human_vaginal_data
-    - migs_org_hydrocarbon_resources_cores_data
-    - migs_org_hydrocarbon_resources_fluids_swabs_data
-    - migs_org_microbial_mat_biofilm_data
-    - migs_org_miscellaneous_natural_or_artificial_environment_data
-    - migs_org_plant_associated_data
-    - migs_org_sediment_data
-    - migs_org_soil_data
-    - migs_org_symbiont_associated_data
-    - migs_org_wastewater_sludge_data
-    - migs_org_water_data
-    - migs_pl_data
-    - migs_pl_agriculture_data
-    - migs_pl_air_data
-    - migs_pl_built_environment_data
-    - migs_pl_food_animal_and_animal_feed_data
-    - migs_pl_food_farm_environment_data
-    - migs_pl_food_food_production_facility_data
-    - migs_pl_food_human_foods_data
-    - migs_pl_host_associated_data
-    - migs_pl_human_associated_data
-    - migs_pl_human_gut_data
-    - migs_pl_human_oral_data
-    - migs_pl_human_skin_data
-    - migs_pl_human_vaginal_data
-    - migs_pl_hydrocarbon_resources_cores_data
-    - migs_pl_hydrocarbon_resources_fluids_swabs_data
-    - migs_pl_microbial_mat_biofilm_data
-    - migs_pl_miscellaneous_natural_or_artificial_environment_data
-    - migs_pl_plant_associated_data
-    - migs_pl_sediment_data
-    - migs_pl_soil_data
-    - migs_pl_symbiont_associated_data
-    - migs_pl_wastewater_sludge_data
-    - migs_pl_water_data
-    - migs_vi_data
-    - migs_vi_agriculture_data
-    - migs_vi_air_data
-    - migs_vi_built_environment_data
-    - migs_vi_food_animal_and_animal_feed_data
-    - migs_vi_food_farm_environment_data
-    - migs_vi_food_food_production_facility_data
-    - migs_vi_food_human_foods_data
-    - migs_vi_host_associated_data
-    - migs_vi_human_associated_data
-    - migs_vi_human_gut_data
-    - migs_vi_human_oral_data
-    - migs_vi_human_skin_data
-    - migs_vi_human_vaginal_data
-    - migs_vi_hydrocarbon_resources_cores_data
-    - migs_vi_hydrocarbon_resources_fluids_swabs_data
-    - migs_vi_microbial_mat_biofilm_data
-    - migs_vi_miscellaneous_natural_or_artificial_environment_data
-    - migs_vi_plant_associated_data
-    - migs_vi_sediment_data
-    - migs_vi_soil_data
-    - migs_vi_symbiont_associated_data
-    - migs_vi_wastewater_sludge_data
-    - migs_vi_water_data
-    - mimag_data
-    - mimag_agriculture_data
-    - mimag_air_data
-    - mimag_built_environment_data
-    - mimag_food_animal_and_animal_feed_data
-    - mimag_food_farm_environment_data
-    - mimag_food_food_production_facility_data
-    - mimag_food_human_foods_data
-    - mimag_host_associated_data
-    - mimag_human_associated_data
-    - mimag_human_gut_data
-    - mimag_human_oral_data
-    - mimag_human_skin_data
-    - mimag_human_vaginal_data
-    - mimag_hydrocarbon_resources_cores_data
-    - mimag_hydrocarbon_resources_fluids_swabs_data
-    - mimag_microbial_mat_biofilm_data
-    - mimag_miscellaneous_natural_or_artificial_environment_data
-    - mimag_plant_associated_data
-    - mimag_sediment_data
-    - mimag_soil_data
-    - mimag_symbiont_associated_data
-    - mimag_wastewater_sludge_data
-    - mimag_water_data
-    - mimarks_c_data
-    - mimarks_c_agriculture_data
-    - mimarks_c_air_data
-    - mimarks_c_built_environment_data
-    - mimarks_c_food_animal_and_animal_feed_data
-    - mimarks_c_food_farm_environment_data
-    - mimarks_c_food_food_production_facility_data
-    - mimarks_c_food_human_foods_data
-    - mimarks_c_host_associated_data
-    - mimarks_c_human_associated_data
-    - mimarks_c_human_gut_data
-    - mimarks_c_human_oral_data
-    - mimarks_c_human_skin_data
-    - mimarks_c_human_vaginal_data
-    - mimarks_c_hydrocarbon_resources_cores_data
-    - mimarks_c_hydrocarbon_resources_fluids_swabs_data
-    - mimarks_c_microbial_mat_biofilm_data
-    - mimarks_c_miscellaneous_natural_or_artificial_environment_data
-    - mimarks_c_plant_associated_data
-    - mimarks_c_sediment_data
-    - mimarks_c_soil_data
-    - mimarks_c_symbiont_associated_data
-    - mimarks_c_wastewater_sludge_data
-    - mimarks_c_water_data
-    - mimarks_s_data
-    - mimarks_s_agriculture_data
-    - mimarks_s_air_data
-    - mimarks_s_built_environment_data
-    - mimarks_s_food_animal_and_animal_feed_data
-    - mimarks_s_food_farm_environment_data
-    - mimarks_s_food_food_production_facility_data
-    - mimarks_s_food_human_foods_data
-    - mimarks_s_host_associated_data
-    - mimarks_s_human_associated_data
-    - mimarks_s_human_gut_data
-    - mimarks_s_human_oral_data
-    - mimarks_s_human_skin_data
-    - mimarks_s_human_vaginal_data
-    - mimarks_s_hydrocarbon_resources_cores_data
-    - mimarks_s_hydrocarbon_resources_fluids_swabs_data
-    - mimarks_s_microbial_mat_biofilm_data
-    - mimarks_s_miscellaneous_natural_or_artificial_environment_data
-    - mimarks_s_plant_associated_data
-    - mimarks_s_sediment_data
-    - mimarks_s_soil_data
-    - mimarks_s_symbiont_associated_data
-    - mimarks_s_wastewater_sludge_data
-    - mimarks_s_water_data
-    - mims_data
-    - mims_agriculture_data
-    - mims_air_data
-    - mims_built_environment_data
-    - mims_food_animal_and_animal_feed_data
-    - mims_food_farm_environment_data
-    - mims_food_food_production_facility_data
-    - mims_food_human_foods_data
-    - mims_host_associated_data
-    - mims_human_associated_data
-    - mims_human_gut_data
-    - mims_human_oral_data
-    - mims_human_skin_data
-    - mims_human_vaginal_data
-    - mims_hydrocarbon_resources_cores_data
-    - mims_hydrocarbon_resources_fluids_swabs_data
-    - mims_microbial_mat_biofilm_data
-    - mims_miscellaneous_natural_or_artificial_environment_data
-    - mims_plant_associated_data
-    - mims_sediment_data
-    - mims_soil_data
-    - mims_symbiont_associated_data
-    - mims_wastewater_sludge_data
-    - mims_water_data
-    - misag_data
-    - misag_agriculture_data
-    - misag_air_data
-    - misag_built_environment_data
-    - misag_food_animal_and_animal_feed_data
-    - misag_food_farm_environment_data
-    - misag_food_food_production_facility_data
-    - misag_food_human_foods_data
-    - misag_host_associated_data
-    - misag_human_associated_data
-    - misag_human_gut_data
-    - misag_human_oral_data
-    - misag_human_skin_data
-    - misag_human_vaginal_data
-    - misag_hydrocarbon_resources_cores_data
-    - misag_hydrocarbon_resources_fluids_swabs_data
-    - misag_microbial_mat_biofilm_data
-    - misag_miscellaneous_natural_or_artificial_environment_data
-    - misag_plant_associated_data
-    - misag_sediment_data
-    - misag_soil_data
-    - misag_symbiont_associated_data
-    - misag_wastewater_sludge_data
-    - misag_water_data
-    - miuvig_data
-    - miuvig_agriculture_data
-    - miuvig_air_data
-    - miuvig_built_environment_data
-    - miuvig_food_animal_and_animal_feed_data
-    - miuvig_food_farm_environment_data
-    - miuvig_food_food_production_facility_data
-    - miuvig_food_human_foods_data
-    - miuvig_host_associated_data
-    - miuvig_human_associated_data
-    - miuvig_human_gut_data
-    - miuvig_human_oral_data
-    - miuvig_human_skin_data
-    - miuvig_human_vaginal_data
-    - miuvig_hydrocarbon_resources_cores_data
-    - miuvig_hydrocarbon_resources_fluids_swabs_data
-    - miuvig_microbial_mat_biofilm_data
-    - miuvig_miscellaneous_natural_or_artificial_environment_data
-    - miuvig_plant_associated_data
-    - miuvig_sediment_data
-    - miuvig_soil_data
-    - miuvig_symbiont_associated_data
-    - miuvig_wastewater_sludge_data
-    - miuvig_water_data
+      - migs_ba_data
+      - agriculture_data
+      - migs_ba_agriculture_data
+      - air_data
+      - migs_ba_air_data
+      - built_environment_data
+      - migs_ba_built_environment_data
+      - food_animal_and_animal_feed_data
+      - migs_ba_food_animal_and_animal_feed_data
+      - food_farm_environment_data
+      - migs_ba_food_farm_environment_data
+      - food_food_production_facility_data
+      - migs_ba_food_food_production_facility_data
+      - food_human_foods_data
+      - migs_ba_food_human_foods_data
+      - host_associated_data
+      - migs_ba_host_associated_data
+      - human_associated_data
+      - migs_ba_human_associated_data
+      - human_gut_data
+      - migs_ba_human_gut_data
+      - human_oral_data
+      - migs_ba_human_oral_data
+      - human_skin_data
+      - migs_ba_human_skin_data
+      - human_vaginal_data
+      - migs_ba_human_vaginal_data
+      - hydrocarbon_resources_cores_data
+      - migs_ba_hydrocarbon_resources_cores_data
+      - hydrocarbon_resources_fluids_swabs_data
+      - migs_ba_hydrocarbon_resources_fluids_swabs_data
+      - microbial_mat_biofilm_data
+      - migs_ba_microbial_mat_biofilm_data
+      - miscellaneous_natural_or_artificial_environment_data
+      - migs_ba_miscellaneous_natural_or_artificial_environment_data
+      - plant_associated_data
+      - migs_ba_plant_associated_data
+      - sediment_data
+      - migs_ba_sediment_data
+      - soil_data
+      - migs_ba_soil_data
+      - symbiont_associated_data
+      - migs_ba_symbiont_associated_data
+      - wastewater_sludge_data
+      - migs_ba_wastewater_sludge_data
+      - water_data
+      - migs_ba_water_data
+      - migs_eu_data
+      - migs_eu_agriculture_data
+      - migs_eu_air_data
+      - migs_eu_built_environment_data
+      - migs_eu_food_animal_and_animal_feed_data
+      - migs_eu_food_farm_environment_data
+      - migs_eu_food_food_production_facility_data
+      - migs_eu_food_human_foods_data
+      - migs_eu_host_associated_data
+      - migs_eu_human_associated_data
+      - migs_eu_human_gut_data
+      - migs_eu_human_oral_data
+      - migs_eu_human_skin_data
+      - migs_eu_human_vaginal_data
+      - migs_eu_hydrocarbon_resources_cores_data
+      - migs_eu_hydrocarbon_resources_fluids_swabs_data
+      - migs_eu_microbial_mat_biofilm_data
+      - migs_eu_miscellaneous_natural_or_artificial_environment_data
+      - migs_eu_plant_associated_data
+      - migs_eu_sediment_data
+      - migs_eu_soil_data
+      - migs_eu_symbiont_associated_data
+      - migs_eu_wastewater_sludge_data
+      - migs_eu_water_data
+      - migs_org_data
+      - migs_org_agriculture_data
+      - migs_org_air_data
+      - migs_org_built_environment_data
+      - migs_org_food_animal_and_animal_feed_data
+      - migs_org_food_farm_environment_data
+      - migs_org_food_food_production_facility_data
+      - migs_org_food_human_foods_data
+      - migs_org_host_associated_data
+      - migs_org_human_associated_data
+      - migs_org_human_gut_data
+      - migs_org_human_oral_data
+      - migs_org_human_skin_data
+      - migs_org_human_vaginal_data
+      - migs_org_hydrocarbon_resources_cores_data
+      - migs_org_hydrocarbon_resources_fluids_swabs_data
+      - migs_org_microbial_mat_biofilm_data
+      - migs_org_miscellaneous_natural_or_artificial_environment_data
+      - migs_org_plant_associated_data
+      - migs_org_sediment_data
+      - migs_org_soil_data
+      - migs_org_symbiont_associated_data
+      - migs_org_wastewater_sludge_data
+      - migs_org_water_data
+      - migs_pl_data
+      - migs_pl_agriculture_data
+      - migs_pl_air_data
+      - migs_pl_built_environment_data
+      - migs_pl_food_animal_and_animal_feed_data
+      - migs_pl_food_farm_environment_data
+      - migs_pl_food_food_production_facility_data
+      - migs_pl_food_human_foods_data
+      - migs_pl_host_associated_data
+      - migs_pl_human_associated_data
+      - migs_pl_human_gut_data
+      - migs_pl_human_oral_data
+      - migs_pl_human_skin_data
+      - migs_pl_human_vaginal_data
+      - migs_pl_hydrocarbon_resources_cores_data
+      - migs_pl_hydrocarbon_resources_fluids_swabs_data
+      - migs_pl_microbial_mat_biofilm_data
+      - migs_pl_miscellaneous_natural_or_artificial_environment_data
+      - migs_pl_plant_associated_data
+      - migs_pl_sediment_data
+      - migs_pl_soil_data
+      - migs_pl_symbiont_associated_data
+      - migs_pl_wastewater_sludge_data
+      - migs_pl_water_data
+      - migs_vi_data
+      - migs_vi_agriculture_data
+      - migs_vi_air_data
+      - migs_vi_built_environment_data
+      - migs_vi_food_animal_and_animal_feed_data
+      - migs_vi_food_farm_environment_data
+      - migs_vi_food_food_production_facility_data
+      - migs_vi_food_human_foods_data
+      - migs_vi_host_associated_data
+      - migs_vi_human_associated_data
+      - migs_vi_human_gut_data
+      - migs_vi_human_oral_data
+      - migs_vi_human_skin_data
+      - migs_vi_human_vaginal_data
+      - migs_vi_hydrocarbon_resources_cores_data
+      - migs_vi_hydrocarbon_resources_fluids_swabs_data
+      - migs_vi_microbial_mat_biofilm_data
+      - migs_vi_miscellaneous_natural_or_artificial_environment_data
+      - migs_vi_plant_associated_data
+      - migs_vi_sediment_data
+      - migs_vi_soil_data
+      - migs_vi_symbiont_associated_data
+      - migs_vi_wastewater_sludge_data
+      - migs_vi_water_data
+      - mimag_data
+      - mimag_agriculture_data
+      - mimag_air_data
+      - mimag_built_environment_data
+      - mimag_food_animal_and_animal_feed_data
+      - mimag_food_farm_environment_data
+      - mimag_food_food_production_facility_data
+      - mimag_food_human_foods_data
+      - mimag_host_associated_data
+      - mimag_human_associated_data
+      - mimag_human_gut_data
+      - mimag_human_oral_data
+      - mimag_human_skin_data
+      - mimag_human_vaginal_data
+      - mimag_hydrocarbon_resources_cores_data
+      - mimag_hydrocarbon_resources_fluids_swabs_data
+      - mimag_microbial_mat_biofilm_data
+      - mimag_miscellaneous_natural_or_artificial_environment_data
+      - mimag_plant_associated_data
+      - mimag_sediment_data
+      - mimag_soil_data
+      - mimag_symbiont_associated_data
+      - mimag_wastewater_sludge_data
+      - mimag_water_data
+      - mimarks_c_data
+      - mimarks_c_agriculture_data
+      - mimarks_c_air_data
+      - mimarks_c_built_environment_data
+      - mimarks_c_food_animal_and_animal_feed_data
+      - mimarks_c_food_farm_environment_data
+      - mimarks_c_food_food_production_facility_data
+      - mimarks_c_food_human_foods_data
+      - mimarks_c_host_associated_data
+      - mimarks_c_human_associated_data
+      - mimarks_c_human_gut_data
+      - mimarks_c_human_oral_data
+      - mimarks_c_human_skin_data
+      - mimarks_c_human_vaginal_data
+      - mimarks_c_hydrocarbon_resources_cores_data
+      - mimarks_c_hydrocarbon_resources_fluids_swabs_data
+      - mimarks_c_microbial_mat_biofilm_data
+      - mimarks_c_miscellaneous_natural_or_artificial_environment_data
+      - mimarks_c_plant_associated_data
+      - mimarks_c_sediment_data
+      - mimarks_c_soil_data
+      - mimarks_c_symbiont_associated_data
+      - mimarks_c_wastewater_sludge_data
+      - mimarks_c_water_data
+      - mimarks_s_data
+      - mimarks_s_agriculture_data
+      - mimarks_s_air_data
+      - mimarks_s_built_environment_data
+      - mimarks_s_food_animal_and_animal_feed_data
+      - mimarks_s_food_farm_environment_data
+      - mimarks_s_food_food_production_facility_data
+      - mimarks_s_food_human_foods_data
+      - mimarks_s_host_associated_data
+      - mimarks_s_human_associated_data
+      - mimarks_s_human_gut_data
+      - mimarks_s_human_oral_data
+      - mimarks_s_human_skin_data
+      - mimarks_s_human_vaginal_data
+      - mimarks_s_hydrocarbon_resources_cores_data
+      - mimarks_s_hydrocarbon_resources_fluids_swabs_data
+      - mimarks_s_microbial_mat_biofilm_data
+      - mimarks_s_miscellaneous_natural_or_artificial_environment_data
+      - mimarks_s_plant_associated_data
+      - mimarks_s_sediment_data
+      - mimarks_s_soil_data
+      - mimarks_s_symbiont_associated_data
+      - mimarks_s_wastewater_sludge_data
+      - mimarks_s_water_data
+      - mims_data
+      - mims_agriculture_data
+      - mims_air_data
+      - mims_built_environment_data
+      - mims_food_animal_and_animal_feed_data
+      - mims_food_farm_environment_data
+      - mims_food_food_production_facility_data
+      - mims_food_human_foods_data
+      - mims_host_associated_data
+      - mims_human_associated_data
+      - mims_human_gut_data
+      - mims_human_oral_data
+      - mims_human_skin_data
+      - mims_human_vaginal_data
+      - mims_hydrocarbon_resources_cores_data
+      - mims_hydrocarbon_resources_fluids_swabs_data
+      - mims_microbial_mat_biofilm_data
+      - mims_miscellaneous_natural_or_artificial_environment_data
+      - mims_plant_associated_data
+      - mims_sediment_data
+      - mims_soil_data
+      - mims_symbiont_associated_data
+      - mims_wastewater_sludge_data
+      - mims_water_data
+      - misag_data
+      - misag_agriculture_data
+      - misag_air_data
+      - misag_built_environment_data
+      - misag_food_animal_and_animal_feed_data
+      - misag_food_farm_environment_data
+      - misag_food_food_production_facility_data
+      - misag_food_human_foods_data
+      - misag_host_associated_data
+      - misag_human_associated_data
+      - misag_human_gut_data
+      - misag_human_oral_data
+      - misag_human_skin_data
+      - misag_human_vaginal_data
+      - misag_hydrocarbon_resources_cores_data
+      - misag_hydrocarbon_resources_fluids_swabs_data
+      - misag_microbial_mat_biofilm_data
+      - misag_miscellaneous_natural_or_artificial_environment_data
+      - misag_plant_associated_data
+      - misag_sediment_data
+      - misag_soil_data
+      - misag_symbiont_associated_data
+      - misag_wastewater_sludge_data
+      - misag_water_data
+      - miuvig_data
+      - miuvig_agriculture_data
+      - miuvig_air_data
+      - miuvig_built_environment_data
+      - miuvig_food_animal_and_animal_feed_data
+      - miuvig_food_farm_environment_data
+      - miuvig_food_food_production_facility_data
+      - miuvig_food_human_foods_data
+      - miuvig_host_associated_data
+      - miuvig_human_associated_data
+      - miuvig_human_gut_data
+      - miuvig_human_oral_data
+      - miuvig_human_skin_data
+      - miuvig_human_vaginal_data
+      - miuvig_hydrocarbon_resources_cores_data
+      - miuvig_hydrocarbon_resources_fluids_swabs_data
+      - miuvig_microbial_mat_biofilm_data
+      - miuvig_miscellaneous_natural_or_artificial_environment_data
+      - miuvig_plant_associated_data
+      - miuvig_sediment_data
+      - miuvig_soil_data
+      - miuvig_symbiont_associated_data
+      - miuvig_wastewater_sludge_data
+      - miuvig_water_data
     tree_root: true
   MigsBaAgriculture:
     description: MIxS Data that comply with the MigsBa checklist and the Agriculture
       Extension
     title: MigsBa combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016018
   MigsBaAir:
     description: MIxS Data that comply with the MigsBa checklist and the Air Extension
     title: MigsBa combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016000
   MigsBaBuiltEnvironment:
     description: MIxS Data that comply with the MigsBa checklist and the BuiltEnvironment
       Extension
     title: MigsBa combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016001
   MigsBaFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsBa checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsBa combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016019
   MigsBaFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsBa checklist and the FoodFarmEnvironment
       Extension
     title: MigsBa combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016020
   MigsBaFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsBa checklist and the FoodFoodProductionFacility
       Extension
     title: MigsBa combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016021
   MigsBaFoodHumanFoods:
     description: MIxS Data that comply with the MigsBa checklist and the FoodHumanFoods
       Extension
     title: MigsBa combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016022
   MigsBaHostAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the HostAssociated
       Extension
     title: MigsBa combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016002
   MigsBaHumanAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the HumanAssociated
       Extension
     title: MigsBa combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016003
   MigsBaHumanGut:
     description: MIxS Data that comply with the MigsBa checklist and the HumanGut
       Extension
     title: MigsBa combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016004
   MigsBaHumanOral:
     description: MIxS Data that comply with the MigsBa checklist and the HumanOral
       Extension
     title: MigsBa combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016005
   MigsBaHumanSkin:
     description: MIxS Data that comply with the MigsBa checklist and the HumanSkin
       Extension
     title: MigsBa combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016006
   MigsBaHumanVaginal:
     description: MIxS Data that comply with the MigsBa checklist and the HumanVaginal
       Extension
     title: MigsBa combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016007
   MigsBaHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsBa checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsBa combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016015
   MigsBaHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsBa checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsBa combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016016
   MigsBaMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsBa checklist and the MicrobialMatBiofilm
       Extension
     title: MigsBa combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016008
   MigsBaMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsBa checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsBa combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016009
   MigsBaPlantAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the PlantAssociated
       Extension
     title: MigsBa combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016010
   MigsBaSediment:
     description: MIxS Data that comply with the MigsBa checklist and the Sediment
       Extension
     title: MigsBa combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016011
   MigsBaSoil:
     description: MIxS Data that comply with the MigsBa checklist and the Soil Extension
     title: MigsBa combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016012
   MigsBaSymbiontAssociated:
     description: MIxS Data that comply with the MigsBa checklist and the SymbiontAssociated
       Extension
     title: MigsBa combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016023
   MigsBaWastewaterSludge:
     description: MIxS Data that comply with the MigsBa checklist and the WastewaterSludge
       Extension
     title: MigsBa combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016013
   MigsBaWater:
     description: MIxS Data that comply with the MigsBa checklist and the Water Extension
     title: MigsBa combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MigsBa
+      - MigsBa
     class_uri: MIXS:0010003_0016014
   MigsEuAgriculture:
     description: MIxS Data that comply with the MigsEu checklist and the Agriculture
       Extension
     title: MigsEu combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016018
   MigsEuAir:
     description: MIxS Data that comply with the MigsEu checklist and the Air Extension
     title: MigsEu combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016000
   MigsEuBuiltEnvironment:
     description: MIxS Data that comply with the MigsEu checklist and the BuiltEnvironment
       Extension
     title: MigsEu combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016001
   MigsEuFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsEu checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsEu combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016019
   MigsEuFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsEu checklist and the FoodFarmEnvironment
       Extension
     title: MigsEu combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016020
   MigsEuFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsEu checklist and the FoodFoodProductionFacility
       Extension
     title: MigsEu combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016021
   MigsEuFoodHumanFoods:
     description: MIxS Data that comply with the MigsEu checklist and the FoodHumanFoods
       Extension
     title: MigsEu combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016022
   MigsEuHostAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the HostAssociated
       Extension
     title: MigsEu combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016002
   MigsEuHumanAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the HumanAssociated
       Extension
     title: MigsEu combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016003
   MigsEuHumanGut:
     description: MIxS Data that comply with the MigsEu checklist and the HumanGut
       Extension
     title: MigsEu combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016004
   MigsEuHumanOral:
     description: MIxS Data that comply with the MigsEu checklist and the HumanOral
       Extension
     title: MigsEu combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016005
   MigsEuHumanSkin:
     description: MIxS Data that comply with the MigsEu checklist and the HumanSkin
       Extension
     title: MigsEu combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016006
   MigsEuHumanVaginal:
     description: MIxS Data that comply with the MigsEu checklist and the HumanVaginal
       Extension
     title: MigsEu combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016007
   MigsEuHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsEu checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsEu combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016015
   MigsEuHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsEu checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsEu combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016016
   MigsEuMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsEu checklist and the MicrobialMatBiofilm
       Extension
     title: MigsEu combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016008
   MigsEuMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsEu checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsEu combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016009
   MigsEuPlantAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the PlantAssociated
       Extension
     title: MigsEu combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016010
   MigsEuSediment:
     description: MIxS Data that comply with the MigsEu checklist and the Sediment
       Extension
     title: MigsEu combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016011
   MigsEuSoil:
     description: MIxS Data that comply with the MigsEu checklist and the Soil Extension
     title: MigsEu combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016012
   MigsEuSymbiontAssociated:
     description: MIxS Data that comply with the MigsEu checklist and the SymbiontAssociated
       Extension
     title: MigsEu combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016023
   MigsEuWastewaterSludge:
     description: MIxS Data that comply with the MigsEu checklist and the WastewaterSludge
       Extension
     title: MigsEu combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016013
   MigsEuWater:
     description: MIxS Data that comply with the MigsEu checklist and the Water Extension
     title: MigsEu combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MigsEu
+      - MigsEu
     class_uri: MIXS:0010002_0016014
   MigsOrgAgriculture:
     description: MIxS Data that comply with the MigsOrg checklist and the Agriculture
       Extension
     title: MigsOrg combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016018
   MigsOrgAir:
     description: MIxS Data that comply with the MigsOrg checklist and the Air Extension
     title: MigsOrg combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016000
   MigsOrgBuiltEnvironment:
     description: MIxS Data that comply with the MigsOrg checklist and the BuiltEnvironment
       Extension
     title: MigsOrg combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016001
   MigsOrgFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsOrg combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016019
   MigsOrgFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodFarmEnvironment
       Extension
     title: MigsOrg combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016020
   MigsOrgFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodFoodProductionFacility
       Extension
     title: MigsOrg combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016021
   MigsOrgFoodHumanFoods:
     description: MIxS Data that comply with the MigsOrg checklist and the FoodHumanFoods
       Extension
     title: MigsOrg combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016022
   MigsOrgHostAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the HostAssociated
       Extension
     title: MigsOrg combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016002
   MigsOrgHumanAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanAssociated
       Extension
     title: MigsOrg combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016003
   MigsOrgHumanGut:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanGut
       Extension
     title: MigsOrg combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016004
   MigsOrgHumanOral:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanOral
       Extension
     title: MigsOrg combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016005
   MigsOrgHumanSkin:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanSkin
       Extension
     title: MigsOrg combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016006
   MigsOrgHumanVaginal:
     description: MIxS Data that comply with the MigsOrg checklist and the HumanVaginal
       Extension
     title: MigsOrg combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016007
   MigsOrgHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsOrg checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsOrg combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016015
   MigsOrgHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsOrg checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsOrg combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016016
   MigsOrgMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsOrg checklist and the MicrobialMatBiofilm
       Extension
     title: MigsOrg combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016008
   MigsOrgMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsOrg checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsOrg combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016009
   MigsOrgPlantAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the PlantAssociated
       Extension
     title: MigsOrg combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016010
   MigsOrgSediment:
     description: MIxS Data that comply with the MigsOrg checklist and the Sediment
       Extension
     title: MigsOrg combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016011
   MigsOrgSoil:
     description: MIxS Data that comply with the MigsOrg checklist and the Soil Extension
     title: MigsOrg combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016012
   MigsOrgSymbiontAssociated:
     description: MIxS Data that comply with the MigsOrg checklist and the SymbiontAssociated
       Extension
     title: MigsOrg combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016023
   MigsOrgWastewaterSludge:
     description: MIxS Data that comply with the MigsOrg checklist and the WastewaterSludge
       Extension
     title: MigsOrg combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016013
   MigsOrgWater:
     description: MIxS Data that comply with the MigsOrg checklist and the Water Extension
     title: MigsOrg combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MigsOrg
+      - MigsOrg
     class_uri: MIXS:0010006_0016014
   MigsPlAgriculture:
     description: MIxS Data that comply with the MigsPl checklist and the Agriculture
       Extension
     title: MigsPl combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016018
   MigsPlAir:
     description: MIxS Data that comply with the MigsPl checklist and the Air Extension
     title: MigsPl combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016000
   MigsPlBuiltEnvironment:
     description: MIxS Data that comply with the MigsPl checklist and the BuiltEnvironment
       Extension
     title: MigsPl combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016001
   MigsPlFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsPl checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsPl combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016019
   MigsPlFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsPl checklist and the FoodFarmEnvironment
       Extension
     title: MigsPl combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016020
   MigsPlFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsPl checklist and the FoodFoodProductionFacility
       Extension
     title: MigsPl combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016021
   MigsPlFoodHumanFoods:
     description: MIxS Data that comply with the MigsPl checklist and the FoodHumanFoods
       Extension
     title: MigsPl combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016022
   MigsPlHostAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the HostAssociated
       Extension
     title: MigsPl combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016002
   MigsPlHumanAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the HumanAssociated
       Extension
     title: MigsPl combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016003
   MigsPlHumanGut:
     description: MIxS Data that comply with the MigsPl checklist and the HumanGut
       Extension
     title: MigsPl combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016004
   MigsPlHumanOral:
     description: MIxS Data that comply with the MigsPl checklist and the HumanOral
       Extension
     title: MigsPl combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016005
   MigsPlHumanSkin:
     description: MIxS Data that comply with the MigsPl checklist and the HumanSkin
       Extension
     title: MigsPl combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016006
   MigsPlHumanVaginal:
     description: MIxS Data that comply with the MigsPl checklist and the HumanVaginal
       Extension
     title: MigsPl combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016007
   MigsPlHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsPl checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsPl combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016015
   MigsPlHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsPl checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsPl combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016016
   MigsPlMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsPl checklist and the MicrobialMatBiofilm
       Extension
     title: MigsPl combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016008
   MigsPlMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsPl checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsPl combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016009
   MigsPlPlantAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the PlantAssociated
       Extension
     title: MigsPl combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016010
   MigsPlSediment:
     description: MIxS Data that comply with the MigsPl checklist and the Sediment
       Extension
     title: MigsPl combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016011
   MigsPlSoil:
     description: MIxS Data that comply with the MigsPl checklist and the Soil Extension
     title: MigsPl combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016012
   MigsPlSymbiontAssociated:
     description: MIxS Data that comply with the MigsPl checklist and the SymbiontAssociated
       Extension
     title: MigsPl combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016023
   MigsPlWastewaterSludge:
     description: MIxS Data that comply with the MigsPl checklist and the WastewaterSludge
       Extension
     title: MigsPl combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016013
   MigsPlWater:
     description: MIxS Data that comply with the MigsPl checklist and the Water Extension
     title: MigsPl combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MigsPl
+      - MigsPl
     class_uri: MIXS:0010004_0016014
   MigsViAgriculture:
     description: MIxS Data that comply with the MigsVi checklist and the Agriculture
       Extension
     title: MigsVi combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016018
   MigsViAir:
     description: MIxS Data that comply with the MigsVi checklist and the Air Extension
     title: MigsVi combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016000
   MigsViBuiltEnvironment:
     description: MIxS Data that comply with the MigsVi checklist and the BuiltEnvironment
       Extension
     title: MigsVi combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016001
   MigsViFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MigsVi checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MigsVi combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016019
   MigsViFoodFarmEnvironment:
     description: MIxS Data that comply with the MigsVi checklist and the FoodFarmEnvironment
       Extension
     title: MigsVi combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016020
   MigsViFoodFoodProductionFacility:
     description: MIxS Data that comply with the MigsVi checklist and the FoodFoodProductionFacility
       Extension
     title: MigsVi combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016021
   MigsViFoodHumanFoods:
     description: MIxS Data that comply with the MigsVi checklist and the FoodHumanFoods
       Extension
     title: MigsVi combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016022
   MigsViHostAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the HostAssociated
       Extension
     title: MigsVi combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016002
   MigsViHumanAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the HumanAssociated
       Extension
     title: MigsVi combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016003
   MigsViHumanGut:
     description: MIxS Data that comply with the MigsVi checklist and the HumanGut
       Extension
     title: MigsVi combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016004
   MigsViHumanOral:
     description: MIxS Data that comply with the MigsVi checklist and the HumanOral
       Extension
     title: MigsVi combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016005
   MigsViHumanSkin:
     description: MIxS Data that comply with the MigsVi checklist and the HumanSkin
       Extension
     title: MigsVi combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016006
   MigsViHumanVaginal:
     description: MIxS Data that comply with the MigsVi checklist and the HumanVaginal
       Extension
     title: MigsVi combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016007
   MigsViHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MigsVi checklist and the HydrocarbonResourcesCores
       Extension
     title: MigsVi combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016015
   MigsViHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MigsVi checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MigsVi combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016016
   MigsViMicrobialMatBiofilm:
     description: MIxS Data that comply with the MigsVi checklist and the MicrobialMatBiofilm
       Extension
     title: MigsVi combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016008
   MigsViMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MigsVi checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MigsVi combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016009
   MigsViPlantAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the PlantAssociated
       Extension
     title: MigsVi combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016010
   MigsViSediment:
     description: MIxS Data that comply with the MigsVi checklist and the Sediment
       Extension
     title: MigsVi combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016011
   MigsViSoil:
     description: MIxS Data that comply with the MigsVi checklist and the Soil Extension
     title: MigsVi combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016012
   MigsViSymbiontAssociated:
     description: MIxS Data that comply with the MigsVi checklist and the SymbiontAssociated
       Extension
     title: MigsVi combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016023
   MigsViWastewaterSludge:
     description: MIxS Data that comply with the MigsVi checklist and the WastewaterSludge
       Extension
     title: MigsVi combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016013
   MigsViWater:
     description: MIxS Data that comply with the MigsVi checklist and the Water Extension
     title: MigsVi combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MigsVi
+      - MigsVi
     class_uri: MIXS:0010005_0016014
   MimagAgriculture:
     description: MIxS Data that comply with the Mimag checklist and the Agriculture
       Extension
     title: Mimag combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016018
   MimagAir:
     description: MIxS Data that comply with the Mimag checklist and the Air Extension
     title: Mimag combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016000
   MimagBuiltEnvironment:
     description: MIxS Data that comply with the Mimag checklist and the BuiltEnvironment
       Extension
     title: Mimag combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016001
   MimagFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Mimag checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Mimag combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016019
   MimagFoodFarmEnvironment:
     description: MIxS Data that comply with the Mimag checklist and the FoodFarmEnvironment
       Extension
     title: Mimag combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016020
   MimagFoodFoodProductionFacility:
     description: MIxS Data that comply with the Mimag checklist and the FoodFoodProductionFacility
       Extension
     title: Mimag combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016021
   MimagFoodHumanFoods:
     description: MIxS Data that comply with the Mimag checklist and the FoodHumanFoods
       Extension
     title: Mimag combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016022
   MimagHostAssociated:
     description: MIxS Data that comply with the Mimag checklist and the HostAssociated
       Extension
     title: Mimag combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016002
   MimagHumanAssociated:
     description: MIxS Data that comply with the Mimag checklist and the HumanAssociated
       Extension
     title: Mimag combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016003
   MimagHumanGut:
     description: MIxS Data that comply with the Mimag checklist and the HumanGut Extension
     title: Mimag combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016004
   MimagHumanOral:
     description: MIxS Data that comply with the Mimag checklist and the HumanOral
       Extension
     title: Mimag combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016005
   MimagHumanSkin:
     description: MIxS Data that comply with the Mimag checklist and the HumanSkin
       Extension
     title: Mimag combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016006
   MimagHumanVaginal:
     description: MIxS Data that comply with the Mimag checklist and the HumanVaginal
       Extension
     title: Mimag combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016007
   MimagHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Mimag checklist and the HydrocarbonResourcesCores
       Extension
     title: Mimag combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016015
   MimagHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Mimag checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Mimag combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016016
   MimagMicrobialMatBiofilm:
     description: MIxS Data that comply with the Mimag checklist and the MicrobialMatBiofilm
       Extension
     title: Mimag combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016008
   MimagMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Mimag checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Mimag combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016009
   MimagPlantAssociated:
     description: MIxS Data that comply with the Mimag checklist and the PlantAssociated
       Extension
     title: Mimag combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016010
   MimagSediment:
     description: MIxS Data that comply with the Mimag checklist and the Sediment Extension
     title: Mimag combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016011
   MimagSoil:
     description: MIxS Data that comply with the Mimag checklist and the Soil Extension
     title: Mimag combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016012
   MimagSymbiontAssociated:
     description: MIxS Data that comply with the Mimag checklist and the SymbiontAssociated
       Extension
     title: Mimag combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016023
   MimagWastewaterSludge:
     description: MIxS Data that comply with the Mimag checklist and the WastewaterSludge
       Extension
     title: Mimag combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016013
   MimagWater:
     description: MIxS Data that comply with the Mimag checklist and the Water Extension
     title: Mimag combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - Mimag
+      - Mimag
     class_uri: MIXS:0010011_0016014
   MimarksCAgriculture:
     description: MIxS Data that comply with the MimarksC checklist and the Agriculture
       Extension
     title: MimarksC combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016018
   MimarksCAir:
     description: MIxS Data that comply with the MimarksC checklist and the Air Extension
     title: MimarksC combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016000
   MimarksCBuiltEnvironment:
     description: MIxS Data that comply with the MimarksC checklist and the BuiltEnvironment
       Extension
     title: MimarksC combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016001
   MimarksCFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MimarksC checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MimarksC combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016019
   MimarksCFoodFarmEnvironment:
     description: MIxS Data that comply with the MimarksC checklist and the FoodFarmEnvironment
       Extension
     title: MimarksC combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016020
   MimarksCFoodFoodProductionFacility:
     description: MIxS Data that comply with the MimarksC checklist and the FoodFoodProductionFacility
       Extension
     title: MimarksC combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016021
   MimarksCFoodHumanFoods:
     description: MIxS Data that comply with the MimarksC checklist and the FoodHumanFoods
       Extension
     title: MimarksC combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016022
   MimarksCHostAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the HostAssociated
       Extension
     title: MimarksC combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016002
   MimarksCHumanAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the HumanAssociated
       Extension
     title: MimarksC combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016003
   MimarksCHumanGut:
     description: MIxS Data that comply with the MimarksC checklist and the HumanGut
       Extension
     title: MimarksC combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016004
   MimarksCHumanOral:
     description: MIxS Data that comply with the MimarksC checklist and the HumanOral
       Extension
     title: MimarksC combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016005
   MimarksCHumanSkin:
     description: MIxS Data that comply with the MimarksC checklist and the HumanSkin
       Extension
     title: MimarksC combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016006
   MimarksCHumanVaginal:
     description: MIxS Data that comply with the MimarksC checklist and the HumanVaginal
       Extension
     title: MimarksC combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016007
   MimarksCHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MimarksC checklist and the HydrocarbonResourcesCores
       Extension
     title: MimarksC combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016015
   MimarksCHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MimarksC checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MimarksC combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016016
   MimarksCMicrobialMatBiofilm:
     description: MIxS Data that comply with the MimarksC checklist and the MicrobialMatBiofilm
       Extension
     title: MimarksC combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016008
   MimarksCMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MimarksC checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MimarksC combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016009
   MimarksCPlantAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the PlantAssociated
       Extension
     title: MimarksC combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016010
   MimarksCSediment:
     description: MIxS Data that comply with the MimarksC checklist and the Sediment
       Extension
     title: MimarksC combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016011
   MimarksCSoil:
     description: MIxS Data that comply with the MimarksC checklist and the Soil Extension
     title: MimarksC combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016012
   MimarksCSymbiontAssociated:
     description: MIxS Data that comply with the MimarksC checklist and the SymbiontAssociated
       Extension
     title: MimarksC combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016023
   MimarksCWastewaterSludge:
     description: MIxS Data that comply with the MimarksC checklist and the WastewaterSludge
       Extension
     title: MimarksC combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016013
   MimarksCWater:
     description: MIxS Data that comply with the MimarksC checklist and the Water Extension
     title: MimarksC combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MimarksC
+      - MimarksC
     class_uri: MIXS:0010009_0016014
   MimarksSAgriculture:
     description: MIxS Data that comply with the MimarksS checklist and the Agriculture
       Extension
     title: MimarksS combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016018
   MimarksSAir:
     description: MIxS Data that comply with the MimarksS checklist and the Air Extension
     title: MimarksS combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016000
   MimarksSBuiltEnvironment:
     description: MIxS Data that comply with the MimarksS checklist and the BuiltEnvironment
       Extension
     title: MimarksS combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016001
   MimarksSFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the MimarksS checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: MimarksS combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016019
   MimarksSFoodFarmEnvironment:
     description: MIxS Data that comply with the MimarksS checklist and the FoodFarmEnvironment
       Extension
     title: MimarksS combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016020
   MimarksSFoodFoodProductionFacility:
     description: MIxS Data that comply with the MimarksS checklist and the FoodFoodProductionFacility
       Extension
     title: MimarksS combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016021
   MimarksSFoodHumanFoods:
     description: MIxS Data that comply with the MimarksS checklist and the FoodHumanFoods
       Extension
     title: MimarksS combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016022
   MimarksSHostAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the HostAssociated
       Extension
     title: MimarksS combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016002
   MimarksSHumanAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the HumanAssociated
       Extension
     title: MimarksS combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016003
   MimarksSHumanGut:
     description: MIxS Data that comply with the MimarksS checklist and the HumanGut
       Extension
     title: MimarksS combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016004
   MimarksSHumanOral:
     description: MIxS Data that comply with the MimarksS checklist and the HumanOral
       Extension
     title: MimarksS combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016005
   MimarksSHumanSkin:
     description: MIxS Data that comply with the MimarksS checklist and the HumanSkin
       Extension
     title: MimarksS combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016006
   MimarksSHumanVaginal:
     description: MIxS Data that comply with the MimarksS checklist and the HumanVaginal
       Extension
     title: MimarksS combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016007
   MimarksSHydrocarbonResourcesCores:
     description: MIxS Data that comply with the MimarksS checklist and the HydrocarbonResourcesCores
       Extension
     title: MimarksS combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016015
   MimarksSHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the MimarksS checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: MimarksS combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016016
   MimarksSMicrobialMatBiofilm:
     description: MIxS Data that comply with the MimarksS checklist and the MicrobialMatBiofilm
       Extension
     title: MimarksS combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016008
   MimarksSMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the MimarksS checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: MimarksS combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016009
   MimarksSPlantAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the PlantAssociated
       Extension
     title: MimarksS combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016010
   MimarksSSediment:
     description: MIxS Data that comply with the MimarksS checklist and the Sediment
       Extension
     title: MimarksS combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016011
   MimarksSSoil:
     description: MIxS Data that comply with the MimarksS checklist and the Soil Extension
     title: MimarksS combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016012
   MimarksSSymbiontAssociated:
     description: MIxS Data that comply with the MimarksS checklist and the SymbiontAssociated
       Extension
     title: MimarksS combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016023
   MimarksSWastewaterSludge:
     description: MIxS Data that comply with the MimarksS checklist and the WastewaterSludge
       Extension
     title: MimarksS combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016013
   MimarksSWater:
     description: MIxS Data that comply with the MimarksS checklist and the Water Extension
     title: MimarksS combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - MimarksS
+      - MimarksS
     class_uri: MIXS:0010008_0016014
   MimsAgriculture:
     description: MIxS Data that comply with the Mims checklist and the Agriculture
       Extension
     title: Mims combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016018
   MimsAir:
     description: MIxS Data that comply with the Mims checklist and the Air Extension
     title: Mims combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016000
   MimsBuiltEnvironment:
     description: MIxS Data that comply with the Mims checklist and the BuiltEnvironment
       Extension
     title: Mims combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016001
   MimsFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Mims checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Mims combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016019
   MimsFoodFarmEnvironment:
     description: MIxS Data that comply with the Mims checklist and the FoodFarmEnvironment
       Extension
     title: Mims combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016020
   MimsFoodFoodProductionFacility:
     description: MIxS Data that comply with the Mims checklist and the FoodFoodProductionFacility
       Extension
     title: Mims combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016021
   MimsFoodHumanFoods:
     description: MIxS Data that comply with the Mims checklist and the FoodHumanFoods
       Extension
     title: Mims combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016022
   MimsHostAssociated:
     description: MIxS Data that comply with the Mims checklist and the HostAssociated
       Extension
     title: Mims combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016002
   MimsHumanAssociated:
     description: MIxS Data that comply with the Mims checklist and the HumanAssociated
       Extension
     title: Mims combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016003
   MimsHumanGut:
     description: MIxS Data that comply with the Mims checklist and the HumanGut Extension
     title: Mims combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016004
   MimsHumanOral:
     description: MIxS Data that comply with the Mims checklist and the HumanOral Extension
     title: Mims combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016005
   MimsHumanSkin:
     description: MIxS Data that comply with the Mims checklist and the HumanSkin Extension
     title: Mims combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016006
   MimsHumanVaginal:
     description: MIxS Data that comply with the Mims checklist and the HumanVaginal
       Extension
     title: Mims combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016007
   MimsHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Mims checklist and the HydrocarbonResourcesCores
       Extension
     title: Mims combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016015
   MimsHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Mims checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Mims combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016016
   MimsMicrobialMatBiofilm:
     description: MIxS Data that comply with the Mims checklist and the MicrobialMatBiofilm
       Extension
     title: Mims combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016008
   MimsMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Mims checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Mims combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016009
   MimsPlantAssociated:
     description: MIxS Data that comply with the Mims checklist and the PlantAssociated
       Extension
     title: Mims combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016010
   MimsSediment:
     description: MIxS Data that comply with the Mims checklist and the Sediment Extension
     title: Mims combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016011
   MimsSoil:
     description: MIxS Data that comply with the Mims checklist and the Soil Extension
     title: Mims combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016012
   MimsSymbiontAssociated:
     description: MIxS Data that comply with the Mims checklist and the SymbiontAssociated
       Extension
     title: Mims combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016023
   MimsWastewaterSludge:
     description: MIxS Data that comply with the Mims checklist and the WastewaterSludge
       Extension
     title: Mims combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016013
   MimsWater:
     description: MIxS Data that comply with the Mims checklist and the Water Extension
     title: Mims combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - Mims
+      - Mims
     class_uri: MIXS:0010007_0016014
   MisagAgriculture:
     description: MIxS Data that comply with the Misag checklist and the Agriculture
       Extension
     title: Misag combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016018
   MisagAir:
     description: MIxS Data that comply with the Misag checklist and the Air Extension
     title: Misag combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016000
   MisagBuiltEnvironment:
     description: MIxS Data that comply with the Misag checklist and the BuiltEnvironment
       Extension
     title: Misag combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016001
   MisagFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Misag checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Misag combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016019
   MisagFoodFarmEnvironment:
     description: MIxS Data that comply with the Misag checklist and the FoodFarmEnvironment
       Extension
     title: Misag combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016020
   MisagFoodFoodProductionFacility:
     description: MIxS Data that comply with the Misag checklist and the FoodFoodProductionFacility
       Extension
     title: Misag combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016021
   MisagFoodHumanFoods:
     description: MIxS Data that comply with the Misag checklist and the FoodHumanFoods
       Extension
     title: Misag combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016022
   MisagHostAssociated:
     description: MIxS Data that comply with the Misag checklist and the HostAssociated
       Extension
     title: Misag combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016002
   MisagHumanAssociated:
     description: MIxS Data that comply with the Misag checklist and the HumanAssociated
       Extension
     title: Misag combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016003
   MisagHumanGut:
     description: MIxS Data that comply with the Misag checklist and the HumanGut Extension
     title: Misag combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016004
   MisagHumanOral:
     description: MIxS Data that comply with the Misag checklist and the HumanOral
       Extension
     title: Misag combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016005
   MisagHumanSkin:
     description: MIxS Data that comply with the Misag checklist and the HumanSkin
       Extension
     title: Misag combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016006
   MisagHumanVaginal:
     description: MIxS Data that comply with the Misag checklist and the HumanVaginal
       Extension
     title: Misag combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016007
   MisagHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Misag checklist and the HydrocarbonResourcesCores
       Extension
     title: Misag combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016015
   MisagHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Misag checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Misag combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016016
   MisagMicrobialMatBiofilm:
     description: MIxS Data that comply with the Misag checklist and the MicrobialMatBiofilm
       Extension
     title: Misag combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016008
   MisagMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Misag checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Misag combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016009
   MisagPlantAssociated:
     description: MIxS Data that comply with the Misag checklist and the PlantAssociated
       Extension
     title: Misag combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016010
   MisagSediment:
     description: MIxS Data that comply with the Misag checklist and the Sediment Extension
     title: Misag combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016011
   MisagSoil:
     description: MIxS Data that comply with the Misag checklist and the Soil Extension
     title: Misag combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016012
   MisagSymbiontAssociated:
     description: MIxS Data that comply with the Misag checklist and the SymbiontAssociated
       Extension
     title: Misag combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016023
   MisagWastewaterSludge:
     description: MIxS Data that comply with the Misag checklist and the WastewaterSludge
       Extension
     title: Misag combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016013
   MisagWater:
     description: MIxS Data that comply with the Misag checklist and the Water Extension
     title: Misag combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - Misag
+      - Misag
     class_uri: MIXS:0010010_0016014
   MiuvigAgriculture:
     description: MIxS Data that comply with the Miuvig checklist and the Agriculture
       Extension
     title: Miuvig combined with Agriculture
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Agriculture
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016018
   MiuvigAir:
     description: MIxS Data that comply with the Miuvig checklist and the Air Extension
     title: Miuvig combined with Air
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Air
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016000
   MiuvigBuiltEnvironment:
     description: MIxS Data that comply with the Miuvig checklist and the BuiltEnvironment
       Extension
     title: Miuvig combined with BuiltEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: BuiltEnvironment
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016001
   MiuvigFoodAnimalAndAnimalFeed:
     description: MIxS Data that comply with the Miuvig checklist and the FoodAnimalAndAnimalFeed
       Extension
     title: Miuvig combined with FoodAnimalAndAnimalFeed
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodAnimalAndAnimalFeed
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016019
   MiuvigFoodFarmEnvironment:
     description: MIxS Data that comply with the Miuvig checklist and the FoodFarmEnvironment
       Extension
     title: Miuvig combined with FoodFarmEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFarmEnvironment
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016020
   MiuvigFoodFoodProductionFacility:
     description: MIxS Data that comply with the Miuvig checklist and the FoodFoodProductionFacility
       Extension
     title: Miuvig combined with FoodFoodProductionFacility
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodFoodProductionFacility
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016021
   MiuvigFoodHumanFoods:
     description: MIxS Data that comply with the Miuvig checklist and the FoodHumanFoods
       Extension
     title: Miuvig combined with FoodHumanFoods
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: FoodHumanFoods
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016022
   MiuvigHostAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the HostAssociated
       Extension
     title: Miuvig combined with HostAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HostAssociated
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016002
   MiuvigHumanAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the HumanAssociated
       Extension
     title: Miuvig combined with HumanAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanAssociated
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016003
   MiuvigHumanGut:
     description: MIxS Data that comply with the Miuvig checklist and the HumanGut
       Extension
     title: Miuvig combined with HumanGut
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanGut
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016004
   MiuvigHumanOral:
     description: MIxS Data that comply with the Miuvig checklist and the HumanOral
       Extension
     title: Miuvig combined with HumanOral
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanOral
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016005
   MiuvigHumanSkin:
     description: MIxS Data that comply with the Miuvig checklist and the HumanSkin
       Extension
     title: Miuvig combined with HumanSkin
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanSkin
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016006
   MiuvigHumanVaginal:
     description: MIxS Data that comply with the Miuvig checklist and the HumanVaginal
       Extension
     title: Miuvig combined with HumanVaginal
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HumanVaginal
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016007
   MiuvigHydrocarbonResourcesCores:
     description: MIxS Data that comply with the Miuvig checklist and the HydrocarbonResourcesCores
       Extension
     title: Miuvig combined with HydrocarbonResourcesCores
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesCores
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016015
   MiuvigHydrocarbonResourcesFluidsSwabs:
     description: MIxS Data that comply with the Miuvig checklist and the HydrocarbonResourcesFluidsSwabs
       Extension
     title: Miuvig combined with HydrocarbonResourcesFluidsSwabs
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: HydrocarbonResourcesFluidsSwabs
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016016
   MiuvigMicrobialMatBiofilm:
     description: MIxS Data that comply with the Miuvig checklist and the MicrobialMatBiofilm
       Extension
     title: Miuvig combined with MicrobialMatBiofilm
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MicrobialMatBiofilm
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016008
   MiuvigMiscellaneousNaturalOrArtificialEnvironment:
     description: MIxS Data that comply with the Miuvig checklist and the MiscellaneousNaturalOrArtificialEnvironment
       Extension
     title: Miuvig combined with MiscellaneousNaturalOrArtificialEnvironment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: MiscellaneousNaturalOrArtificialEnvironment
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016009
   MiuvigPlantAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the PlantAssociated
       Extension
     title: Miuvig combined with PlantAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: PlantAssociated
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016010
   MiuvigSediment:
     description: MIxS Data that comply with the Miuvig checklist and the Sediment
       Extension
     title: Miuvig combined with Sediment
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Sediment
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016011
   MiuvigSoil:
     description: MIxS Data that comply with the Miuvig checklist and the Soil Extension
     title: Miuvig combined with Soil
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Soil
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016012
   MiuvigSymbiontAssociated:
     description: MIxS Data that comply with the Miuvig checklist and the SymbiontAssociated
       Extension
     title: Miuvig combined with SymbiontAssociated
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: SymbiontAssociated
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016023
   MiuvigWastewaterSludge:
     description: MIxS Data that comply with the Miuvig checklist and the WastewaterSludge
       Extension
     title: Miuvig combined with WastewaterSludge
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: WastewaterSludge
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016013
   MiuvigWater:
     description: MIxS Data that comply with the Miuvig checklist and the Water Extension
     title: Miuvig combined with Water
     in_subset:
-    - combination_classes
+      - combination_classes
     is_a: Water
     mixins:
-    - Miuvig
+      - Miuvig
     class_uri: MIXS:0010012_0016014
 settings:
-  country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  parameters: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  region: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  room_name: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  software: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  specific_location: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  storage_condition_type: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  termLabel: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  unit: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  version: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  DOI: ^doi:10.\d{2,9}/.*$
+  agrochemical_name: ".*"
+  amount: '[-+]?[0-9]*\.?[0-9]+'
+  add_recov_methods: 'Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer Addition|Surfactant Addition|Not Applicable|other'
+  DOI: '^doi:10.\d{2,9}/.*$'
   NCBItaxon_id: NCBITaxon:\d+
   PMID: ^PMID:\d+$
   URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$
   adapter: '[ACGTRKSYMWBHDVN]+'
+  adapter_A_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
+  adapter_B_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
   ambiguous_nucleotides: '[ACGTRKSYMWBHDVN]+'
+  country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  date_time_stamp: '(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$'
   duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
   float: '[-+]?[0-9]*\.?[0-9]+'
   integer: '[1-9][0-9]*'
   lat: (-?((?:[0-8]?[0-9](?:\.\d{0,8})?)|90))
   lon: -?[0-9]+(?:\.[0-9]{0,8})?$|^-?(1[0-7]{1,2})
+  name: '.*'
+  parameters: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  particulate_matter_name: '.*'
+  region: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  room_name: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   room_number: '[1-9][0-9]*'
   scientific_float: '[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?'
+  software: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  specific_location: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  storage_condition_type: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   termID: '[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'
+  termLabel: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  text: '.*'
+  unit: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  version: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)


### PR DESCRIPTION
the values that a slot accepts can be constrained in several ways
- `range`: (enumeration, string, integer, boolean, etc)
- `multivalued`: (true or false)
- `pattern`: a regular expression
- `structured_pattern`: a Value syntax-like expression, using a constrained vocabulary of `settings` that can be expanded into `patterns`

Many MIxS slots have also had `string_serialization`s for a few releases now, and this has caused a lot of confusion. I wanted to capture specifications that can't really be expressed with any of the mechanisms listed above, but the real intent of `string_serialization` is to tell a system outside of LinkML: if you have have the values of some variables, you can construct the value of this slot with some expression. Like in  a schema where's there's `first_name`, `last_name` and `full_name` slots, the `string_serialization` for `full_name` might be '{first_name} {last_name}'*

This PR starts to replace some of the `string_serialization`s with more actionable slot definitions 

Here are two examples of how  `string_serialization` has been used in MIxS to store complex constraints

```yaml
  compl_score:
    annotations:
      Expected_value: quality;percent completeness
    description: 'Completeness score is typically based on either the fraction of
      markers found as compared to a database or the percent of a genome found as
      compared to a closely related reference genome. High Quality Draft: >90%, Medium
      Quality Draft: >50%, and Low Quality Draft: < 50% should have the indicated
      completeness scores'
    title: completeness score
    examples:
    - value: med;60%
    in_subset:
    - sequencing
    keywords:
    - score
    string_serialization: '[high|med|low];{percentage}'
    slot_uri: MIXS:0000069
```

In this case, MIxS seems to be saying that the legal value of  `compl_score` if one of the following (high, med or low) followed by a percentage value , including the percent sign. 

```yaml
  cur_land_use:
    annotations:
      Expected_value: enumeration
    description: Present state of sample site
    title: current land use
    examples:
    - value: conifers
    keywords:
    - land
    - use
    string_serialization: '[cities|farmstead|industrial areas|roads/railroads|rock|sand|gravel|mudflats|salt
      flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste areas|small
      grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
      (grass,sedges,rushes)|tundra (mosses,lichens)|rangeland|pastureland (grasslands
      used for livestock grazing)|hayland|meadows (grasses,alfalfa,fescue,bromegrass,timothy)|shrub
      land (e.g. mesquite,sage-brush,creosote bush,shrub oak,eucalyptus)|successional
      shrub land (tree saplings,hazels,sumacs,chokecherry,shrub dogwoods,blackberries)|shrub
      crops (blueberries,nursery ornamentals,filberts)|vine crops (grapes)|conifers
      (e.g. pine,spruce,fir,cypress)|hardwoods (e.g. oak,hickory,elm,aspen)|intermixed
      hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen forest
      receiving >406 cm annual rainfall)|swamp (permanent or semi-permanent water
      body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery
      trees)]'
    slot_uri: MIXS:0001080
```

In that case, it would appear that the the legal values can be enumerated, but an enumeration wasn't built because including punctuation in the permissible values can case crashes in some use cases.

`*` That's a very simple, Western perspective