### PR TITLE
add `---` document separator to beginning of deprecated.yaml file

### DIFF
--- a/src/mixs/schema/deprecated.yaml
+++ b/src/mixs/schema/deprecated.yaml
@@ -1,3 +1,4 @@
+---
 name: GSC-Deprecated-Elements
 title: Genomic Standards Consortium Deprecated Elements
 description: Elements that have been deprecated over time, in the schema for the Genomic Standards Consortium (GSC)


### PR DESCRIPTION
LinkML provides a [linkml-lint](https://linkml.io/linkml/schemas/linter.html) tool to check for **schema content** that isn't illegal but is strongly discouraged. 

But even that doesn't check for **standardized YAML** content. Sticking with a standardized YAML format can help us detect unusual styles before they become LinkML errors.

@sujaypatil96 and I added a GitHub action that runs mixs.yaml though `yamllint` in a previous PR.

This PR is the fruition of `yamllint`: it noticed that we are not starting mixs.yaml with the recommended YAML document separator (`---`) ,  so we are proposing to add it in this PR.

The document separator is not required in a file that only contains a single document (which is the case mixs.yaml), but is an illustration of using a standardized format. Eventually we will be able to detect unusual styles with `yamllint` and fix them with [yamlfmt](https://github.com/google/yamlfmt). 

The MIxS community can collectively decide which `yamllint` and `yamlfmt` suggested styles we want to accept as is, which we wish to fine tune, and which we wish to disregard.

