### PR TITLE
YAML and LinkML auto-formatting and enumeration auto-describing

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,4 +1,4 @@
 formatter:
   type: basic
   include_document_start: true
-  max_line_length: 79
+  max_line_length: 0

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,4 @@
+formatter:
+  type: basic
+  include_document_start: true
+  max_line_length: 79

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,9 @@ examples/output: src/mixs/schema/mixs.yaml
 
 .PHONY: standardize-schema
 
+#  |\
+  #	yamlfmt -in -conf .yamlfmt >
+
 standardize-schema:
 	$(RUN) python src/scripts/describe_enums_by_slots_using.py \
     --schema_file src/mixs/schema/mixs.yaml \
@@ -172,10 +175,13 @@ standardize-schema:
 	yq eval 'del(.slots.[].domain)'  |\
 	yq eval 'del(.slots.[].name)' |\
 	yq eval 'del(.source_file)'  |\
-	yq eval 'del(.subsets.[].name)' |\
-	yamlfmt -in -conf .yamlfmt > src/mixs/schema/mixs_standardized.yaml
+	yq eval 'del(.subsets.[].name)' | cat > src/mixs/schema/mixs_standardized.yaml
 	mv src/mixs/schema/mixs_standardized.yaml src/mixs/schema/mixs.yaml
 	rm -rf src/mixs/schema/mixs_standardized.yaml src/mixs/schema/mixs_with_enum_descriptions.yaml
+
+test1:
+	echo $$PATH
+	yamlfmt  -conf .yamlfmt src/mixs/schema/mixs.yaml >  src/mixs/schema/mixs_standardized.yam
 
 # Test documentation locally
 serve: mkd-serve

--- a/Makefile
+++ b/Makefile
@@ -151,16 +151,6 @@ examples/output: src/mixs/schema/mixs.yaml
 
 .PHONY: standardize-schema
 
-#   IFSAC_category:
-#      name: IFSAC_category
-#      annotations:
-#        Expected_value:
-#          tag: Expected_value
-#          value: IFSAC term
-
-  # 	yq eval '.slots.annotations |= map_values(.value)' |\
-  # 	yq eval '.slots.[].annotations |= map_values(.value))' |\
-
 standardize-schema:
 	$(RUN) python src/scripts/describe_enums_by_slots_using.py \
     --schema_file src/mixs/schema/mixs.yaml \

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,16 @@ examples/output: src/mixs/schema/mixs.yaml
 
 .PHONY: standardize-schema
 
+#   IFSAC_category:
+#      name: IFSAC_category
+#      annotations:
+#        Expected_value:
+#          tag: Expected_value
+#          value: IFSAC term
+
+  # 	yq eval '.slots.annotations |= map_values(.value)' |\
+  # 	yq eval '.slots.[].annotations |= map_values(.value))' |\
+
 standardize-schema:
 	$(RUN) python src/scripts/describe_enums_by_slots_using.py \
     --schema_file src/mixs/schema/mixs.yaml \
@@ -161,8 +171,10 @@ standardize-schema:
 		--no-materialize-attributes \
 		--materialize-patterns src/mixs/schema/mixs_with_enum_descriptions.yaml |\
 	yq eval '(.. | select(has("from_schema")) | .from_schema) style="" | del(.. | select(has("from_schema")).from_schema)' |\
+	yq eval '.classes[] |= select(has("annotations")).annotations |= map_values(.value)' |\
 	yq eval '.prefixes |= map_values(.prefix_reference)' |\
 	yq eval '.settings |= map_values(.setting_value)'  |\
+	yq eval '.slots[] |= select(has("annotations")).annotations |= map_values(.value)' |\
 	yq eval 'del(.classes.[].name)' |\
 	yq eval 'del(.classes.[].slot_usage.[].name)'  |\
 	yq eval 'del(.enums.[].name)'  |\

--- a/Makefile
+++ b/Makefile
@@ -152,11 +152,14 @@ examples/output: src/mixs/schema/mixs.yaml
 .PHONY: standardize-schema
 
 standardize-schema:
+	$(RUN) python src/scripts/describe_enums_by_slots_using.py \
+    --schema_file src/mixs/schema/mixs.yaml \
+    --output_file src/mixs/schema/mixs_with_enum_descriptions.yaml
 	$(RUN) gen-linkml \
 		--format yaml \
 		--no-mergeimports \
 		--no-materialize-attributes \
-		--materialize-patterns src/mixs/schema/mixs.yaml |\
+		--materialize-patterns src/mixs/schema/mixs_with_enum_descriptions.yaml |\
 	yq eval '(.. | select(has("from_schema")) | .from_schema) style="" | del(.. | select(has("from_schema")).from_schema)' |\
 	yq eval '.prefixes |= map_values(.prefix_reference)' |\
 	yq eval '.settings |= map_values(.setting_value)'  |\
@@ -170,7 +173,7 @@ standardize-schema:
 	yq eval 'del(.subsets.[].name)' |\
 	yamlfmt -in -conf .yamlfmt > src/mixs/schema/mixs_standardized.yaml
 	mv src/mixs/schema/mixs_standardized.yaml src/mixs/schema/mixs.yaml
-	rm -rf src/mixs/schema/mixs_standardized.yaml
+	rm -rf src/mixs/schema/mixs_standardized.yaml src/mixs/schema/mixs_with_enum_descriptions.yaml
 
 # Test documentation locally
 serve: mkd-serve

--- a/mixs.yaml
+++ b/mixs.yaml
@@ -1,0 +1,20305 @@
+---
+name: mixs
+description: 'This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative ''source of truth'' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project'
+comments:
+  - 'slot titles that are associated with more than one slot name/SCN: host sex'
+source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
+id: https://w3id.org/mixs
+version: v6.2.0
+imports:
+  - linkml:types
+prefixes:
+  linkml: https://w3id.org/linkml/
+  MIXS: https://w3id.org/mixs/
+  xsd: http://www.w3.org/2001/XMLSchema#
+  shex: http://www.w3.org/ns/shex#
+  schema: http://schema.org/
+default_prefix: MIXS
+default_range: string
+subsets:
+  combination_classes: {}
+  sequencing: {}
+  environment: {}
+  nucleic acid sequence source: {}
+  investigation: {}
+enums:
+  BiolStatEnum:
+    description: Permissible values, used by term biol_stat
+    permissible_values:
+      breeder's line: {}
+      clonal selection: {}
+      hybrid: {}
+      inbred line: {}
+      mutant: {}
+      natural: {}
+      semi-natural: {}
+      wild: {}
+  AssemblyQualEnum:
+    description: Permissible values, used by term assembly_qual
+    permissible_values:
+      Finished genome: {}
+      High-quality draft genome: {}
+      Medium-quality draft genome: {}
+      Low-quality draft genome: {}
+      Genome fragment(s): {}
+  AeroStrucEnum:
+    description: Permissible values, used by term aero_struc
+    permissible_values:
+      glider: {}
+      plane: {}
+  AnimalBodyCondEnum:
+    description: Permissible values, used by term animal_body_cond
+    permissible_values:
+      normal: {}
+      over conditioned: {}
+      under conditioned: {}
+  AnimalSexEnum:
+    description: Permissible values, used by term animal_sex
+    permissible_values:
+      castrated female: {}
+      castrated male: {}
+      intact female: {}
+      intact male: {}
+  ArchStrucEnum:
+    description: Permissible values, used by term arch_struc
+    permissible_values:
+      building: {}
+      home: {}
+      shed: {}
+  BinParamEnum:
+    description: Permissible values, used by term bin_param
+    permissible_values:
+      codon usage: {}
+      combination: {}
+      coverage: {}
+      homology search: {}
+      kmer: {}
+  BioticRelationshipEnum:
+    description: Permissible values, used by term biotic_relationship
+    permissible_values:
+      commensalism: {}
+      free living: {}
+      mutualism: {}
+      parasitism: {}
+      symbiotic: {}
+  BuildingSettingEnum:
+    description: Permissible values, used by term building_setting
+    permissible_values:
+      exurban: {}
+      rural: {}
+      suburban: {}
+      urban: {}
+  BuildDocsEnum:
+    description: Permissible values, used by term build_docs
+    permissible_values:
+      building information model: {}
+      commissioning report: {}
+      complaint logs: {}
+      contract administration: {}
+      cost estimate: {}
+      janitorial schedules or logs: {}
+      maintenance plans: {}
+      schedule: {}
+      sections: {}
+      shop drawings: {}
+      submittals: {}
+      ventilation system: {}
+      windows: {}
+  BuildOccupTypeEnum:
+    description: Permissible values, used by term build_occup_type
+    permissible_values:
+      airport: {}
+      commercial: {}
+      health care: {}
+      high rise: {}
+      low rise: {}
+      market: {}
+      office: {}
+      residence: {}
+      residential: {}
+      restaurant: {}
+      school: {}
+      sports complex: {}
+      wood framed: {}
+  BuiltStrucSetEnum:
+    description: Permissible values, used by term built_struc_set
+    permissible_values:
+      rural: {}
+      urban: {}
+  CeilFinishMatEnum:
+    description: Permissible values, used by term ceil_finish_mat
+    permissible_values:
+      PVC: {}
+      drywall: {}
+      fiberglass: {}
+      metal: {}
+      mineral fibre: {}
+      mineral wool/calcium silicate: {}
+      plasterboard: {}
+      stucco: {}
+      tiles: {}
+      wood: {}
+  CeilStrucEnum:
+    description: Permissible values, used by term ceil_struc
+    permissible_values:
+      concrete: {}
+      wood frame: {}
+  CeilTypeEnum:
+    description: Permissible values, used by term ceil_type
+    permissible_values:
+      barrel-shaped: {}
+      cathedral: {}
+      coffered: {}
+      concave: {}
+      cove: {}
+      dropped: {}
+      stretched: {}
+  ComplApprEnum:
+    description: Permissible values, used by term compl_appr
+    permissible_values:
+      marker gene: {}
+      other: {}
+      reference based: {}
+  ContamScreenInputEnum:
+    description: Permissible values, used by term contam_screen_input
+    permissible_values:
+      contigs: {}
+      reads: {}
+  CultResultEnum:
+    description: Permissible values, used by term cult_result
+    permissible_values:
+      absent: {}
+      active: {}
+      inactive: {}
+      negative: {}
+      'no': {}
+      positive: {}
+      present: {}
+      'yes': {}
+  DeposEnvEnum:
+    description: Permissible values, used by term depos_env
+    permissible_values:
+      Continental - Aeolian: {}
+      Continental - Alluvial: {}
+      Continental - Fluvial: {}
+      Continental - Lacustrine: {}
+      Marine - Deep: {}
+      Marine - Reef: {}
+      Marine - Shallow: {}
+      Other - Evaporite: {}
+      Other - Glacial: {}
+      Other - Volcanic: {}
+      Transitional - Beach: {}
+      Transitional - Deltaic: {}
+      Transitional - Lagoonal: {}
+      Transitional - Lake: {}
+      Transitional - Tidal: {}
+      other: {}
+  DominantHandEnum:
+    description: Permissible values, used by term dominant_hand
+    permissible_values:
+      ambidextrous: {}
+      left: {}
+      right: {}
+  DoorCompTypeEnum:
+    description: Permissible values, used by term door_comp_type
+    permissible_values:
+      metal covered: {}
+      revolving: {}
+      sliding: {}
+      telescopic: {}
+  DoorDirectEnum:
+    description: Permissible values, used by term door_direct
+    permissible_values:
+      inward: {}
+      outward: {}
+      sideways: {}
+  DoorMatEnum:
+    description: Permissible values, used by term door_mat
+    permissible_values:
+      aluminum: {}
+      cellular PVC: {}
+      engineered plastic: {}
+      fiberboard: {}
+      fiberglass: {}
+      metal: {}
+      thermoplastic alloy: {}
+      vinyl: {}
+      wood: {}
+      wood/plastic composite: {}
+  DoorMoveEnum:
+    description: Permissible values, used by term door_move
+    permissible_values:
+      collapsible: {}
+      folding: {}
+      revolving: {}
+      rolling shutter: {}
+      sliding: {}
+      swinging: {}
+  DoorTypeEnum:
+    description: Permissible values, used by term door_type
+    permissible_values:
+      composite: {}
+      metal: {}
+      wooden: {}
+  DoorTypeMetalEnum:
+    description: Permissible values, used by term door_type_metal
+    permissible_values:
+      collapsible: {}
+      corrugated steel: {}
+      hollow: {}
+      rolling shutters: {}
+      steel plate: {}
+  DrainageClassEnum:
+    description: Permissible values, used by term drainage_class
+    permissible_values:
+      excessively drained: {}
+      moderately well: {}
+      poorly: {}
+      somewhat poorly: {}
+      very poorly: {}
+      well: {}
+  DrawingsEnum:
+    description: Permissible values, used by term drawings
+    permissible_values:
+      as built: {}
+      bid: {}
+      building navigation map: {}
+      construction: {}
+      design: {}
+      diagram: {}
+      operation: {}
+      sketch: {}
+  ExtrWeatherEventEnum:
+    description: Permissible values, used by term extr_weather_event
+    permissible_values:
+      drought: {}
+      dust storm: {}
+      extreme cold: {}
+      extreme heat: {}
+      flood: {}
+      frost: {}
+      hail: {}
+      high precipitation: {}
+      high winds: {}
+  FacilityTypeEnum:
+    description: Permissible values, used by term facility_type
+    permissible_values:
+      ambient storage: {}
+      caterer-catering point: {}
+      distribution: {}
+      frozen storage: {}
+      importer-broker: {}
+      interstate conveyance: {}
+      labeler-relabeler: {}
+      manufacturing-processing: {}
+      packaging: {}
+      refrigerated storage: {}
+      storage: {}
+  FaoClassEnum:
+    description: Permissible values, used by term fao_class
+    permissible_values:
+      Acrisols: {}
+      Alisols: {}
+      Andosols: {}
+      Anthrosols: {}
+      Arenosols: {}
+      Calcisols: {}
+      Cambisols: {}
+      Chernozems: {}
+      Cryosols: {}
+      Durisols: {}
+      Ferralsols: {}
+      Fluvisols: {}
+      Gleysols: {}
+      Greyzems:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+      Gypsisols: {}
+      Histosols: {}
+      Kastanozems: {}
+      Lithosols:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+      Leptosols: {}
+      Lixisols: {}
+      Luvisols: {}
+      Nitosols: {}
+      Phaeozems: {}
+      Planosols: {}
+      Plinthosols: {}
+      Podzols: {}
+      Podzoluvisols:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+      Rankers:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+      Regosols:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+      Rendzinas:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+      Solonchaks: {}
+      Solonetz: {}
+      Stagnosols: {}
+      Technosols: {}
+      Umbrisols: {}
+      Vertisols: {}
+      Yermosols:
+        deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
+  FarmWaterSourceEnum:
+    description: Permissible values, used by term farm_water_source
+    permissible_values:
+      brackish: {}
+      canal: {}
+      collected rainwater: {}
+      ditch: {}
+      estuary: {}
+      freshwater: {}
+      lake: {}
+      manmade: {}
+      melt pond: {}
+      municipal: {}
+      natural: {}
+      pond: {}
+      reservior: {}
+      river: {}
+      saline: {}
+      storage tank: {}
+      stream: {}
+      well: {}
+  FilterTypeEnum:
+    description: Permissible values, used by term filter_type
+    permissible_values:
+      HEPA: {}
+      chemical air filter: {}
+      electrostatic: {}
+      gas-phase or ultraviolet air treatments: {}
+      low-MERV pleated media: {}
+      particulate air filter: {}
+  FireplaceTypeEnum:
+    description: Permissible values, used by term fireplace_type
+    permissible_values:
+      gas burning: {}
+      wood burning: {}
+  FloorStrucEnum:
+    description: Permissible values, used by term floor_struc
+    permissible_values:
+      balcony: {}
+      concrete: {}
+      floating floor: {}
+      glass floor: {}
+      raised floor: {}
+      sprung floor: {}
+      wood-framed: {}
+  FloorWaterMoldEnum:
+    description: Permissible values, used by term floor_water_mold
+    permissible_values:
+      bulging walls: {}
+      ceiling discoloration: {}
+      condensation: {}
+      floor discoloration: {}
+      mold odor: {}
+      peeling paint or wallpaper: {}
+      wall discoloration: {}
+      water stains: {}
+      wet floor: {}
+  FoodCleanProcEnum:
+    description: Permissible values, used by term food_clean_proc
+    permissible_values:
+      drum and drain: {}
+      manual spinner: {}
+      rinsed with sanitizer solution: {}
+      rinsed with water: {}
+      scrubbed with brush: {}
+      scrubbed with hand: {}
+      soaking: {}
+  FoodTraceListEnum:
+    description: Permissible values, used by term food_trace_list
+    permissible_values:
+      cheeses-other than hard cheeses: {}
+      crustaceans: {}
+      cucumbers: {}
+      finfish-including smoked finfish: {}
+      fruits and vegetables-fresh cut: {}
+      herbs-fresh: {}
+      leafy greens-including fresh cut leafy greens: {}
+      melons: {}
+      mollusks-bivalves: {}
+      nut butter: {}
+      peppers: {}
+      ready to eat deli salads: {}
+      shell eggs: {}
+      sprouts: {}
+      tomatoes: {}
+      tropical tree fruits: {}
+  FreqCleanEnum:
+    description: Permissible values, used by term freq_clean
+    permissible_values:
+      Annually: {}
+      Daily: {}
+      Monthly: {}
+      Quarterly: {}
+      Weekly: {}
+      other: {}
+  FurnitureEnum:
+    description: Permissible values, used by term furniture
+    permissible_values:
+      cabinet: {}
+      chair: {}
+      desks: {}
+  GenderRestroomEnum:
+    description: Permissible values, used by term gender_restroom
+    permissible_values:
+      all gender: {}
+      female: {}
+      gender neutral: {}
+      male: {}
+      male and female: {}
+      unisex: {}
+  GrowthHabitEnum:
+    description: Permissible values, used by term growth_habit
+    permissible_values:
+      erect: {}
+      prostrate: {}
+      semi-erect: {}
+      spreading: {}
+  HandidnessEnum:
+    description: Permissible values, used by term handidness
+    permissible_values:
+      ambidexterity: {}
+      left handedness: {}
+      mixed-handedness: {}
+      right handedness: {}
+  HcrEnum:
+    description: Permissible values, used by term hcr
+    permissible_values:
+      Coalbed: {}
+      Gas Reservoir: {}
+      Oil Reservoir: {}
+      Oil Sand: {}
+      Shale: {}
+      Tight Gas Reservoir: {}
+      Tight Oil Reservoir: {}
+      other: {}
+  HcProducedEnum:
+    description: Permissible values, used by term hc_produced
+    permissible_values:
+      Bitumen: {}
+      Coalbed Methane: {}
+      Gas: {}
+      Gas-Condensate: {}
+      Oil: {}
+      other: {}
+  HeatCoolTypeEnum:
+    description: Permissible values, used by term heat_cool_type
+    permissible_values:
+      forced air system: {}
+      heat pump: {}
+      radiant system: {}
+      steam forced heat: {}
+      wood stove: {}
+  HeatSysDelivMethEnum:
+    description: Permissible values, used by term heat_sys_deliv_meth
+    permissible_values:
+      conductive: {}
+      radiant: {}
+  HostCellularLocEnum:
+    description: Permissible values, used by term host_cellular_loc
+    permissible_values:
+      extracellular: {}
+      intracellular: {}
+      not determined: {}
+  HostDependenceEnum:
+    description: Permissible values, used by term host_dependence
+    permissible_values:
+      facultative: {}
+      obligate: {}
+  HostPredApprEnum:
+    description: Permissible values, used by term host_pred_appr
+    permissible_values:
+      CRISPR spacer match: {}
+      co-occurrence: {}
+      combination: {}
+      host sequence similarity: {}
+      kmer similarity: {}
+      other: {}
+      provirus: {}
+  HostSpecificityEnum:
+    description: Permissible values, used by term host_specificity
+    permissible_values:
+      family-specific: {}
+      generalist: {}
+      genus-specific: {}
+      species-specific: {}
+  IndoorSpaceEnum:
+    description: Permissible values, used by term indoor_space
+    permissible_values:
+      bathroom: {}
+      bedroom: {}
+      elevator: {}
+      foyer: {}
+      hallway: {}
+      kitchen: {}
+      locker room: {}
+      office: {}
+  IndoorSurfEnum:
+    description: Permissible values, used by term indoor_surf
+    permissible_values:
+      cabinet: {}
+      ceiling: {}
+      counter top: {}
+      door: {}
+      shelving: {}
+      vent cover: {}
+      wall: {}
+      window: {}
+  LibLayoutEnum:
+    description: Permissible values, used by term lib_layout
+    permissible_values:
+      other: {}
+      paired: {}
+      single: {}
+      vector: {}
+  LightTypeEnum:
+    description: Permissible values, used by term light_type
+    permissible_values:
+      desk lamp: {}
+      electric light: {}
+      fluorescent lights: {}
+      natural light: {}
+      none: {}
+  LithologyEnum:
+    description: Permissible values, used by term lithology
+    permissible_values:
+      Basement: {}
+      Chalk: {}
+      Chert: {}
+      Coal: {}
+      Conglomerate: {}
+      Diatomite: {}
+      Dolomite: {}
+      Limestone: {}
+      Sandstone: {}
+      Shale: {}
+      Siltstone: {}
+      Volcanic: {}
+      other: {}
+  MagCovSoftwareEnum:
+    description: Permissible values, used by term mag_cov_software
+    permissible_values:
+      bbmap: {}
+      bowtie: {}
+      bwa: {}
+      other: {}
+  MechStrucEnum:
+    description: Permissible values, used by term mech_struc
+    permissible_values:
+      boat: {}
+      bus: {}
+      car: {}
+      carriage: {}
+      coach: {}
+      elevator: {}
+      escalator: {}
+      subway: {}
+      train: {}
+  ModeTransmissionEnum:
+    description: Permissible values, used by term mode_transmission
+    permissible_values:
+      horizontal:castrator: {}
+      horizontal:directly transmitted: {}
+      horizontal:micropredator: {}
+      horizontal:parasitoid: {}
+      horizontal:trophically transmitted: {}
+      horizontal:vector transmitted: {}
+      vertical: {}
+  NegContTypeEnum:
+    description: Permissible values, used by term neg_cont_type
+    permissible_values:
+      DNA-free PCR mix: {}
+      distilled water: {}
+      empty collection device: {}
+      empty collection tube: {}
+      phosphate buffer: {}
+      sterile swab: {}
+      sterile syringe: {}
+  OccupDocumentEnum:
+    description: Permissible values, used by term occup_document
+    permissible_values:
+      automated count: {}
+      estimate: {}
+      manual count: {}
+      videos: {}
+  OxyStatSampEnum:
+    description: Permissible values, used by term oxy_stat_samp
+    permissible_values:
+      aerobic: {}
+      anaerobic: {}
+      other: {}
+  PlantReprodCropEnum:
+    description: Permissible values, used by term plant_reprod_crop
+    permissible_values:
+      plant cutting: {}
+      pregerminated seed: {}
+      ratoon: {}
+      seed: {}
+      seedling: {}
+      whole mature plant: {}
+  PlantSexEnum:
+    description: Permissible values, used by term plant_sex
+    permissible_values:
+      Androdioecious: {}
+      Androecious: {}
+      Androgynomonoecious: {}
+      Androgynous: {}
+      Andromonoecious: {}
+      Bisexual: {}
+      Dichogamous: {}
+      Diclinous: {}
+      Dioecious: {}
+      Gynodioecious: {}
+      Gynoecious: {}
+      Gynomonoecious: {}
+      Hermaphroditic: {}
+      Imperfect: {}
+      Monoclinous: {}
+      Monoecious: {}
+      Perfect: {}
+      Polygamodioecious: {}
+      Polygamomonoecious: {}
+      Polygamous: {}
+      Protandrous: {}
+      Protogynous: {}
+      Subandroecious: {}
+      Subdioecious: {}
+      Subgynoecious: {}
+      Synoecious: {}
+      Trimonoecious: {}
+      Trioecious: {}
+      Unisexual: {}
+  PredGenomeStrucEnum:
+    description: Permissible values, used by term pred_genome_struc
+    permissible_values:
+      non-segmented: {}
+      segmented: {}
+      undetermined: {}
+  ProfilePositionEnum:
+    description: Permissible values, used by term profile_position
+    permissible_values:
+      backslope: {}
+      footslope: {}
+      shoulder: {}
+      summit: {}
+      toeslope: {}
+  QuadPosEnum:
+    description: Permissible values, used by term quad_pos
+    permissible_values:
+      East side: {}
+      North side: {}
+      South side: {}
+      West side: {}
+  RelSampLocEnum:
+    description: Permissible values, used by term rel_samp_loc
+    permissible_values:
+      center of car: {}
+      edge of car: {}
+      under a seat: {}
+  RelToOxygenEnum:
+    description: Permissible values, used by term rel_to_oxygen
+    permissible_values:
+      aerobe: {}
+      anaerobe: {}
+      facultative: {}
+      microaerophilic: {}
+      microanaerobe: {}
+      obligate aerobe: {}
+      obligate anaerobe: {}
+  RoomCondtEnum:
+    description: Permissible values, used by term room_condt
+    permissible_values:
+      damaged: {}
+      needs repair: {}
+      new: {}
+      rupture: {}
+      visible signs of mold/mildew: {}
+      visible wear: {}
+  RoomConnectedEnum:
+    description: Permissible values, used by term room_connected
+    permissible_values:
+      attic: {}
+      bathroom: {}
+      closet: {}
+      conference room: {}
+      elevator: {}
+      examining room: {}
+      hallway: {}
+      kitchen: {}
+      mail room: {}
+      office: {}
+      stairwell: {}
+  RoomLocEnum:
+    description: Permissible values, used by term room_loc
+    permissible_values:
+      corner room: {}
+      exterior wall: {}
+      interior room: {}
+  RoomSampPosEnum:
+    description: Permissible values, used by term room_samp_pos
+    permissible_values:
+      center: {}
+      east corner: {}
+      north corner: {}
+      northeast corner: {}
+      northwest corner: {}
+      south corner: {}
+      southeast corner: {}
+      southwest corner: {}
+      west corner: {}
+  RouteTransmissionEnum:
+    description: Permissible values, used by term route_transmission
+    permissible_values:
+      environmental:faecal-oral: {}
+      transplacental: {}
+      vector-borne:vector penetration: {}
+  SampCaptStatusEnum:
+    description: Permissible values, used by term samp_capt_status
+    permissible_values:
+      active surveillance in response to an outbreak: {}
+      active surveillance not initiated by an outbreak: {}
+      farm sample: {}
+      market sample: {}
+      other: {}
+  SampCollectPointEnum:
+    description: Permissible values, used by term samp_collect_point
+    permissible_values:
+      drilling rig: {}
+      other: {}
+      separator: {}
+      storage tank: {}
+      test well: {}
+      well: {}
+      wellhead: {}
+  SampDisStageEnum:
+    description: Permissible values, used by term samp_dis_stage
+    permissible_values:
+      dissemination: {}
+      growth and reproduction: {}
+      infection: {}
+      inoculation: {}
+      other: {}
+      penetration: {}
+  SampLocConditionEnum:
+    description: Permissible values, used by term samp_loc_condition
+    permissible_values:
+      damaged: {}
+      new: {}
+      rupture: {}
+      visible signs of mold-mildew: {}
+      visible weariness repair: {}
+  SampSubtypeEnum:
+    description: Permissible values, used by term samp_subtype
+    permissible_values:
+      biofilm: {}
+      not applicable: {}
+      oil phase: {}
+      other: {}
+      water phase: {}
+  SampSurfMoistureEnum:
+    description: Permissible values, used by term samp_surf_moisture
+    permissible_values:
+      intermittent moisture: {}
+      not present: {}
+      submerged: {}
+  SampTransportContEnum:
+    description: Permissible values, used by term samp_transport_cont
+    permissible_values:
+      bottle: {}
+      cooler: {}
+      glass vial: {}
+      plastic vial: {}
+      vendor supplied container: {}
+  SampWeatherEnum:
+    description: Permissible values, used by term samp_weather
+    permissible_values:
+      clear sky: {}
+      cloudy: {}
+      foggy: {}
+      hail: {}
+      rain: {}
+      sleet: {}
+      snow: {}
+      sunny: {}
+      windy: {}
+  ScLysisApproachEnum:
+    description: Permissible values, used by term sc_lysis_approach
+    permissible_values:
+      chemical: {}
+      combination: {}
+      enzymatic: {}
+      physical: {}
+  SeasonUseEnum:
+    description: Permissible values, used by term season_use
+    permissible_values:
+      Fall: {}
+      Spring: {}
+      Summer: {}
+      Winter: {}
+  SedimentTypeEnum:
+    description: Permissible values, used by term sediment_type
+    permissible_values:
+      biogenous: {}
+      cosmogenous: {}
+      hydrogenous: {}
+      lithogenous: {}
+  SeqQualityCheckEnum:
+    description: Permissible values, used by term seq_quality_check
+    permissible_values:
+      manually edited: {}
+      none: {}
+  ShadingDeviceLocEnum:
+    description: Permissible values, used by term shading_device_loc
+    permissible_values:
+      exterior: {}
+      interior: {}
+  ShadingDeviceTypeEnum:
+    description: Permissible values, used by term shading_device_type
+    permissible_values:
+      bahama shutters: {}
+      exterior roll blind: {}
+      gambrel awning: {}
+      hood awning: {}
+      porchroller awning: {}
+      sarasota shutters: {}
+      slatted aluminum: {}
+      solid aluminum awning: {}
+      sun screen: {}
+      tree: {}
+      trellis: {}
+      venetian awning: {}
+  CompassDirections8Enum:
+    description: 'Permissible values, used by 6 terms: door_loc, ext_wall_orient, ext_window_orient, heat_deliv_loc, wall_loc, window_loc'
+    permissible_values:
+      east: {}
+      north: {}
+      northeast: {}
+      northwest: {}
+      south: {}
+      southeast: {}
+      southwest: {}
+      west: {}
+  MoldVisibilityEnum:
+    description: 'Permissible values, used by 5 terms: ceil_water_mold, door_water_mold, shad_dev_water_mold, wall_water_mold, window_water_mold'
+    permissible_values:
+      no presence of mold visible: {}
+      presence of mold visible: {}
+  DamagedRupturedEnum:
+    description: 'Permissible values, used by 3 terms: door_cond, shading_device_cond, window_cond'
+    permissible_values:
+      damaged: {}
+      needs repair: {}
+      new: {}
+      rupture: {}
+      visible wear: {}
+  DamagedEnum:
+    description: 'Permissible values, used by 3 terms: ceil_cond, floor_cond, int_wall_cond'
+    permissible_values:
+      damaged: {}
+      needs repair: {}
+      new: {}
+      rupture: {}
+      visible wear: {}
+  CeilingWallTextureEnum:
+    description: 'Permissible values, used by 2 terms: ceil_texture, wall_texture'
+    permissible_values:
+      Santa-Fe texture: {}
+      crows feet: {}
+      crows-foot stomp: {}
+      double skip: {}
+      hawk and trowel: {}
+      knockdown: {}
+      orange peel: {}
+      popcorn: {}
+      rosebud stomp: {}
+      skip trowel: {}
+      smooth: {}
+      stomp knockdown: {}
+      swirl: {}
+  GeolAgeEnum:
+    description: 'Permissible values, used by 2 terms: hcr_geol_age, sr_geol_age'
+    permissible_values:
+      Archean: {}
+      Cambrian: {}
+      Carboniferous: {}
+      Cenozoic: {}
+      Cretaceous: {}
+      Devonian: {}
+      Jurassic: {}
+      Mesozoic: {}
+      Neogene: {}
+      Ordovician: {}
+      Paleogene: {}
+      Paleozoic: {}
+      Permian: {}
+      Precambrian: {}
+      Proterozoic: {}
+      Silurian: {}
+      Triassic: {}
+      other: {}
+  SoilHorizonEnum:
+    description: Permissible values, used by term soil_horizon
+    permissible_values:
+      A horizon: {}
+      B horizon: {}
+      C horizon: {}
+      E horizon: {}
+      O horizon: {}
+      Permafrost: {}
+      R layer: {}
+  SoilTextureClassEnum:
+    description: Permissible values, used by term soil_texture_class
+    permissible_values:
+      clay: {}
+      clay loam: {}
+      loam: {}
+      loamy sand: {}
+      sand: {}
+      sandy clay: {}
+      sandy clay loam: {}
+      sandy loam: {}
+      silt: {}
+      silt loam: {}
+      silty clay: {}
+      silty clay loam: {}
+  SortTechEnum:
+    description: Permissible values, used by term sort_tech
+    permissible_values:
+      flow cytometric cell sorting: {}
+      lazer-tweezing: {}
+      microfluidics: {}
+      micromanipulation: {}
+      optical manipulation: {}
+      other: {}
+  SpaceTypStateEnum:
+    description: Permissible values, used by term space_typ_state
+    permissible_values:
+      typically occupied: {}
+      typically unoccupied: {}
+  SpecificEnum:
+    description: Permissible values, used by term specific
+    permissible_values:
+      as built: {}
+      bid: {}
+      construction: {}
+      design: {}
+      operation: {}
+      photos: {}
+  SrDepEnvEnum:
+    description: Permissible values, used by term sr_dep_env
+    permissible_values:
+      Fluvioldeltaic: {}
+      Fluviomarine: {}
+      Lacustine: {}
+      Marine: {}
+      other: {}
+  SrKerogTypeEnum:
+    description: Permissible values, used by term sr_kerog_type
+    permissible_values:
+      Type I: {}
+      Type II: {}
+      Type III: {}
+      Type IV: {}
+      other: {}
+  SrLithologyEnum:
+    description: Permissible values, used by term sr_lithology
+    permissible_values:
+      Biosilicieous: {}
+      Carbonate: {}
+      Clastic: {}
+      Coal: {}
+      other: {}
+  SubstructureTypeEnum:
+    description: Permissible values, used by term substructure_type
+    permissible_values:
+      basement: {}
+      crawlspace: {}
+      slab on grade: {}
+  SurfAirContEnum:
+    description: Permissible values, used by term surf_air_cont
+    permissible_values:
+      biocides: {}
+      biological contaminants: {}
+      dust: {}
+      nutrients: {}
+      organic matter: {}
+      particulate matter: {}
+      radon: {}
+      volatile organic compounds: {}
+  SurfMaterialEnum:
+    description: Permissible values, used by term surf_material
+    permissible_values:
+      adobe: {}
+      carpet: {}
+      cinder blocks: {}
+      concrete: {}
+      glass: {}
+      hay bales: {}
+      metal: {}
+      paint: {}
+      plastic: {}
+      stainless steel: {}
+      stone: {}
+      stucco: {}
+      tile: {}
+      vinyl: {}
+      wood: {}
+  SymbiontHostRoleEnum:
+    description: Permissible values, used by term symbiont_host_role
+    permissible_values:
+      accidental: {}
+      dead-end: {}
+      definitive: {}
+      intermediate: {}
+      paratenic: {}
+      reservoir: {}
+      single host: {}
+  SymLifeCycleTypeEnum:
+    description: Permissible values, used by term sym_life_cycle_type
+    permissible_values:
+      complex life cycle: {}
+      simple life cycle: {}
+  TaxIdentEnum:
+    description: Permissible values, used by term tax_ident
+    permissible_values:
+      16S rRNA gene: {}
+      multi-marker approach: {}
+      other: {}
+  TidalStageEnum:
+    description: Permissible values, used by term tidal_stage
+    permissible_values:
+      ebb tide: {}
+      flood tide: {}
+      high tide: {}
+      low tide: {}
+  TillageEnum:
+    description: Permissible values, used by term tillage
+    permissible_values:
+      chisel: {}
+      cutting disc: {}
+      disc plough: {}
+      drill: {}
+      mouldboard: {}
+      ridge till: {}
+      strip tillage: {}
+      tined: {}
+      zonal tillage: {}
+  TrainLineEnum:
+    description: Permissible values, used by term train_line
+    permissible_values:
+      green: {}
+      orange: {}
+      red: {}
+  TrainStatLocEnum:
+    description: Permissible values, used by term train_stat_loc
+    permissible_values:
+      forest hills: {}
+      riverside: {}
+      south station above ground: {}
+      south station amtrak: {}
+      south station underground: {}
+  TrainStopLocEnum:
+    description: Permissible values, used by term train_stop_loc
+    permissible_values:
+      downtown: {}
+      end: {}
+      mid: {}
+  TrophicLevelEnum:
+    description: Permissible values, used by term trophic_level
+    permissible_values:
+      autotroph: {}
+      carboxydotroph: {}
+      chemoautolithotroph: {}
+      chemoautotroph: {}
+      chemoheterotroph: {}
+      chemolithoautotroph: {}
+      chemolithotroph: {}
+      chemoorganoheterotroph: {}
+      chemoorganotroph: {}
+      chemosynthetic: {}
+      chemotroph: {}
+      copiotroph: {}
+      diazotroph: {}
+      facultative: {}
+      heterotroph: {}
+      lithoautotroph: {}
+      lithoheterotroph: {}
+      lithotroph: {}
+      methanotroph: {}
+      methylotroph: {}
+      mixotroph: {}
+      obligate: {}
+      oligotroph: {}
+      organoheterotroph: {}
+      organotroph: {}
+      photoautotroph: {}
+      photoheterotroph: {}
+      photolithoautotroph: {}
+      photolithotroph: {}
+      photosynthetic: {}
+      phototroph: {}
+  TypeOfSymbiosisEnum:
+    description: Permissible values, used by term type_of_symbiosis
+    permissible_values:
+      commensalistic: {}
+      mutualistic: {}
+      parasitic: {}
+  UrineCollectMethEnum:
+    description: Permissible values, used by term urine_collect_meth
+    permissible_values:
+      catheter: {}
+      clean catch: {}
+  UrobiomSexEnum:
+    description: Permissible values, used by term urobiom_sex
+    permissible_values:
+      female: {}
+      hermaphrodite: {}
+      male: {}
+      neuter: {}
+  VirusEnrichApprEnum:
+    description: Permissible values, used by term virus_enrich_appr
+    permissible_values:
+      CsCl density gradient: {}
+      DNAse: {}
+      FeCl Precipitation: {}
+      PEG Precipitation: {}
+      RNAse: {}
+      centrifugation: {}
+      filtration: {}
+      none: {}
+      other: {}
+      targeted sequence capture: {}
+      ultracentrifugation: {}
+      ultrafiltration: {}
+  WallConstTypeEnum:
+    description: Permissible values, used by term wall_const_type
+    permissible_values:
+      fire resistive: {}
+      frame construction: {}
+      joisted masonry: {}
+      light noncombustible: {}
+      masonry noncombustible: {}
+      modified fire resistive: {}
+  WallFinishMatEnum:
+    description: Permissible values, used by term wall_finish_mat
+    permissible_values:
+      acoustical treatment: {}
+      gypsum board: {}
+      gypsum plaster: {}
+      masonry: {}
+      metal: {}
+      plaster: {}
+      stone facing: {}
+      terrazzo: {}
+      tile: {}
+      veneer plaster: {}
+      wood: {}
+  WallSurfTreatmentEnum:
+    description: Permissible values, used by term wall_surf_treatment
+    permissible_values:
+      fabric: {}
+      no treatment: {}
+      painted: {}
+      paneling: {}
+      stucco: {}
+      wall paper: {}
+  WaterFeatTypeEnum:
+    description: Permissible values, used by term water_feat_type
+    permissible_values:
+      fountain: {}
+      pool: {}
+      standing feature: {}
+      stream: {}
+      waterfall: {}
+  WeekdayEnum:
+    description: Permissible values, used by term weekday
+    permissible_values:
+      Friday: {}
+      Monday: {}
+      Saturday: {}
+      Sunday: {}
+      Thursday: {}
+      Tuesday: {}
+      Wednesday: {}
+  WgaAmpApprEnum:
+    description: Permissible values, used by term wga_amp_appr
+    permissible_values:
+      mda based: {}
+      pcr based: {}
+  WindowCoverEnum:
+    description: Permissible values, used by term window_cover
+    permissible_values:
+      blinds: {}
+      curtains: {}
+      none: {}
+  WindowHorizPosEnum:
+    description: Permissible values, used by term window_horiz_pos
+    permissible_values:
+      left: {}
+      middle: {}
+      right: {}
+  WindowMatEnum:
+    description: Permissible values, used by term window_mat
+    permissible_values:
+      clad: {}
+      fiberglass: {}
+      metal: {}
+      vinyl: {}
+      wood: {}
+  WindowStatusEnum:
+    description: Permissible values, used by term window_status
+    permissible_values:
+      closed: {}
+      open: {}
+  WindowTypeEnum:
+    description: Permissible values, used by term window_type
+    permissible_values:
+      fixed window: {}
+      horizontal sash window: {}
+      single-hung sash window: {}
+  WindowVertPosEnum:
+    description: Permissible values, used by term window_vert_pos
+    permissible_values:
+      bottom: {}
+      high: {}
+      low: {}
+      middle: {}
+      top: {}
+slots:
+  migs_ba_data:
+    description: Data that comply with checklist MigsBa
+    title: MigsBa data
+    slot_uri: MIXS:migs_ba_data
+    range: MigsBa
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  agriculture_data:
+    description: Data that comply with Extension Agriculture
+    title: Agriculture data
+    slot_uri: MIXS:agriculture_data
+    range: Agriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_agriculture_data:
+    description: Data that comply with MigsBa combined with Agriculture
+    title: MigsBaAgriculture data
+    slot_uri: MIXS:migs_ba_agriculture_data
+    range: MigsBaAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  air_data:
+    description: Data that comply with Extension Air
+    title: Air data
+    keywords:
+      - air
+    slot_uri: MIXS:air_data
+    range: Air
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_air_data:
+    description: Data that comply with MigsBa combined with Air
+    title: MigsBaAir data
+    slot_uri: MIXS:migs_ba_air_data
+    range: MigsBaAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  built_environment_data:
+    description: Data that comply with Extension BuiltEnvironment
+    title: BuiltEnvironment data
+    slot_uri: MIXS:built_environment_data
+    range: BuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_built_environment_data:
+    description: Data that comply with MigsBa combined with BuiltEnvironment
+    title: MigsBaBuiltEnvironment data
+    slot_uri: MIXS:migs_ba_built_environment_data
+    range: MigsBaBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  food_animal_and_animal_feed_data:
+    description: Data that comply with Extension FoodAnimalAndAnimalFeed
+    title: FoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:food_animal_and_animal_feed_data
+    range: FoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_food_animal_and_animal_feed_data:
+    description: Data that comply with MigsBa combined with FoodAnimalAndAnimalFeed
+    title: MigsBaFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:migs_ba_food_animal_and_animal_feed_data
+    range: MigsBaFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  food_farm_environment_data:
+    description: Data that comply with Extension FoodFarmEnvironment
+    title: FoodFarmEnvironment data
+    slot_uri: MIXS:food_farm_environment_data
+    range: FoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_food_farm_environment_data:
+    description: Data that comply with MigsBa combined with FoodFarmEnvironment
+    title: MigsBaFoodFarmEnvironment data
+    slot_uri: MIXS:migs_ba_food_farm_environment_data
+    range: MigsBaFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  food_food_production_facility_data:
+    description: Data that comply with Extension FoodFoodProductionFacility
+    title: FoodFoodProductionFacility data
+    slot_uri: MIXS:food_food_production_facility_data
+    range: FoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_food_food_production_facility_data:
+    description: Data that comply with MigsBa combined with FoodFoodProductionFacility
+    title: MigsBaFoodFoodProductionFacility data
+    slot_uri: MIXS:migs_ba_food_food_production_facility_data
+    range: MigsBaFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  food_human_foods_data:
+    description: Data that comply with Extension FoodHumanFoods
+    title: FoodHumanFoods data
+    slot_uri: MIXS:food_human_foods_data
+    range: FoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_food_human_foods_data:
+    description: Data that comply with MigsBa combined with FoodHumanFoods
+    title: MigsBaFoodHumanFoods data
+    slot_uri: MIXS:migs_ba_food_human_foods_data
+    range: MigsBaFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  host_associated_data:
+    description: Data that comply with Extension HostAssociated
+    title: HostAssociated data
+    slot_uri: MIXS:host_associated_data
+    range: HostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_host_associated_data:
+    description: Data that comply with MigsBa combined with HostAssociated
+    title: MigsBaHostAssociated data
+    slot_uri: MIXS:migs_ba_host_associated_data
+    range: MigsBaHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  human_associated_data:
+    description: Data that comply with Extension HumanAssociated
+    title: HumanAssociated data
+    slot_uri: MIXS:human_associated_data
+    range: HumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_human_associated_data:
+    description: Data that comply with MigsBa combined with HumanAssociated
+    title: MigsBaHumanAssociated data
+    slot_uri: MIXS:migs_ba_human_associated_data
+    range: MigsBaHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  human_gut_data:
+    description: Data that comply with Extension HumanGut
+    title: HumanGut data
+    slot_uri: MIXS:human_gut_data
+    range: HumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_human_gut_data:
+    description: Data that comply with MigsBa combined with HumanGut
+    title: MigsBaHumanGut data
+    slot_uri: MIXS:migs_ba_human_gut_data
+    range: MigsBaHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  human_oral_data:
+    description: Data that comply with Extension HumanOral
+    title: HumanOral data
+    slot_uri: MIXS:human_oral_data
+    range: HumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_human_oral_data:
+    description: Data that comply with MigsBa combined with HumanOral
+    title: MigsBaHumanOral data
+    slot_uri: MIXS:migs_ba_human_oral_data
+    range: MigsBaHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  human_skin_data:
+    description: Data that comply with Extension HumanSkin
+    title: HumanSkin data
+    slot_uri: MIXS:human_skin_data
+    range: HumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_human_skin_data:
+    description: Data that comply with MigsBa combined with HumanSkin
+    title: MigsBaHumanSkin data
+    slot_uri: MIXS:migs_ba_human_skin_data
+    range: MigsBaHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  human_vaginal_data:
+    description: Data that comply with Extension HumanVaginal
+    title: HumanVaginal data
+    slot_uri: MIXS:human_vaginal_data
+    range: HumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_human_vaginal_data:
+    description: Data that comply with MigsBa combined with HumanVaginal
+    title: MigsBaHumanVaginal data
+    slot_uri: MIXS:migs_ba_human_vaginal_data
+    range: MigsBaHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  hydrocarbon_resources_cores_data:
+    description: Data that comply with Extension HydrocarbonResourcesCores
+    title: HydrocarbonResourcesCores data
+    slot_uri: MIXS:hydrocarbon_resources_cores_data
+    range: HydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_hydrocarbon_resources_cores_data:
+    description: Data that comply with MigsBa combined with HydrocarbonResourcesCores
+    title: MigsBaHydrocarbonResourcesCores data
+    slot_uri: MIXS:migs_ba_hydrocarbon_resources_cores_data
+    range: MigsBaHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with Extension HydrocarbonResourcesFluidsSwabs
+    title: HydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:hydrocarbon_resources_fluids_swabs_data
+    range: HydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MigsBa combined with HydrocarbonResourcesFluidsSwabs
+    title: MigsBaHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:migs_ba_hydrocarbon_resources_fluids_swabs_data
+    range: MigsBaHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  microbial_mat_biofilm_data:
+    description: Data that comply with Extension MicrobialMatBiofilm
+    title: MicrobialMatBiofilm data
+    slot_uri: MIXS:microbial_mat_biofilm_data
+    range: MicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_microbial_mat_biofilm_data:
+    description: Data that comply with MigsBa combined with MicrobialMatBiofilm
+    title: MigsBaMicrobialMatBiofilm data
+    slot_uri: MIXS:migs_ba_microbial_mat_biofilm_data
+    range: MigsBaMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with Extension MiscellaneousNaturalOrArtificialEnvironment
+    title: MiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:miscellaneous_natural_or_artificial_environment_data
+    range: MiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MigsBa combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MigsBaMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:migs_ba_miscellaneous_natural_or_artificial_environment_data
+    range: MigsBaMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  plant_associated_data:
+    description: Data that comply with Extension PlantAssociated
+    title: PlantAssociated data
+    slot_uri: MIXS:plant_associated_data
+    range: PlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_plant_associated_data:
+    description: Data that comply with MigsBa combined with PlantAssociated
+    title: MigsBaPlantAssociated data
+    slot_uri: MIXS:migs_ba_plant_associated_data
+    range: MigsBaPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  sediment_data:
+    description: Data that comply with Extension Sediment
+    title: Sediment data
+    keywords:
+      - sediment
+    slot_uri: MIXS:sediment_data
+    range: Sediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_sediment_data:
+    description: Data that comply with MigsBa combined with Sediment
+    title: MigsBaSediment data
+    slot_uri: MIXS:migs_ba_sediment_data
+    range: MigsBaSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  soil_data:
+    description: Data that comply with Extension Soil
+    title: Soil data
+    keywords:
+      - soil
+    slot_uri: MIXS:soil_data
+    range: Soil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_soil_data:
+    description: Data that comply with MigsBa combined with Soil
+    title: MigsBaSoil data
+    slot_uri: MIXS:migs_ba_soil_data
+    range: MigsBaSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  symbiont_associated_data:
+    description: Data that comply with Extension SymbiontAssociated
+    title: SymbiontAssociated data
+    slot_uri: MIXS:symbiont_associated_data
+    range: SymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_symbiont_associated_data:
+    description: Data that comply with MigsBa combined with SymbiontAssociated
+    title: MigsBaSymbiontAssociated data
+    slot_uri: MIXS:migs_ba_symbiont_associated_data
+    range: MigsBaSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  wastewater_sludge_data:
+    description: Data that comply with Extension WastewaterSludge
+    title: WastewaterSludge data
+    slot_uri: MIXS:wastewater_sludge_data
+    range: WastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_wastewater_sludge_data:
+    description: Data that comply with MigsBa combined with WastewaterSludge
+    title: MigsBaWastewaterSludge data
+    slot_uri: MIXS:migs_ba_wastewater_sludge_data
+    range: MigsBaWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  water_data:
+    description: Data that comply with Extension Water
+    title: Water data
+    keywords:
+      - water
+    slot_uri: MIXS:water_data
+    range: Water
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_ba_water_data:
+    description: Data that comply with MigsBa combined with Water
+    title: MigsBaWater data
+    slot_uri: MIXS:migs_ba_water_data
+    range: MigsBaWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_data:
+    description: Data that comply with checklist MigsEu
+    title: MigsEu data
+    slot_uri: MIXS:migs_eu_data
+    range: MigsEu
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_agriculture_data:
+    description: Data that comply with MigsEu combined with Agriculture
+    title: MigsEuAgriculture data
+    slot_uri: MIXS:migs_eu_agriculture_data
+    range: MigsEuAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_air_data:
+    description: Data that comply with MigsEu combined with Air
+    title: MigsEuAir data
+    slot_uri: MIXS:migs_eu_air_data
+    range: MigsEuAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_built_environment_data:
+    description: Data that comply with MigsEu combined with BuiltEnvironment
+    title: MigsEuBuiltEnvironment data
+    slot_uri: MIXS:migs_eu_built_environment_data
+    range: MigsEuBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_food_animal_and_animal_feed_data:
+    description: Data that comply with MigsEu combined with FoodAnimalAndAnimalFeed
+    title: MigsEuFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:migs_eu_food_animal_and_animal_feed_data
+    range: MigsEuFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_food_farm_environment_data:
+    description: Data that comply with MigsEu combined with FoodFarmEnvironment
+    title: MigsEuFoodFarmEnvironment data
+    slot_uri: MIXS:migs_eu_food_farm_environment_data
+    range: MigsEuFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_food_food_production_facility_data:
+    description: Data that comply with MigsEu combined with FoodFoodProductionFacility
+    title: MigsEuFoodFoodProductionFacility data
+    slot_uri: MIXS:migs_eu_food_food_production_facility_data
+    range: MigsEuFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_food_human_foods_data:
+    description: Data that comply with MigsEu combined with FoodHumanFoods
+    title: MigsEuFoodHumanFoods data
+    slot_uri: MIXS:migs_eu_food_human_foods_data
+    range: MigsEuFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_host_associated_data:
+    description: Data that comply with MigsEu combined with HostAssociated
+    title: MigsEuHostAssociated data
+    slot_uri: MIXS:migs_eu_host_associated_data
+    range: MigsEuHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_human_associated_data:
+    description: Data that comply with MigsEu combined with HumanAssociated
+    title: MigsEuHumanAssociated data
+    slot_uri: MIXS:migs_eu_human_associated_data
+    range: MigsEuHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_human_gut_data:
+    description: Data that comply with MigsEu combined with HumanGut
+    title: MigsEuHumanGut data
+    slot_uri: MIXS:migs_eu_human_gut_data
+    range: MigsEuHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_human_oral_data:
+    description: Data that comply with MigsEu combined with HumanOral
+    title: MigsEuHumanOral data
+    slot_uri: MIXS:migs_eu_human_oral_data
+    range: MigsEuHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_human_skin_data:
+    description: Data that comply with MigsEu combined with HumanSkin
+    title: MigsEuHumanSkin data
+    slot_uri: MIXS:migs_eu_human_skin_data
+    range: MigsEuHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_human_vaginal_data:
+    description: Data that comply with MigsEu combined with HumanVaginal
+    title: MigsEuHumanVaginal data
+    slot_uri: MIXS:migs_eu_human_vaginal_data
+    range: MigsEuHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_hydrocarbon_resources_cores_data:
+    description: Data that comply with MigsEu combined with HydrocarbonResourcesCores
+    title: MigsEuHydrocarbonResourcesCores data
+    slot_uri: MIXS:migs_eu_hydrocarbon_resources_cores_data
+    range: MigsEuHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MigsEu combined with HydrocarbonResourcesFluidsSwabs
+    title: MigsEuHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:migs_eu_hydrocarbon_resources_fluids_swabs_data
+    range: MigsEuHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_microbial_mat_biofilm_data:
+    description: Data that comply with MigsEu combined with MicrobialMatBiofilm
+    title: MigsEuMicrobialMatBiofilm data
+    slot_uri: MIXS:migs_eu_microbial_mat_biofilm_data
+    range: MigsEuMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MigsEu combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MigsEuMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:migs_eu_miscellaneous_natural_or_artificial_environment_data
+    range: MigsEuMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_plant_associated_data:
+    description: Data that comply with MigsEu combined with PlantAssociated
+    title: MigsEuPlantAssociated data
+    slot_uri: MIXS:migs_eu_plant_associated_data
+    range: MigsEuPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_sediment_data:
+    description: Data that comply with MigsEu combined with Sediment
+    title: MigsEuSediment data
+    slot_uri: MIXS:migs_eu_sediment_data
+    range: MigsEuSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_soil_data:
+    description: Data that comply with MigsEu combined with Soil
+    title: MigsEuSoil data
+    slot_uri: MIXS:migs_eu_soil_data
+    range: MigsEuSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_symbiont_associated_data:
+    description: Data that comply with MigsEu combined with SymbiontAssociated
+    title: MigsEuSymbiontAssociated data
+    slot_uri: MIXS:migs_eu_symbiont_associated_data
+    range: MigsEuSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_wastewater_sludge_data:
+    description: Data that comply with MigsEu combined with WastewaterSludge
+    title: MigsEuWastewaterSludge data
+    slot_uri: MIXS:migs_eu_wastewater_sludge_data
+    range: MigsEuWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_eu_water_data:
+    description: Data that comply with MigsEu combined with Water
+    title: MigsEuWater data
+    slot_uri: MIXS:migs_eu_water_data
+    range: MigsEuWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_data:
+    description: Data that comply with checklist MigsOrg
+    title: MigsOrg data
+    slot_uri: MIXS:migs_org_data
+    range: MigsOrg
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_agriculture_data:
+    description: Data that comply with MigsOrg combined with Agriculture
+    title: MigsOrgAgriculture data
+    slot_uri: MIXS:migs_org_agriculture_data
+    range: MigsOrgAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_air_data:
+    description: Data that comply with MigsOrg combined with Air
+    title: MigsOrgAir data
+    slot_uri: MIXS:migs_org_air_data
+    range: MigsOrgAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_built_environment_data:
+    description: Data that comply with MigsOrg combined with BuiltEnvironment
+    title: MigsOrgBuiltEnvironment data
+    slot_uri: MIXS:migs_org_built_environment_data
+    range: MigsOrgBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_food_animal_and_animal_feed_data:
+    description: Data that comply with MigsOrg combined with FoodAnimalAndAnimalFeed
+    title: MigsOrgFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:migs_org_food_animal_and_animal_feed_data
+    range: MigsOrgFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_food_farm_environment_data:
+    description: Data that comply with MigsOrg combined with FoodFarmEnvironment
+    title: MigsOrgFoodFarmEnvironment data
+    slot_uri: MIXS:migs_org_food_farm_environment_data
+    range: MigsOrgFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_food_food_production_facility_data:
+    description: Data that comply with MigsOrg combined with FoodFoodProductionFacility
+    title: MigsOrgFoodFoodProductionFacility data
+    slot_uri: MIXS:migs_org_food_food_production_facility_data
+    range: MigsOrgFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_food_human_foods_data:
+    description: Data that comply with MigsOrg combined with FoodHumanFoods
+    title: MigsOrgFoodHumanFoods data
+    slot_uri: MIXS:migs_org_food_human_foods_data
+    range: MigsOrgFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_host_associated_data:
+    description: Data that comply with MigsOrg combined with HostAssociated
+    title: MigsOrgHostAssociated data
+    slot_uri: MIXS:migs_org_host_associated_data
+    range: MigsOrgHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_human_associated_data:
+    description: Data that comply with MigsOrg combined with HumanAssociated
+    title: MigsOrgHumanAssociated data
+    slot_uri: MIXS:migs_org_human_associated_data
+    range: MigsOrgHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_human_gut_data:
+    description: Data that comply with MigsOrg combined with HumanGut
+    title: MigsOrgHumanGut data
+    slot_uri: MIXS:migs_org_human_gut_data
+    range: MigsOrgHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_human_oral_data:
+    description: Data that comply with MigsOrg combined with HumanOral
+    title: MigsOrgHumanOral data
+    slot_uri: MIXS:migs_org_human_oral_data
+    range: MigsOrgHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_human_skin_data:
+    description: Data that comply with MigsOrg combined with HumanSkin
+    title: MigsOrgHumanSkin data
+    slot_uri: MIXS:migs_org_human_skin_data
+    range: MigsOrgHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_human_vaginal_data:
+    description: Data that comply with MigsOrg combined with HumanVaginal
+    title: MigsOrgHumanVaginal data
+    slot_uri: MIXS:migs_org_human_vaginal_data
+    range: MigsOrgHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_hydrocarbon_resources_cores_data:
+    description: Data that comply with MigsOrg combined with HydrocarbonResourcesCores
+    title: MigsOrgHydrocarbonResourcesCores data
+    slot_uri: MIXS:migs_org_hydrocarbon_resources_cores_data
+    range: MigsOrgHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MigsOrg combined with HydrocarbonResourcesFluidsSwabs
+    title: MigsOrgHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:migs_org_hydrocarbon_resources_fluids_swabs_data
+    range: MigsOrgHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_microbial_mat_biofilm_data:
+    description: Data that comply with MigsOrg combined with MicrobialMatBiofilm
+    title: MigsOrgMicrobialMatBiofilm data
+    slot_uri: MIXS:migs_org_microbial_mat_biofilm_data
+    range: MigsOrgMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MigsOrg combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MigsOrgMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:migs_org_miscellaneous_natural_or_artificial_environment_data
+    range: MigsOrgMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_plant_associated_data:
+    description: Data that comply with MigsOrg combined with PlantAssociated
+    title: MigsOrgPlantAssociated data
+    slot_uri: MIXS:migs_org_plant_associated_data
+    range: MigsOrgPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_sediment_data:
+    description: Data that comply with MigsOrg combined with Sediment
+    title: MigsOrgSediment data
+    slot_uri: MIXS:migs_org_sediment_data
+    range: MigsOrgSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_soil_data:
+    description: Data that comply with MigsOrg combined with Soil
+    title: MigsOrgSoil data
+    slot_uri: MIXS:migs_org_soil_data
+    range: MigsOrgSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_symbiont_associated_data:
+    description: Data that comply with MigsOrg combined with SymbiontAssociated
+    title: MigsOrgSymbiontAssociated data
+    slot_uri: MIXS:migs_org_symbiont_associated_data
+    range: MigsOrgSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_wastewater_sludge_data:
+    description: Data that comply with MigsOrg combined with WastewaterSludge
+    title: MigsOrgWastewaterSludge data
+    slot_uri: MIXS:migs_org_wastewater_sludge_data
+    range: MigsOrgWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_org_water_data:
+    description: Data that comply with MigsOrg combined with Water
+    title: MigsOrgWater data
+    slot_uri: MIXS:migs_org_water_data
+    range: MigsOrgWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_data:
+    description: Data that comply with checklist MigsPl
+    title: MigsPl data
+    slot_uri: MIXS:migs_pl_data
+    range: MigsPl
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_agriculture_data:
+    description: Data that comply with MigsPl combined with Agriculture
+    title: MigsPlAgriculture data
+    slot_uri: MIXS:migs_pl_agriculture_data
+    range: MigsPlAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_air_data:
+    description: Data that comply with MigsPl combined with Air
+    title: MigsPlAir data
+    slot_uri: MIXS:migs_pl_air_data
+    range: MigsPlAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_built_environment_data:
+    description: Data that comply with MigsPl combined with BuiltEnvironment
+    title: MigsPlBuiltEnvironment data
+    slot_uri: MIXS:migs_pl_built_environment_data
+    range: MigsPlBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_food_animal_and_animal_feed_data:
+    description: Data that comply with MigsPl combined with FoodAnimalAndAnimalFeed
+    title: MigsPlFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:migs_pl_food_animal_and_animal_feed_data
+    range: MigsPlFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_food_farm_environment_data:
+    description: Data that comply with MigsPl combined with FoodFarmEnvironment
+    title: MigsPlFoodFarmEnvironment data
+    slot_uri: MIXS:migs_pl_food_farm_environment_data
+    range: MigsPlFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_food_food_production_facility_data:
+    description: Data that comply with MigsPl combined with FoodFoodProductionFacility
+    title: MigsPlFoodFoodProductionFacility data
+    slot_uri: MIXS:migs_pl_food_food_production_facility_data
+    range: MigsPlFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_food_human_foods_data:
+    description: Data that comply with MigsPl combined with FoodHumanFoods
+    title: MigsPlFoodHumanFoods data
+    slot_uri: MIXS:migs_pl_food_human_foods_data
+    range: MigsPlFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_host_associated_data:
+    description: Data that comply with MigsPl combined with HostAssociated
+    title: MigsPlHostAssociated data
+    slot_uri: MIXS:migs_pl_host_associated_data
+    range: MigsPlHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_human_associated_data:
+    description: Data that comply with MigsPl combined with HumanAssociated
+    title: MigsPlHumanAssociated data
+    slot_uri: MIXS:migs_pl_human_associated_data
+    range: MigsPlHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_human_gut_data:
+    description: Data that comply with MigsPl combined with HumanGut
+    title: MigsPlHumanGut data
+    slot_uri: MIXS:migs_pl_human_gut_data
+    range: MigsPlHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_human_oral_data:
+    description: Data that comply with MigsPl combined with HumanOral
+    title: MigsPlHumanOral data
+    slot_uri: MIXS:migs_pl_human_oral_data
+    range: MigsPlHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_human_skin_data:
+    description: Data that comply with MigsPl combined with HumanSkin
+    title: MigsPlHumanSkin data
+    slot_uri: MIXS:migs_pl_human_skin_data
+    range: MigsPlHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_human_vaginal_data:
+    description: Data that comply with MigsPl combined with HumanVaginal
+    title: MigsPlHumanVaginal data
+    slot_uri: MIXS:migs_pl_human_vaginal_data
+    range: MigsPlHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_hydrocarbon_resources_cores_data:
+    description: Data that comply with MigsPl combined with HydrocarbonResourcesCores
+    title: MigsPlHydrocarbonResourcesCores data
+    slot_uri: MIXS:migs_pl_hydrocarbon_resources_cores_data
+    range: MigsPlHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MigsPl combined with HydrocarbonResourcesFluidsSwabs
+    title: MigsPlHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:migs_pl_hydrocarbon_resources_fluids_swabs_data
+    range: MigsPlHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_microbial_mat_biofilm_data:
+    description: Data that comply with MigsPl combined with MicrobialMatBiofilm
+    title: MigsPlMicrobialMatBiofilm data
+    slot_uri: MIXS:migs_pl_microbial_mat_biofilm_data
+    range: MigsPlMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MigsPl combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MigsPlMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:migs_pl_miscellaneous_natural_or_artificial_environment_data
+    range: MigsPlMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_plant_associated_data:
+    description: Data that comply with MigsPl combined with PlantAssociated
+    title: MigsPlPlantAssociated data
+    slot_uri: MIXS:migs_pl_plant_associated_data
+    range: MigsPlPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_sediment_data:
+    description: Data that comply with MigsPl combined with Sediment
+    title: MigsPlSediment data
+    slot_uri: MIXS:migs_pl_sediment_data
+    range: MigsPlSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_soil_data:
+    description: Data that comply with MigsPl combined with Soil
+    title: MigsPlSoil data
+    slot_uri: MIXS:migs_pl_soil_data
+    range: MigsPlSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_symbiont_associated_data:
+    description: Data that comply with MigsPl combined with SymbiontAssociated
+    title: MigsPlSymbiontAssociated data
+    slot_uri: MIXS:migs_pl_symbiont_associated_data
+    range: MigsPlSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_wastewater_sludge_data:
+    description: Data that comply with MigsPl combined with WastewaterSludge
+    title: MigsPlWastewaterSludge data
+    slot_uri: MIXS:migs_pl_wastewater_sludge_data
+    range: MigsPlWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_pl_water_data:
+    description: Data that comply with MigsPl combined with Water
+    title: MigsPlWater data
+    slot_uri: MIXS:migs_pl_water_data
+    range: MigsPlWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_data:
+    description: Data that comply with checklist MigsVi
+    title: MigsVi data
+    slot_uri: MIXS:migs_vi_data
+    range: MigsVi
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_agriculture_data:
+    description: Data that comply with MigsVi combined with Agriculture
+    title: MigsViAgriculture data
+    slot_uri: MIXS:migs_vi_agriculture_data
+    range: MigsViAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_air_data:
+    description: Data that comply with MigsVi combined with Air
+    title: MigsViAir data
+    slot_uri: MIXS:migs_vi_air_data
+    range: MigsViAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_built_environment_data:
+    description: Data that comply with MigsVi combined with BuiltEnvironment
+    title: MigsViBuiltEnvironment data
+    slot_uri: MIXS:migs_vi_built_environment_data
+    range: MigsViBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_food_animal_and_animal_feed_data:
+    description: Data that comply with MigsVi combined with FoodAnimalAndAnimalFeed
+    title: MigsViFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:migs_vi_food_animal_and_animal_feed_data
+    range: MigsViFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_food_farm_environment_data:
+    description: Data that comply with MigsVi combined with FoodFarmEnvironment
+    title: MigsViFoodFarmEnvironment data
+    slot_uri: MIXS:migs_vi_food_farm_environment_data
+    range: MigsViFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_food_food_production_facility_data:
+    description: Data that comply with MigsVi combined with FoodFoodProductionFacility
+    title: MigsViFoodFoodProductionFacility data
+    slot_uri: MIXS:migs_vi_food_food_production_facility_data
+    range: MigsViFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_food_human_foods_data:
+    description: Data that comply with MigsVi combined with FoodHumanFoods
+    title: MigsViFoodHumanFoods data
+    slot_uri: MIXS:migs_vi_food_human_foods_data
+    range: MigsViFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_host_associated_data:
+    description: Data that comply with MigsVi combined with HostAssociated
+    title: MigsViHostAssociated data
+    slot_uri: MIXS:migs_vi_host_associated_data
+    range: MigsViHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_human_associated_data:
+    description: Data that comply with MigsVi combined with HumanAssociated
+    title: MigsViHumanAssociated data
+    slot_uri: MIXS:migs_vi_human_associated_data
+    range: MigsViHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_human_gut_data:
+    description: Data that comply with MigsVi combined with HumanGut
+    title: MigsViHumanGut data
+    slot_uri: MIXS:migs_vi_human_gut_data
+    range: MigsViHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_human_oral_data:
+    description: Data that comply with MigsVi combined with HumanOral
+    title: MigsViHumanOral data
+    slot_uri: MIXS:migs_vi_human_oral_data
+    range: MigsViHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_human_skin_data:
+    description: Data that comply with MigsVi combined with HumanSkin
+    title: MigsViHumanSkin data
+    slot_uri: MIXS:migs_vi_human_skin_data
+    range: MigsViHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_human_vaginal_data:
+    description: Data that comply with MigsVi combined with HumanVaginal
+    title: MigsViHumanVaginal data
+    slot_uri: MIXS:migs_vi_human_vaginal_data
+    range: MigsViHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_hydrocarbon_resources_cores_data:
+    description: Data that comply with MigsVi combined with HydrocarbonResourcesCores
+    title: MigsViHydrocarbonResourcesCores data
+    slot_uri: MIXS:migs_vi_hydrocarbon_resources_cores_data
+    range: MigsViHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MigsVi combined with HydrocarbonResourcesFluidsSwabs
+    title: MigsViHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:migs_vi_hydrocarbon_resources_fluids_swabs_data
+    range: MigsViHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_microbial_mat_biofilm_data:
+    description: Data that comply with MigsVi combined with MicrobialMatBiofilm
+    title: MigsViMicrobialMatBiofilm data
+    slot_uri: MIXS:migs_vi_microbial_mat_biofilm_data
+    range: MigsViMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MigsVi combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MigsViMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:migs_vi_miscellaneous_natural_or_artificial_environment_data
+    range: MigsViMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_plant_associated_data:
+    description: Data that comply with MigsVi combined with PlantAssociated
+    title: MigsViPlantAssociated data
+    slot_uri: MIXS:migs_vi_plant_associated_data
+    range: MigsViPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_sediment_data:
+    description: Data that comply with MigsVi combined with Sediment
+    title: MigsViSediment data
+    slot_uri: MIXS:migs_vi_sediment_data
+    range: MigsViSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_soil_data:
+    description: Data that comply with MigsVi combined with Soil
+    title: MigsViSoil data
+    slot_uri: MIXS:migs_vi_soil_data
+    range: MigsViSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_symbiont_associated_data:
+    description: Data that comply with MigsVi combined with SymbiontAssociated
+    title: MigsViSymbiontAssociated data
+    slot_uri: MIXS:migs_vi_symbiont_associated_data
+    range: MigsViSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_wastewater_sludge_data:
+    description: Data that comply with MigsVi combined with WastewaterSludge
+    title: MigsViWastewaterSludge data
+    slot_uri: MIXS:migs_vi_wastewater_sludge_data
+    range: MigsViWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  migs_vi_water_data:
+    description: Data that comply with MigsVi combined with Water
+    title: MigsViWater data
+    slot_uri: MIXS:migs_vi_water_data
+    range: MigsViWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_data:
+    description: Data that comply with checklist Mimag
+    title: Mimag data
+    slot_uri: MIXS:mimag_data
+    range: Mimag
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_agriculture_data:
+    description: Data that comply with Mimag combined with Agriculture
+    title: MimagAgriculture data
+    slot_uri: MIXS:mimag_agriculture_data
+    range: MimagAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_air_data:
+    description: Data that comply with Mimag combined with Air
+    title: MimagAir data
+    slot_uri: MIXS:mimag_air_data
+    range: MimagAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_built_environment_data:
+    description: Data that comply with Mimag combined with BuiltEnvironment
+    title: MimagBuiltEnvironment data
+    slot_uri: MIXS:mimag_built_environment_data
+    range: MimagBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_food_animal_and_animal_feed_data:
+    description: Data that comply with Mimag combined with FoodAnimalAndAnimalFeed
+    title: MimagFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:mimag_food_animal_and_animal_feed_data
+    range: MimagFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_food_farm_environment_data:
+    description: Data that comply with Mimag combined with FoodFarmEnvironment
+    title: MimagFoodFarmEnvironment data
+    slot_uri: MIXS:mimag_food_farm_environment_data
+    range: MimagFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_food_food_production_facility_data:
+    description: Data that comply with Mimag combined with FoodFoodProductionFacility
+    title: MimagFoodFoodProductionFacility data
+    slot_uri: MIXS:mimag_food_food_production_facility_data
+    range: MimagFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_food_human_foods_data:
+    description: Data that comply with Mimag combined with FoodHumanFoods
+    title: MimagFoodHumanFoods data
+    slot_uri: MIXS:mimag_food_human_foods_data
+    range: MimagFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_host_associated_data:
+    description: Data that comply with Mimag combined with HostAssociated
+    title: MimagHostAssociated data
+    slot_uri: MIXS:mimag_host_associated_data
+    range: MimagHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_human_associated_data:
+    description: Data that comply with Mimag combined with HumanAssociated
+    title: MimagHumanAssociated data
+    slot_uri: MIXS:mimag_human_associated_data
+    range: MimagHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_human_gut_data:
+    description: Data that comply with Mimag combined with HumanGut
+    title: MimagHumanGut data
+    slot_uri: MIXS:mimag_human_gut_data
+    range: MimagHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_human_oral_data:
+    description: Data that comply with Mimag combined with HumanOral
+    title: MimagHumanOral data
+    slot_uri: MIXS:mimag_human_oral_data
+    range: MimagHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_human_skin_data:
+    description: Data that comply with Mimag combined with HumanSkin
+    title: MimagHumanSkin data
+    slot_uri: MIXS:mimag_human_skin_data
+    range: MimagHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_human_vaginal_data:
+    description: Data that comply with Mimag combined with HumanVaginal
+    title: MimagHumanVaginal data
+    slot_uri: MIXS:mimag_human_vaginal_data
+    range: MimagHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_hydrocarbon_resources_cores_data:
+    description: Data that comply with Mimag combined with HydrocarbonResourcesCores
+    title: MimagHydrocarbonResourcesCores data
+    slot_uri: MIXS:mimag_hydrocarbon_resources_cores_data
+    range: MimagHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with Mimag combined with HydrocarbonResourcesFluidsSwabs
+    title: MimagHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:mimag_hydrocarbon_resources_fluids_swabs_data
+    range: MimagHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_microbial_mat_biofilm_data:
+    description: Data that comply with Mimag combined with MicrobialMatBiofilm
+    title: MimagMicrobialMatBiofilm data
+    slot_uri: MIXS:mimag_microbial_mat_biofilm_data
+    range: MimagMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with Mimag combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MimagMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:mimag_miscellaneous_natural_or_artificial_environment_data
+    range: MimagMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_plant_associated_data:
+    description: Data that comply with Mimag combined with PlantAssociated
+    title: MimagPlantAssociated data
+    slot_uri: MIXS:mimag_plant_associated_data
+    range: MimagPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_sediment_data:
+    description: Data that comply with Mimag combined with Sediment
+    title: MimagSediment data
+    slot_uri: MIXS:mimag_sediment_data
+    range: MimagSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_soil_data:
+    description: Data that comply with Mimag combined with Soil
+    title: MimagSoil data
+    slot_uri: MIXS:mimag_soil_data
+    range: MimagSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_symbiont_associated_data:
+    description: Data that comply with Mimag combined with SymbiontAssociated
+    title: MimagSymbiontAssociated data
+    slot_uri: MIXS:mimag_symbiont_associated_data
+    range: MimagSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_wastewater_sludge_data:
+    description: Data that comply with Mimag combined with WastewaterSludge
+    title: MimagWastewaterSludge data
+    slot_uri: MIXS:mimag_wastewater_sludge_data
+    range: MimagWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimag_water_data:
+    description: Data that comply with Mimag combined with Water
+    title: MimagWater data
+    slot_uri: MIXS:mimag_water_data
+    range: MimagWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_data:
+    description: Data that comply with checklist MimarksC
+    title: MimarksC data
+    slot_uri: MIXS:mimarks_c_data
+    range: MimarksC
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_agriculture_data:
+    description: Data that comply with MimarksC combined with Agriculture
+    title: MimarksCAgriculture data
+    slot_uri: MIXS:mimarks_c_agriculture_data
+    range: MimarksCAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_air_data:
+    description: Data that comply with MimarksC combined with Air
+    title: MimarksCAir data
+    slot_uri: MIXS:mimarks_c_air_data
+    range: MimarksCAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_built_environment_data:
+    description: Data that comply with MimarksC combined with BuiltEnvironment
+    title: MimarksCBuiltEnvironment data
+    slot_uri: MIXS:mimarks_c_built_environment_data
+    range: MimarksCBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_food_animal_and_animal_feed_data:
+    description: Data that comply with MimarksC combined with FoodAnimalAndAnimalFeed
+    title: MimarksCFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:mimarks_c_food_animal_and_animal_feed_data
+    range: MimarksCFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_food_farm_environment_data:
+    description: Data that comply with MimarksC combined with FoodFarmEnvironment
+    title: MimarksCFoodFarmEnvironment data
+    slot_uri: MIXS:mimarks_c_food_farm_environment_data
+    range: MimarksCFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_food_food_production_facility_data:
+    description: Data that comply with MimarksC combined with FoodFoodProductionFacility
+    title: MimarksCFoodFoodProductionFacility data
+    slot_uri: MIXS:mimarks_c_food_food_production_facility_data
+    range: MimarksCFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_food_human_foods_data:
+    description: Data that comply with MimarksC combined with FoodHumanFoods
+    title: MimarksCFoodHumanFoods data
+    slot_uri: MIXS:mimarks_c_food_human_foods_data
+    range: MimarksCFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_host_associated_data:
+    description: Data that comply with MimarksC combined with HostAssociated
+    title: MimarksCHostAssociated data
+    slot_uri: MIXS:mimarks_c_host_associated_data
+    range: MimarksCHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_human_associated_data:
+    description: Data that comply with MimarksC combined with HumanAssociated
+    title: MimarksCHumanAssociated data
+    slot_uri: MIXS:mimarks_c_human_associated_data
+    range: MimarksCHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_human_gut_data:
+    description: Data that comply with MimarksC combined with HumanGut
+    title: MimarksCHumanGut data
+    slot_uri: MIXS:mimarks_c_human_gut_data
+    range: MimarksCHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_human_oral_data:
+    description: Data that comply with MimarksC combined with HumanOral
+    title: MimarksCHumanOral data
+    slot_uri: MIXS:mimarks_c_human_oral_data
+    range: MimarksCHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_human_skin_data:
+    description: Data that comply with MimarksC combined with HumanSkin
+    title: MimarksCHumanSkin data
+    slot_uri: MIXS:mimarks_c_human_skin_data
+    range: MimarksCHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_human_vaginal_data:
+    description: Data that comply with MimarksC combined with HumanVaginal
+    title: MimarksCHumanVaginal data
+    slot_uri: MIXS:mimarks_c_human_vaginal_data
+    range: MimarksCHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_hydrocarbon_resources_cores_data:
+    description: Data that comply with MimarksC combined with HydrocarbonResourcesCores
+    title: MimarksCHydrocarbonResourcesCores data
+    slot_uri: MIXS:mimarks_c_hydrocarbon_resources_cores_data
+    range: MimarksCHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MimarksC combined with HydrocarbonResourcesFluidsSwabs
+    title: MimarksCHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:mimarks_c_hydrocarbon_resources_fluids_swabs_data
+    range: MimarksCHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_microbial_mat_biofilm_data:
+    description: Data that comply with MimarksC combined with MicrobialMatBiofilm
+    title: MimarksCMicrobialMatBiofilm data
+    slot_uri: MIXS:mimarks_c_microbial_mat_biofilm_data
+    range: MimarksCMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MimarksC combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MimarksCMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:mimarks_c_miscellaneous_natural_or_artificial_environment_data
+    range: MimarksCMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_plant_associated_data:
+    description: Data that comply with MimarksC combined with PlantAssociated
+    title: MimarksCPlantAssociated data
+    slot_uri: MIXS:mimarks_c_plant_associated_data
+    range: MimarksCPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_sediment_data:
+    description: Data that comply with MimarksC combined with Sediment
+    title: MimarksCSediment data
+    slot_uri: MIXS:mimarks_c_sediment_data
+    range: MimarksCSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_soil_data:
+    description: Data that comply with MimarksC combined with Soil
+    title: MimarksCSoil data
+    slot_uri: MIXS:mimarks_c_soil_data
+    range: MimarksCSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_symbiont_associated_data:
+    description: Data that comply with MimarksC combined with SymbiontAssociated
+    title: MimarksCSymbiontAssociated data
+    slot_uri: MIXS:mimarks_c_symbiont_associated_data
+    range: MimarksCSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_wastewater_sludge_data:
+    description: Data that comply with MimarksC combined with WastewaterSludge
+    title: MimarksCWastewaterSludge data
+    slot_uri: MIXS:mimarks_c_wastewater_sludge_data
+    range: MimarksCWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_c_water_data:
+    description: Data that comply with MimarksC combined with Water
+    title: MimarksCWater data
+    slot_uri: MIXS:mimarks_c_water_data
+    range: MimarksCWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_data:
+    description: Data that comply with checklist MimarksS
+    title: MimarksS data
+    slot_uri: MIXS:mimarks_s_data
+    range: MimarksS
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_agriculture_data:
+    description: Data that comply with MimarksS combined with Agriculture
+    title: MimarksSAgriculture data
+    slot_uri: MIXS:mimarks_s_agriculture_data
+    range: MimarksSAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_air_data:
+    description: Data that comply with MimarksS combined with Air
+    title: MimarksSAir data
+    slot_uri: MIXS:mimarks_s_air_data
+    range: MimarksSAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_built_environment_data:
+    description: Data that comply with MimarksS combined with BuiltEnvironment
+    title: MimarksSBuiltEnvironment data
+    slot_uri: MIXS:mimarks_s_built_environment_data
+    range: MimarksSBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_food_animal_and_animal_feed_data:
+    description: Data that comply with MimarksS combined with FoodAnimalAndAnimalFeed
+    title: MimarksSFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:mimarks_s_food_animal_and_animal_feed_data
+    range: MimarksSFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_food_farm_environment_data:
+    description: Data that comply with MimarksS combined with FoodFarmEnvironment
+    title: MimarksSFoodFarmEnvironment data
+    slot_uri: MIXS:mimarks_s_food_farm_environment_data
+    range: MimarksSFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_food_food_production_facility_data:
+    description: Data that comply with MimarksS combined with FoodFoodProductionFacility
+    title: MimarksSFoodFoodProductionFacility data
+    slot_uri: MIXS:mimarks_s_food_food_production_facility_data
+    range: MimarksSFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_food_human_foods_data:
+    description: Data that comply with MimarksS combined with FoodHumanFoods
+    title: MimarksSFoodHumanFoods data
+    slot_uri: MIXS:mimarks_s_food_human_foods_data
+    range: MimarksSFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_host_associated_data:
+    description: Data that comply with MimarksS combined with HostAssociated
+    title: MimarksSHostAssociated data
+    slot_uri: MIXS:mimarks_s_host_associated_data
+    range: MimarksSHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_human_associated_data:
+    description: Data that comply with MimarksS combined with HumanAssociated
+    title: MimarksSHumanAssociated data
+    slot_uri: MIXS:mimarks_s_human_associated_data
+    range: MimarksSHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_human_gut_data:
+    description: Data that comply with MimarksS combined with HumanGut
+    title: MimarksSHumanGut data
+    slot_uri: MIXS:mimarks_s_human_gut_data
+    range: MimarksSHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_human_oral_data:
+    description: Data that comply with MimarksS combined with HumanOral
+    title: MimarksSHumanOral data
+    slot_uri: MIXS:mimarks_s_human_oral_data
+    range: MimarksSHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_human_skin_data:
+    description: Data that comply with MimarksS combined with HumanSkin
+    title: MimarksSHumanSkin data
+    slot_uri: MIXS:mimarks_s_human_skin_data
+    range: MimarksSHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_human_vaginal_data:
+    description: Data that comply with MimarksS combined with HumanVaginal
+    title: MimarksSHumanVaginal data
+    slot_uri: MIXS:mimarks_s_human_vaginal_data
+    range: MimarksSHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_hydrocarbon_resources_cores_data:
+    description: Data that comply with MimarksS combined with HydrocarbonResourcesCores
+    title: MimarksSHydrocarbonResourcesCores data
+    slot_uri: MIXS:mimarks_s_hydrocarbon_resources_cores_data
+    range: MimarksSHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with MimarksS combined with HydrocarbonResourcesFluidsSwabs
+    title: MimarksSHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:mimarks_s_hydrocarbon_resources_fluids_swabs_data
+    range: MimarksSHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_microbial_mat_biofilm_data:
+    description: Data that comply with MimarksS combined with MicrobialMatBiofilm
+    title: MimarksSMicrobialMatBiofilm data
+    slot_uri: MIXS:mimarks_s_microbial_mat_biofilm_data
+    range: MimarksSMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with MimarksS combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MimarksSMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:mimarks_s_miscellaneous_natural_or_artificial_environment_data
+    range: MimarksSMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_plant_associated_data:
+    description: Data that comply with MimarksS combined with PlantAssociated
+    title: MimarksSPlantAssociated data
+    slot_uri: MIXS:mimarks_s_plant_associated_data
+    range: MimarksSPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_sediment_data:
+    description: Data that comply with MimarksS combined with Sediment
+    title: MimarksSSediment data
+    slot_uri: MIXS:mimarks_s_sediment_data
+    range: MimarksSSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_soil_data:
+    description: Data that comply with MimarksS combined with Soil
+    title: MimarksSSoil data
+    slot_uri: MIXS:mimarks_s_soil_data
+    range: MimarksSSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_symbiont_associated_data:
+    description: Data that comply with MimarksS combined with SymbiontAssociated
+    title: MimarksSSymbiontAssociated data
+    slot_uri: MIXS:mimarks_s_symbiont_associated_data
+    range: MimarksSSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_wastewater_sludge_data:
+    description: Data that comply with MimarksS combined with WastewaterSludge
+    title: MimarksSWastewaterSludge data
+    slot_uri: MIXS:mimarks_s_wastewater_sludge_data
+    range: MimarksSWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mimarks_s_water_data:
+    description: Data that comply with MimarksS combined with Water
+    title: MimarksSWater data
+    slot_uri: MIXS:mimarks_s_water_data
+    range: MimarksSWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_data:
+    description: Data that comply with checklist Mims
+    title: Mims data
+    slot_uri: MIXS:mims_data
+    range: Mims
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_agriculture_data:
+    description: Data that comply with Mims combined with Agriculture
+    title: MimsAgriculture data
+    slot_uri: MIXS:mims_agriculture_data
+    range: MimsAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_air_data:
+    description: Data that comply with Mims combined with Air
+    title: MimsAir data
+    slot_uri: MIXS:mims_air_data
+    range: MimsAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_built_environment_data:
+    description: Data that comply with Mims combined with BuiltEnvironment
+    title: MimsBuiltEnvironment data
+    slot_uri: MIXS:mims_built_environment_data
+    range: MimsBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_food_animal_and_animal_feed_data:
+    description: Data that comply with Mims combined with FoodAnimalAndAnimalFeed
+    title: MimsFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:mims_food_animal_and_animal_feed_data
+    range: MimsFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_food_farm_environment_data:
+    description: Data that comply with Mims combined with FoodFarmEnvironment
+    title: MimsFoodFarmEnvironment data
+    slot_uri: MIXS:mims_food_farm_environment_data
+    range: MimsFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_food_food_production_facility_data:
+    description: Data that comply with Mims combined with FoodFoodProductionFacility
+    title: MimsFoodFoodProductionFacility data
+    slot_uri: MIXS:mims_food_food_production_facility_data
+    range: MimsFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_food_human_foods_data:
+    description: Data that comply with Mims combined with FoodHumanFoods
+    title: MimsFoodHumanFoods data
+    slot_uri: MIXS:mims_food_human_foods_data
+    range: MimsFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_host_associated_data:
+    description: Data that comply with Mims combined with HostAssociated
+    title: MimsHostAssociated data
+    slot_uri: MIXS:mims_host_associated_data
+    range: MimsHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_human_associated_data:
+    description: Data that comply with Mims combined with HumanAssociated
+    title: MimsHumanAssociated data
+    slot_uri: MIXS:mims_human_associated_data
+    range: MimsHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_human_gut_data:
+    description: Data that comply with Mims combined with HumanGut
+    title: MimsHumanGut data
+    slot_uri: MIXS:mims_human_gut_data
+    range: MimsHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_human_oral_data:
+    description: Data that comply with Mims combined with HumanOral
+    title: MimsHumanOral data
+    slot_uri: MIXS:mims_human_oral_data
+    range: MimsHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_human_skin_data:
+    description: Data that comply with Mims combined with HumanSkin
+    title: MimsHumanSkin data
+    slot_uri: MIXS:mims_human_skin_data
+    range: MimsHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_human_vaginal_data:
+    description: Data that comply with Mims combined with HumanVaginal
+    title: MimsHumanVaginal data
+    slot_uri: MIXS:mims_human_vaginal_data
+    range: MimsHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_hydrocarbon_resources_cores_data:
+    description: Data that comply with Mims combined with HydrocarbonResourcesCores
+    title: MimsHydrocarbonResourcesCores data
+    slot_uri: MIXS:mims_hydrocarbon_resources_cores_data
+    range: MimsHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with Mims combined with HydrocarbonResourcesFluidsSwabs
+    title: MimsHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:mims_hydrocarbon_resources_fluids_swabs_data
+    range: MimsHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_microbial_mat_biofilm_data:
+    description: Data that comply with Mims combined with MicrobialMatBiofilm
+    title: MimsMicrobialMatBiofilm data
+    slot_uri: MIXS:mims_microbial_mat_biofilm_data
+    range: MimsMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with Mims combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MimsMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:mims_miscellaneous_natural_or_artificial_environment_data
+    range: MimsMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_plant_associated_data:
+    description: Data that comply with Mims combined with PlantAssociated
+    title: MimsPlantAssociated data
+    slot_uri: MIXS:mims_plant_associated_data
+    range: MimsPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_sediment_data:
+    description: Data that comply with Mims combined with Sediment
+    title: MimsSediment data
+    slot_uri: MIXS:mims_sediment_data
+    range: MimsSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_soil_data:
+    description: Data that comply with Mims combined with Soil
+    title: MimsSoil data
+    slot_uri: MIXS:mims_soil_data
+    range: MimsSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_symbiont_associated_data:
+    description: Data that comply with Mims combined with SymbiontAssociated
+    title: MimsSymbiontAssociated data
+    slot_uri: MIXS:mims_symbiont_associated_data
+    range: MimsSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_wastewater_sludge_data:
+    description: Data that comply with Mims combined with WastewaterSludge
+    title: MimsWastewaterSludge data
+    slot_uri: MIXS:mims_wastewater_sludge_data
+    range: MimsWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  mims_water_data:
+    description: Data that comply with Mims combined with Water
+    title: MimsWater data
+    slot_uri: MIXS:mims_water_data
+    range: MimsWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_data:
+    description: Data that comply with checklist Misag
+    title: Misag data
+    slot_uri: MIXS:misag_data
+    range: Misag
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_agriculture_data:
+    description: Data that comply with Misag combined with Agriculture
+    title: MisagAgriculture data
+    slot_uri: MIXS:misag_agriculture_data
+    range: MisagAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_air_data:
+    description: Data that comply with Misag combined with Air
+    title: MisagAir data
+    slot_uri: MIXS:misag_air_data
+    range: MisagAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_built_environment_data:
+    description: Data that comply with Misag combined with BuiltEnvironment
+    title: MisagBuiltEnvironment data
+    slot_uri: MIXS:misag_built_environment_data
+    range: MisagBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_food_animal_and_animal_feed_data:
+    description: Data that comply with Misag combined with FoodAnimalAndAnimalFeed
+    title: MisagFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:misag_food_animal_and_animal_feed_data
+    range: MisagFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_food_farm_environment_data:
+    description: Data that comply with Misag combined with FoodFarmEnvironment
+    title: MisagFoodFarmEnvironment data
+    slot_uri: MIXS:misag_food_farm_environment_data
+    range: MisagFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_food_food_production_facility_data:
+    description: Data that comply with Misag combined with FoodFoodProductionFacility
+    title: MisagFoodFoodProductionFacility data
+    slot_uri: MIXS:misag_food_food_production_facility_data
+    range: MisagFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_food_human_foods_data:
+    description: Data that comply with Misag combined with FoodHumanFoods
+    title: MisagFoodHumanFoods data
+    slot_uri: MIXS:misag_food_human_foods_data
+    range: MisagFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_host_associated_data:
+    description: Data that comply with Misag combined with HostAssociated
+    title: MisagHostAssociated data
+    slot_uri: MIXS:misag_host_associated_data
+    range: MisagHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_human_associated_data:
+    description: Data that comply with Misag combined with HumanAssociated
+    title: MisagHumanAssociated data
+    slot_uri: MIXS:misag_human_associated_data
+    range: MisagHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_human_gut_data:
+    description: Data that comply with Misag combined with HumanGut
+    title: MisagHumanGut data
+    slot_uri: MIXS:misag_human_gut_data
+    range: MisagHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_human_oral_data:
+    description: Data that comply with Misag combined with HumanOral
+    title: MisagHumanOral data
+    slot_uri: MIXS:misag_human_oral_data
+    range: MisagHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_human_skin_data:
+    description: Data that comply with Misag combined with HumanSkin
+    title: MisagHumanSkin data
+    slot_uri: MIXS:misag_human_skin_data
+    range: MisagHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_human_vaginal_data:
+    description: Data that comply with Misag combined with HumanVaginal
+    title: MisagHumanVaginal data
+    slot_uri: MIXS:misag_human_vaginal_data
+    range: MisagHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_hydrocarbon_resources_cores_data:
+    description: Data that comply with Misag combined with HydrocarbonResourcesCores
+    title: MisagHydrocarbonResourcesCores data
+    slot_uri: MIXS:misag_hydrocarbon_resources_cores_data
+    range: MisagHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with Misag combined with HydrocarbonResourcesFluidsSwabs
+    title: MisagHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:misag_hydrocarbon_resources_fluids_swabs_data
+    range: MisagHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_microbial_mat_biofilm_data:
+    description: Data that comply with Misag combined with MicrobialMatBiofilm
+    title: MisagMicrobialMatBiofilm data
+    slot_uri: MIXS:misag_microbial_mat_biofilm_data
+    range: MisagMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with Misag combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MisagMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:misag_miscellaneous_natural_or_artificial_environment_data
+    range: MisagMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_plant_associated_data:
+    description: Data that comply with Misag combined with PlantAssociated
+    title: MisagPlantAssociated data
+    slot_uri: MIXS:misag_plant_associated_data
+    range: MisagPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_sediment_data:
+    description: Data that comply with Misag combined with Sediment
+    title: MisagSediment data
+    slot_uri: MIXS:misag_sediment_data
+    range: MisagSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_soil_data:
+    description: Data that comply with Misag combined with Soil
+    title: MisagSoil data
+    slot_uri: MIXS:misag_soil_data
+    range: MisagSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_symbiont_associated_data:
+    description: Data that comply with Misag combined with SymbiontAssociated
+    title: MisagSymbiontAssociated data
+    slot_uri: MIXS:misag_symbiont_associated_data
+    range: MisagSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_wastewater_sludge_data:
+    description: Data that comply with Misag combined with WastewaterSludge
+    title: MisagWastewaterSludge data
+    slot_uri: MIXS:misag_wastewater_sludge_data
+    range: MisagWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  misag_water_data:
+    description: Data that comply with Misag combined with Water
+    title: MisagWater data
+    slot_uri: MIXS:misag_water_data
+    range: MisagWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_data:
+    description: Data that comply with checklist Miuvig
+    title: Miuvig data
+    slot_uri: MIXS:miuvig_data
+    range: Miuvig
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_agriculture_data:
+    description: Data that comply with Miuvig combined with Agriculture
+    title: MiuvigAgriculture data
+    slot_uri: MIXS:miuvig_agriculture_data
+    range: MiuvigAgriculture
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_air_data:
+    description: Data that comply with Miuvig combined with Air
+    title: MiuvigAir data
+    slot_uri: MIXS:miuvig_air_data
+    range: MiuvigAir
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_built_environment_data:
+    description: Data that comply with Miuvig combined with BuiltEnvironment
+    title: MiuvigBuiltEnvironment data
+    slot_uri: MIXS:miuvig_built_environment_data
+    range: MiuvigBuiltEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_food_animal_and_animal_feed_data:
+    description: Data that comply with Miuvig combined with FoodAnimalAndAnimalFeed
+    title: MiuvigFoodAnimalAndAnimalFeed data
+    slot_uri: MIXS:miuvig_food_animal_and_animal_feed_data
+    range: MiuvigFoodAnimalAndAnimalFeed
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_food_farm_environment_data:
+    description: Data that comply with Miuvig combined with FoodFarmEnvironment
+    title: MiuvigFoodFarmEnvironment data
+    slot_uri: MIXS:miuvig_food_farm_environment_data
+    range: MiuvigFoodFarmEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_food_food_production_facility_data:
+    description: Data that comply with Miuvig combined with FoodFoodProductionFacility
+    title: MiuvigFoodFoodProductionFacility data
+    slot_uri: MIXS:miuvig_food_food_production_facility_data
+    range: MiuvigFoodFoodProductionFacility
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_food_human_foods_data:
+    description: Data that comply with Miuvig combined with FoodHumanFoods
+    title: MiuvigFoodHumanFoods data
+    slot_uri: MIXS:miuvig_food_human_foods_data
+    range: MiuvigFoodHumanFoods
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_host_associated_data:
+    description: Data that comply with Miuvig combined with HostAssociated
+    title: MiuvigHostAssociated data
+    slot_uri: MIXS:miuvig_host_associated_data
+    range: MiuvigHostAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_human_associated_data:
+    description: Data that comply with Miuvig combined with HumanAssociated
+    title: MiuvigHumanAssociated data
+    slot_uri: MIXS:miuvig_human_associated_data
+    range: MiuvigHumanAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_human_gut_data:
+    description: Data that comply with Miuvig combined with HumanGut
+    title: MiuvigHumanGut data
+    slot_uri: MIXS:miuvig_human_gut_data
+    range: MiuvigHumanGut
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_human_oral_data:
+    description: Data that comply with Miuvig combined with HumanOral
+    title: MiuvigHumanOral data
+    slot_uri: MIXS:miuvig_human_oral_data
+    range: MiuvigHumanOral
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_human_skin_data:
+    description: Data that comply with Miuvig combined with HumanSkin
+    title: MiuvigHumanSkin data
+    slot_uri: MIXS:miuvig_human_skin_data
+    range: MiuvigHumanSkin
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_human_vaginal_data:
+    description: Data that comply with Miuvig combined with HumanVaginal
+    title: MiuvigHumanVaginal data
+    slot_uri: MIXS:miuvig_human_vaginal_data
+    range: MiuvigHumanVaginal
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_hydrocarbon_resources_cores_data:
+    description: Data that comply with Miuvig combined with HydrocarbonResourcesCores
+    title: MiuvigHydrocarbonResourcesCores data
+    slot_uri: MIXS:miuvig_hydrocarbon_resources_cores_data
+    range: MiuvigHydrocarbonResourcesCores
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_hydrocarbon_resources_fluids_swabs_data:
+    description: Data that comply with Miuvig combined with HydrocarbonResourcesFluidsSwabs
+    title: MiuvigHydrocarbonResourcesFluidsSwabs data
+    slot_uri: MIXS:miuvig_hydrocarbon_resources_fluids_swabs_data
+    range: MiuvigHydrocarbonResourcesFluidsSwabs
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_microbial_mat_biofilm_data:
+    description: Data that comply with Miuvig combined with MicrobialMatBiofilm
+    title: MiuvigMicrobialMatBiofilm data
+    slot_uri: MIXS:miuvig_microbial_mat_biofilm_data
+    range: MiuvigMicrobialMatBiofilm
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_miscellaneous_natural_or_artificial_environment_data:
+    description: Data that comply with Miuvig combined with MiscellaneousNaturalOrArtificialEnvironment
+    title: MiuvigMiscellaneousNaturalOrArtificialEnvironment data
+    slot_uri: MIXS:miuvig_miscellaneous_natural_or_artificial_environment_data
+    range: MiuvigMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_plant_associated_data:
+    description: Data that comply with Miuvig combined with PlantAssociated
+    title: MiuvigPlantAssociated data
+    slot_uri: MIXS:miuvig_plant_associated_data
+    range: MiuvigPlantAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_sediment_data:
+    description: Data that comply with Miuvig combined with Sediment
+    title: MiuvigSediment data
+    slot_uri: MIXS:miuvig_sediment_data
+    range: MiuvigSediment
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_soil_data:
+    description: Data that comply with Miuvig combined with Soil
+    title: MiuvigSoil data
+    slot_uri: MIXS:miuvig_soil_data
+    range: MiuvigSoil
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_symbiont_associated_data:
+    description: Data that comply with Miuvig combined with SymbiontAssociated
+    title: MiuvigSymbiontAssociated data
+    slot_uri: MIXS:miuvig_symbiont_associated_data
+    range: MiuvigSymbiontAssociated
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_wastewater_sludge_data:
+    description: Data that comply with Miuvig combined with WastewaterSludge
+    title: MiuvigWastewaterSludge data
+    slot_uri: MIXS:miuvig_wastewater_sludge_data
+    range: MiuvigWastewaterSludge
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  miuvig_water_data:
+    description: Data that comply with Miuvig combined with Water
+    title: MiuvigWater data
+    slot_uri: MIXS:miuvig_water_data
+    range: MiuvigWater
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  HACCP_term:
+    description: Hazard Analysis Critical Control Points (HACCP) food safety terms; This field accepts terms listed under HACCP guide food safety term (http://purl.obolibrary.org/obo/FOODON_03530221)
+    title: Hazard Analysis Critical Control Points (HACCP) guide food safety term
+    examples:
+      - value: tetrodotoxic poisoning [FOODON:03530249]
+    keywords:
+      - food
+      - term
+    slot_uri: MIXS:0001215
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  IFSAC_category:
+    annotations:
+      Expected_value: IFSAC term
+    description: 'The IFSAC food categorization scheme has five distinct levels to which foods can be assigned, depending upon the type of food. First, foods are assigned to one of four food groups (aquatic animals, land animals, plants, and other). Food groups include increasingly specific food categories; dairy, eggs, meat and poultry, and game are in the land animal food group, and the category meat and poultry is further subdivided into more specific categories of meat (beef, pork, other meat) and poultry (chicken, turkey, other poultry). Finally, foods are differentiated by differences in food processing (such as pasteurized fluid dairy products, unpasteurized fluid dairy products, pasteurized solid and semi-solid dairy products, and unpasteurized solid and semi-solid dairy products. An IFSAC food category chart is available from https://www.cdc.gov/foodsafety/ifsac/projects/food-categorization-scheme.html PMID: 28926300'
+    title: Interagency Food Safety Analytics Collaboration (IFSAC) category
+    examples:
+      - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
+    keywords:
+      - food
+    slot_uri: MIXS:0001179
+    range: string
+    required: true
+    multivalued: true
+  abs_air_humidity:
+    annotations:
+      Preferred_unit: gram per gram, kilogram per kilogram, kilogram, pound
+    description: Actual mass of water vapor - mh20 - present in the air water vapor mixture
+    title: absolute air humidity
+    examples:
+      - value: 9 gram per gram
+    keywords:
+      - absolute
+      - air
+      - humidity
+    slot_uri: MIXS:0000122
+    range: string
+    required: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  adapters:
+    description: Adapters provide priming sequences for both amplification and sequencing of the sample-library fragments. Both adapters should be reported; in uppercase letters
+    title: adapters
+    examples:
+      - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000048
+    pattern: ^[ACGTRKSYMWBHDVN]+;[ACGTRKSYMWBHDVN]+$
+    structured_pattern:
+      syntax: ^{adapter_A_DNA_sequence};{adapter_B_DNA_sequence}$
+      interpolated: true
+      partial_match: true
+  add_recov_method:
+    description: Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed for increase of hydrocarbon recovery from resource and start date for each one of them. If "other" is specified, please propose entry in "additional info" field
+    title: secondary and tertiary recovery methods and start date
+    examples:
+      - value: Polymer Addition;2018-06-21T14:30Z
+    keywords:
+      - date
+      - method
+      - recover
+      - secondary
+      - start
+    slot_uri: MIXS:0001009
+    required: true
+    pattern: ^(Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer Addition|Surfactant Addition|Not Applicable|other);(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$$
+    structured_pattern:
+      syntax: ^({add_recov_methods});{date_time_stamp}$
+      interpolated: true
+      partial_match: true
+  additional_info:
+    description: Information that doesn't fit anywhere else. Can also be used to propose new entries for fields with controlled vocabulary
+    title: additional info
+    keywords:
+      - information
+    slot_uri: MIXS:0000300
+    range: string
+  address:
+    description: The street name and building number where the sampling occurred
+    title: address
+    slot_uri: MIXS:0000218
+    pattern: ^[1-9][0-9]* .*}$
+    structured_pattern:
+      syntax: ^{integer} {text}}$
+      interpolated: true
+      partial_match: true
+  adj_room:
+    description: List of rooms (room number, room name) immediately adjacent to the sampling room
+    title: adjacent rooms
+    keywords:
+      - adjacent
+      - room
+    slot_uri: MIXS:0000219
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^{room_name};{room_number}$
+      interpolated: true
+      partial_match: true
+  adjacent_environment:
+    annotations:
+      Expected_value: ENVO_01001110 or ENVO_00000070
+    description: Description of the environmental system or features that are adjacent to the sampling site. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110) and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple terms can be separated by pipes
+    title: environment adjacent to site
+    examples:
+      - value: estuarine biome [ENVO:01000020]
+    keywords:
+      - adjacent
+      - environment
+      - site
+    string_serialization: '{termLabel}{[termID]}'
+    slot_uri: MIXS:0001121
+    multivalued: true
+  aero_struc:
+    description: Aerospace structures typically consist of thin plates with stiffeners for the external surfaces, bulkheads and frames to support the shape and fasteners such as welds, rivets, screws and bolts to hold the components together
+    title: aerospace structure
+    examples:
+      - value: plane
+    slot_uri: MIXS:0000773
+    range: AeroStrucEnum
+  agrochem_addition:
+    annotations:
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Addition of fertilizers, pesticides, etc. - amount and time of applications
+    title: history/agrochemical additions
+    examples:
+      - value: roundup;5 milligram per liter;2018-06-21
+    keywords:
+      - history
+    slot_uri: MIXS:0000639
+    multivalued: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+);(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$$
+    structured_pattern:
+      syntax: ^{agrochemical_name};{amount} {unit};{date_time_stamp}$
+      interpolated: true
+      partial_match: true
+  air_PM_concen:
+    description: Concentration of substances that remain suspended in the air, and comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can report multiple PM's by entering numeric values preceded by name of PM
+    title: air particulate matter concentration
+    examples:
+      - value: PM2.5;10 microgram per cubic meter
+    keywords:
+      - air
+      - concentration
+      - particle
+      - particulate
+    slot_uri: MIXS:0000108
+    multivalued: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{particulate_matter_name};{float} {unit}$
+      interpolated: true
+      partial_match: true
+  air_flow_impede:
+    annotations:
+      Expected_value: enumeration;obstruction type; distance from sampling device
+    description: Presence of objects in the area that would influence or impede air flow through the air filter
+    title: local air flow impediments
+    examples:
+      - value: obstructed;hay bales; 2 m
+    keywords:
+      - air
+    string_serialization: '[obstructed|unobstructed]; {text}; {measurement value}'
+    slot_uri: MIXS:0001146
+    multivalued: true
+  air_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Temperature of the air at the time of sampling
+    title: air temperature
+    keywords:
+      - air
+      - temperature
+    slot_uri: MIXS:0000124
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  air_temp_regm:
+    annotations:
+      Expected_value: temperature value;treatment interval and duration
+      Preferred_unit: meter
+    description: Information about treatment involving an exposure to varying temperatures; should include the temperature, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include different temperature regimens
+    title: air temperature regimen
+    examples:
+      - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - air
+      - regimen
+      - temperature
+    string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000551
+    multivalued: true
+  al_sat:
+    annotations:
+      Preferred_unit: percentage
+    description: Aluminum saturation (esp. For tropical soils)
+    title: extreme_unusual_properties/Al saturation
+    keywords:
+      - extreme
+      - properties
+      - saturation
+      - unusual
+    slot_uri: MIXS:0000607
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  al_sat_meth:
+    description: Reference or method used in determining Al saturation
+    title: extreme_unusual_properties/Al saturation method
+    keywords:
+      - extreme
+      - method
+      - properties
+      - saturation
+      - unusual
+    slot_uri: MIXS:0000324
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  alkalinity:
+    annotations:
+      Preferred_unit: milliequivalent per liter, milligram per liter
+    description: Alkalinity, the ability of a solution to neutralize acids to the equivalence point of carbonate or bicarbonate
+    title: alkalinity
+    examples:
+      - value: 50 milligram per liter
+    keywords:
+      - alkalinity
+    slot_uri: MIXS:0000421
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  alkalinity_method:
+    description: Method used for alkalinity measurement
+    title: alkalinity method
+    examples:
+      - value: titration
+    keywords:
+      - alkalinity
+      - method
+    slot_uri: MIXS:0000298
+    range: string
+  alkyl_diethers:
+    description: Concentration of alkyl diethers
+    title: alkyl diethers
+    examples:
+      - value: 0.005 mole per liter
+    slot_uri: MIXS:0000490
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  alt:
+    annotations:
+      Preferred_unit: meter
+    description: Heights of objects such as airplanes, space shuttles, rockets, atmospheric balloons and heights of places such as atmospheric layers and clouds. It is used to measure the height of an object which is above the earth's surface. In this context, the altitude measurement is the vertical distance between the earth's surface above sea level and the sampled position in the air
+    title: altitude
+    examples:
+      - value: 100 meter
+    in_subset:
+      - environment
+    slot_uri: MIXS:0000094
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  aminopept_act:
+    annotations:
+      Preferred_unit: mole per liter per hour
+    description: Measurement of aminopeptidase activity
+    title: aminopeptidase activity
+    examples:
+      - value: 0.269 mole per liter per hour
+    slot_uri: MIXS:0000172
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ammonium:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: Concentration of ammonium in the sample
+    title: ammonium
+    examples:
+      - value: 1.5 milligram per liter
+    slot_uri: MIXS:0000427
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  amniotic_fluid_color:
+    description: Specification of the color of the amniotic fluid sample
+    title: amniotic fluid/color
+    slot_uri: MIXS:0000276
+    range: string
+  amount_light:
+    annotations:
+      Preferred_unit: lux, lumens per square meter
+    description: The unit of illuminance and luminous emittance, measuring luminous flux per unit area
+    title: amount of light
+    keywords:
+      - light
+    slot_uri: MIXS:0000140
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ances_data:
+    description: Information about either pedigree or other ancestral information description (e.g. parental variety in case of mutant or selection), e.g. A/3*B (meaning [(A x B) x B] x B)
+    title: ancestral data
+    examples:
+      - value: A/3*B
+    slot_uri: MIXS:0000247
+    range: string
+  anim_water_method:
+    description: Description of the equipment or method used to distribute water to livestock. This field accepts termed listed under water delivery equipment (http://opendata.inra.fr/EOL/EOL_0001653). Multiple terms can be separated by pipes
+    title: animal water delivery method
+    examples:
+      - value: water trough [EOL:0001618]
+    keywords:
+      - animal
+      - delivery
+      - method
+      - water
+    slot_uri: MIXS:0001115
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  animal_am:
+    description: The name(s) (generic or brand) of the antimicrobial(s) given to the food animal within the last 30 days
+    title: food animal antimicrobial
+    examples:
+      - value: tetracycline
+    keywords:
+      - animal
+      - antimicrobial
+      - food
+    slot_uri: MIXS:0001243
+    range: string
+  animal_am_dur:
+    description: The duration of time (days) that the antimicrobial was administered to the food animal
+    title: food animal antimicrobial duration
+    examples:
+      - value: 3 days
+    keywords:
+      - animal
+      - antimicrobial
+      - duration
+      - food
+      - period
+    slot_uri: MIXS:0001244
+    pattern: ^[-+]?[0-9]*\.?[0-9]+ days$
+    structured_pattern:
+      syntax: ^{float} days$
+      interpolated: true
+      partial_match: true
+  animal_am_freq:
+    description: The frequency per day that the antimicrobial was administered to the food animal
+    title: food animal antimicrobial frequency
+    examples:
+      - value: '1.5'
+    keywords:
+      - animal
+      - antimicrobial
+      - food
+      - frequency
+    slot_uri: MIXS:0001245
+    range: float
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  animal_am_route:
+    description: The route by which the antimicrobial is adminstered into the body of the food animal
+    title: food animal antimicrobial route of administration
+    examples:
+      - value: oral-feed
+    keywords:
+      - administration
+      - animal
+      - antimicrobial
+      - food
+      - route
+    slot_uri: MIXS:0001246
+    range: string
+  animal_am_use:
+    description: The prescribed intended use of or the condition treated by the antimicrobial given to the food animal by any route of administration
+    title: food animal antimicrobial intended use
+    examples:
+      - value: shipping fever
+    keywords:
+      - animal
+      - antimicrobial
+      - food
+      - use
+    slot_uri: MIXS:0001247
+    range: string
+  animal_body_cond:
+    description: Body condition scoring is a production management tool used to evaluate overall health and nutritional needs of a food animal. Because there are different scoring systems, this field is restricted to three categories
+    title: food animal body condition
+    examples:
+      - value: under conditioned
+    keywords:
+      - animal
+      - body
+      - condition
+      - food
+    slot_uri: MIXS:0001248
+    range: AnimalBodyCondEnum
+  animal_diet:
+    annotations:
+      Expected_value: text or FOODON_03309997
+    description: If the isolate is from a food animal, the type of diet eaten by the food animal.  Please list the main food staple and the setting, if appropriate.  For a list of acceptable animal feed terms or categories, please see http://www.feedipedia.org.  Multiple terms may apply and can be separated by pipes |Food product for animal covers foods intended for consumption by domesticated animals. Consult http://purl.obolibrary.org/obo/FOODON_03309997. If the proper descriptor is not listed please use text to describe the food type. Multiple terms can be separated by one or more pipes. If the proper descriptor is not listed please use text to describe the food product type
+    title: food animal source diet
+    examples:
+      - value: Hay [FOODON:03301763]
+    keywords:
+      - animal
+      - diet
+      - food
+      - source
+    slot_uri: MIXS:0001130
+    range: string
+    multivalued: true
+  animal_feed_equip:
+    annotations:
+      Expected_value: EOL:0001757
+    description: Description of the feeding equipment used for livestock. This field accepts terms listed under feed delivery (http://opendata.inra.fr/EOL/EOL_0001757). Multiple terms can be separated by pipes
+    title: animal feeding equipment
+    examples:
+      - value: self feeding [EOL:0001645]| straight feed trough [EOL:0001661]
+    keywords:
+      - animal
+      - equipment
+    slot_uri: MIXS:0001113
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  animal_group_size:
+    description: The number of food animals of the same species that are maintained together as a unit, i.e. a herd or flock
+    title: food animal group size
+    examples:
+      - value: '80'
+    keywords:
+      - animal
+      - food
+      - size
+    slot_uri: MIXS:0001129
+    range: integer
+  animal_housing:
+    description: Description of the housing system of the livestock. This field accepts terms listed under terrestrial management housing system (http://opendata.inra.fr/EOL/EOL_0001605)
+    title: animal housing system
+    examples:
+      - value: pen rearing system [EOL:0001636]
+    keywords:
+      - animal
+    slot_uri: MIXS:0001180
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  animal_intrusion:
+    description: Identification of animals intruding on the sample or sample site including invertebrates (such as pests or pollinators) and vertebrates (such as wildlife or domesticated animals). This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy. Multiple terms can be separated by pipes
+    title: animal intrusion near sample source
+    examples:
+      - value: Thripidae [NCBITaxon:45053]
+    keywords:
+      - animal
+      - sample
+      - source
+    slot_uri: MIXS:0001114
+    range: string
+    multivalued: true
+    pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^({termLabel} \[{termID}\])|{integer}$
+      interpolated: true
+      partial_match: true
+  animal_sex:
+    description: The sex and reproductive status of the food animal
+    title: food animal source sex category
+    examples:
+      - value: castrated male
+    keywords:
+      - animal
+      - food
+      - source
+    slot_uri: MIXS:0001249
+    range: AnimalSexEnum
+  annot:
+    annotations:
+      Expected_value: name of tool or pipeline used, or annotation source description
+    description: Tool used for annotation, or for cases where annotation was provided by a community jamboree or model organism database rather than by a specific submitter
+    title: annotation
+    examples:
+      - value: prokka
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000059
+    range: string
+  annual_precpt:
+    annotations:
+      Preferred_unit: millimeter
+    description: The average of all annual precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps
+    title: mean annual precipitation
+    keywords:
+      - mean
+    slot_uri: MIXS:0000644
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  annual_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Mean annual temperature
+    title: mean annual temperature
+    examples:
+      - value: 12.5 degree Celsius
+    keywords:
+      - mean
+      - temperature
+    slot_uri: MIXS:0000642
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  antibiotic_regm:
+    annotations:
+      Expected_value: antibiotic name;antibiotic amount;treatment interval and duration
+      Preferred_unit: milligram
+    description: Information about treatment involving antibiotic administration; should include the name of antibiotic, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple antibiotic regimens
+    title: antibiotic regimen
+    examples:
+      - value: penicillin;5 milligram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+    string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000553
+    multivalued: true
+  api:
+    annotations:
+      Preferred_unit: degrees API
+    description: 'API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g. 31.1   API)'
+    title: API gravity
+    examples:
+      - value: 31.1 API
+    slot_uri: MIXS:0000157
+    range: string
+    required: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  arch_struc:
+    description: An architectural structure is a human-made, free-standing, immobile outdoor construction
+    title: architectural structure
+    examples:
+      - value: shed
+    slot_uri: MIXS:0000774
+    range: ArchStrucEnum
+  area_samp_size:
+    annotations:
+      Expected_value: measurement value
+      Preferred_unit: centimeter
+    description: The total amount or size (volume (ml), mass (g) or area (m2) ) of sample collected
+    title: area sampled size
+    examples:
+      - value: 12 centimeter x 12 centimeter
+    keywords:
+      - area
+      - sample
+      - size
+    string_serialization: '{integer} {unit} x {integer} {unit}'
+    slot_uri: MIXS:0001255
+  aromatics_pc:
+    annotations:
+      Preferred_unit: percent
+    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis method that divides  crude oil  components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+    title: aromatics wt%
+    slot_uri: MIXS:0000133
+    range: string
+    recommended: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{name};{float} {unit}$
+      interpolated: true
+      partial_match: true
+  asphaltenes_pc:
+    annotations:
+      Preferred_unit: percent
+    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis method that divides  crude oil  components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+    title: asphaltenes wt%
+    slot_uri: MIXS:0000135
+    range: string
+    recommended: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{name};{float} {unit}$
+      interpolated: true
+      partial_match: true
+  assembly_name:
+    annotations:
+      Expected_value: name and version of assembly
+    description: Name/version of the assembly provided by the submitter that is used in the genome browsers and in the community
+    title: assembly name
+    examples:
+      - value: HuRef, JCVI_ISG_i3_1.0
+    in_subset:
+      - sequencing
+    string_serialization: '{text} {text}'
+    slot_uri: MIXS:0000057
+  assembly_qual:
+    description: 'The assembly quality category is based on sets of criteria outlined for each assembly quality category. For MISAG/MIMAG; Finished: Single, validated, contiguous sequence per replicon without gaps or ambiguities with a consensus error rate equivalent to Q50 or better. High Quality Draft:Multiple fragments where gaps span repetitive regions. Presence of the large subunit (LSU) RNA, small subunit (SSU) and the presence of 5.8S rRNA or 5S rRNA depending on whether it is a eukaryotic or prokaryotic genome, respectively. Medium Quality Draft:Many fragments with little to no review of assembly other than reporting of standard assembly statistics. Low Quality Draft:Many fragments with little to no review of assembly other than reporting of standard assembly statistics. Assembly statistics include, but are not limited to total assembly size, number of contigs, contig N50/L50, and maximum contig length. For MIUVIG; Finished: Single, validated, contiguous sequence per replicon without gaps or ambiguities, with extensive manual review and editing to annotate putative gene functions and transcriptional units. High-quality draft genome: One or multiple fragments, totaling   90% of the expected genome or replicon sequence or predicted complete. Genome fragment(s): One or multiple fragments, totalling < 90% of the expected genome or replicon sequence, or for which no genome size could be estimated'
+    title: assembly quality
+    examples:
+      - value: High-quality draft genome
+    in_subset:
+      - sequencing
+    keywords:
+      - quality
+    slot_uri: MIXS:0000056
+    range: AssemblyQualEnum
+  assembly_software:
+    description: Tool(s) used for assembly, including version number and parameters
+    title: assembly software
+    examples:
+      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    slot_uri: MIXS:0000058
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{software};{version};{parameters}$
+      interpolated: true
+      partial_match: true
+  associated_resource:
+    annotations:
+      Expected_value: reference to resource
+    description: A related resource that is referenced, cited, or otherwise associated to the sequence
+    title: relevant electronic resources
+    examples:
+      - value: http://www.earthmicrobiome.org/
+    in_subset:
+      - sequencing
+    keywords:
+      - resource
+    string_serialization: '{PMID}|{DOI}|{URL}'
+    slot_uri: MIXS:0000091
+    recommended: true
+    multivalued: true
+  association_duration:
+    annotations:
+      Preferred_unit: year, day, hour
+    description: Time spent in host of the symbiotic organism at the time of sampling; relevant scale depends on symbiotic organism and study
+    title: duration of association with the host
+    keywords:
+      - duration
+      - host
+      - host.
+      - period
+    slot_uri: MIXS:0001299
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  atmospheric_data:
+    annotations:
+      Expected_value: atmospheric data name;measurement value
+    description: Measurement of atmospheric data; can include multiple data
+    title: atmospheric data
+    examples:
+      - value: wind speed;9 knots
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0001097
+    multivalued: true
+  avg_dew_point:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: The average of dew point measures taken at the beginning of every hour over a 24 hour period on the sampling day
+    title: average dew point
+    examples:
+      - value: 25.5 degree Celsius
+    keywords:
+      - average
+    slot_uri: MIXS:0000141
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  avg_occup:
+    description: Daily average occupancy of room. Indicate the number of person(s) daily occupying the sampling room
+    title: average daily occupancy
+    keywords:
+      - average
+    slot_uri: MIXS:0000775
+    range: float
+  avg_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: The average of temperatures taken at the beginning of every hour over a 24 hour period on the sampling day
+    title: average temperature
+    examples:
+      - value: 12.5 degree Celsius
+    keywords:
+      - average
+      - temperature
+    slot_uri: MIXS:0000142
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  bac_prod:
+    annotations:
+      Preferred_unit: milligram per cubic meter per day
+    description: Bacterial production in the water column measured by isotope uptake
+    title: bacterial production
+    examples:
+      - value: 5 milligram per cubic meter per day
+    keywords:
+      - production
+    slot_uri: MIXS:0000683
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  bac_resp:
+    annotations:
+      Preferred_unit: milligram per cubic meter per day, micromole oxygen per liter per hour
+    description: Measurement of bacterial respiration in the water column
+    title: bacterial respiration
+    examples:
+      - value: 300 micromole oxygen per liter per hour
+    slot_uri: MIXS:0000684
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  bacteria_carb_prod:
+    description: Measurement of bacterial carbon production
+    title: bacterial carbon production
+    examples:
+      - value: 2.53 microgram per liter per hour
+    keywords:
+      - carbon
+      - production
+    slot_uri: MIXS:0000173
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  bacterial_density:
+    annotations:
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram of dry weight
+    description: Number of bacteria in sample, as defined by bacteria density (http://purl.obolibrary.org/obo/GENEPIO_0000043)
+    title: bacteria density
+    examples:
+      - value: 10 colony forming units per gram dry weight
+    keywords:
+      - density
+    slot_uri: MIXS:0001194
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  barometric_press:
+    annotations:
+      Preferred_unit: millibar
+    description: Force per unit area exerted against a surface by the weight of air above that surface
+    title: barometric pressure
+    examples:
+      - value: 5 millibar
+    keywords:
+      - pressure
+    slot_uri: MIXS:0000096
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  basin:
+    description: Name of the basin (e.g. Campos)
+    title: basin name
+    examples:
+      - value: Campos
+    slot_uri: MIXS:0000290
+    range: string
+    required: true
+  bathroom_count:
+    description: The number of bathrooms in the building
+    title: bathroom count
+    examples:
+      - value: '1'
+    keywords:
+      - count
+    slot_uri: MIXS:0000776
+    range: integer
+  bedroom_count:
+    description: The number of bedrooms in the building
+    title: bedroom count
+    examples:
+      - value: '2'
+    keywords:
+      - count
+    slot_uri: MIXS:0000777
+    range: integer
+  benzene:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of benzene in the sample
+    title: benzene
+    slot_uri: MIXS:0000153
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  bin_param:
+    description: The parameters that have been applied during the extraction of genomes from metagenomic datasets
+    title: binning parameters
+    examples:
+      - value: coverage
+        description: was 'coverage and kmer'
+      - value: kmer
+        description: was coverage and kmer
+    in_subset:
+      - sequencing
+    keywords:
+      - parameter
+    slot_uri: MIXS:0000077
+    range: BinParamEnum
+  bin_software:
+    annotations:
+      Expected_value: names and versions of software(s) used
+    description: Tool(s) used for the extraction of genomes from metagenomic datasets, where possible include a product ID (PID) of the tool(s) used
+    title: binning software
+    examples:
+      - value: MetaCluster-TA (RRID:SCR_004599), MaxBin (biotools:maxbin)
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    string_serialization: '{software};{version}{PID}'
+    slot_uri: MIXS:0000078
+  biochem_oxygen_dem:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: Amount of dissolved oxygen needed by aerobic biological organisms in a body of water to break down organic material present in a given water sample at certain temperature over a specific time period
+    title: biochemical oxygen demand
+    keywords:
+      - oxygen
+    slot_uri: MIXS:0000653
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  biocide:
+    annotations:
+      Expected_value: name;name;timestamp
+    description: List of biocides (commercial name of product and supplier) and date of administration
+    title: biocide administration
+    examples:
+      - value: ALPHA 1427;Baker Hughes;2008-01-23
+    keywords:
+      - administration
+    string_serialization: '{text};{text};{timestamp}'
+    slot_uri: MIXS:0001011
+    recommended: true
+  biocide_admin_method:
+    annotations:
+      Expected_value: measurement value;frequency;duration;duration
+      Preferred_unit: milligram per liter
+    description: Method of biocide administration (dose, frequency, duration, time elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr; 3 days)
+    title: biocide administration method
+    keywords:
+      - administration
+      - method
+    string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration}'
+    slot_uri: MIXS:0000456
+    recommended: true
+  biocide_used:
+    annotations:
+      Expected_value: commercial name of biocide, active ingredient in biocide or class of biocide
+    description: Substance intended for preventing, neutralizing, destroying, repelling, or mitigating the effects of any pest or microorganism; that inhibits the growth, reproduction, and activity of organisms, including fungal cells; decreases the number of fungi or pests present; deters microbial growth and degradation of other ingredients in the formulation. Indicate the biocide used on the location where the sample was taken. Multiple terms can be separated by pipes
+    title: biocide
+    examples:
+      - value: Quaternary ammonium compound|SterBac
+    slot_uri: MIXS:0001258
+    range: string
+    multivalued: true
+  biol_stat:
+    description: The level of genome modification
+    title: biological status
+    examples:
+      - value: natural
+    keywords:
+      - status
+    slot_uri: MIXS:0000858
+    range: BiolStatEnum
+  biomass:
+    annotations:
+      Expected_value: biomass type;measurement value
+      Preferred_unit: ton, kilogram, gram
+    description: Amount of biomass; should include the name for the part of biomass measured, e.g. Microbial, total. Can include multiple measurements
+    title: biomass
+    examples:
+      - value: total;20 gram
+    keywords:
+      - biomass
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000174
+    multivalued: true
+  biotic_regm:
+    description: Information about treatment(s) involving use of biotic factors, such as bacteria, viruses or fungi
+    title: biotic regimen
+    examples:
+      - value: sample inoculated with Rhizobium spp. Culture
+    keywords:
+      - regimen
+    slot_uri: MIXS:0001038
+    range: string
+    multivalued: true
+  biotic_relationship:
+    description: Description of relationship(s) between the subject organism and other organism(s) it is associated with. E.g., parasite on species X; mutualist with species Y. The target organism is the subject of the relationship, and the other organism(s) is the object
+    title: observed biotic relationship
+    examples:
+      - value: free living
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - observed
+      - relationship
+    slot_uri: MIXS:0000028
+    range: BioticRelationshipEnum
+  birth_control:
+    annotations:
+      Expected_value: medication name
+    description: Specification of birth control medication used
+    title: birth control
+    slot_uri: MIXS:0000286
+    range: string
+  bishomohopanol:
+    annotations:
+      Preferred_unit: microgram per liter, microgram per gram
+    description: Concentration of bishomohopanol
+    title: bishomohopanol
+    examples:
+      - value: 14 microgram per liter
+    slot_uri: MIXS:0000175
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  blood_blood_disord:
+    description: History of blood disorders; can include multiple disorders.  The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, hematopoietic system disease (https://disease-ontology.org/?id=DOID:74)
+    title: blood/blood disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000271
+    range: string
+    multivalued: true
+  blood_press_diast:
+    annotations:
+      Preferred_unit: millimeter mercury
+    description: Resting diastolic blood pressure, measured as mm mercury
+    title: host blood pressure diastolic
+    keywords:
+      - host
+      - host.
+      - pressure
+    slot_uri: MIXS:0000258
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  blood_press_syst:
+    annotations:
+      Preferred_unit: millimeter mercury
+    description: Resting systolic blood pressure, measured as mm mercury
+    title: host blood pressure systolic
+    keywords:
+      - host
+      - host.
+      - pressure
+    slot_uri: MIXS:0000259
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  bromide:
+    annotations:
+      Preferred_unit: parts per million
+    description: Concentration of bromide
+    title: bromide
+    examples:
+      - value: 0.05 parts per million
+    slot_uri: MIXS:0000176
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  build_docs:
+    description: The building design, construction and operation documents
+    title: design, construction, and operation documents
+    examples:
+      - value: maintenance plans
+    keywords:
+      - documents
+    slot_uri: MIXS:0000787
+    range: BuildDocsEnum
+  build_occup_type:
+    description: The primary function for which a building or discrete part of a building is intended to be used
+    title: building occupancy type
+    examples:
+      - value: market
+    keywords:
+      - type
+    slot_uri: MIXS:0000761
+    range: BuildOccupTypeEnum
+    required: true
+    multivalued: true
+  building_setting:
+    description: A location (geography) where a building is set
+    title: building setting
+    examples:
+      - value: rural
+    slot_uri: MIXS:0000768
+    range: BuildingSettingEnum
+    required: true
+  built_struc_age:
+    annotations:
+      Preferred_unit: year
+    description: The age of the built structure since construction
+    title: built structure age
+    examples:
+      - value: 15 years
+    keywords:
+      - age
+    slot_uri: MIXS:0000145
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  built_struc_set:
+    description: The characterization of the location of the built structure as high or low human density
+    title: built structure setting
+    examples:
+      - value: rural
+    slot_uri: MIXS:0000778
+    range: BuiltStrucSetEnum
+  built_struc_type:
+    description: A physical structure that is a body or assemblage of bodies in space to form a system capable of supporting loads
+    title: built structure type
+    keywords:
+      - type
+    slot_uri: MIXS:0000721
+    range: string
+  calcium:
+    annotations:
+      Preferred_unit: milligram per liter, micromole per liter, parts per million
+    description: Concentration of calcium in the sample
+    title: calcium
+    examples:
+      - value: 0.2 micromole per liter
+    slot_uri: MIXS:0000432
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  carb_dioxide:
+    annotations:
+      Preferred_unit: micromole per liter, parts per million
+    description: Carbon dioxide (gas) amount or concentration at the time of sampling
+    title: carbon dioxide
+    examples:
+      - value: 410 parts per million
+    keywords:
+      - carbon
+    slot_uri: MIXS:0000097
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  carb_monoxide:
+    annotations:
+      Preferred_unit: micromole per liter, parts per million
+    description: Carbon monoxide (gas) amount or concentration at the time of sampling
+    title: carbon monoxide
+    examples:
+      - value: 0.1 parts per million
+    keywords:
+      - carbon
+    slot_uri: MIXS:0000098
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  carb_nitro_ratio:
+    annotations:
+      Expected_value: measurement value
+    description: Ratio of amount or concentrations of carbon to nitrogen
+    title: carbon/nitrogen ratio
+    examples:
+      - value: '0.417361111'
+    keywords:
+      - carbon
+      - nitrogen
+      - ratio
+    string_serialization: '{float}:{float}'
+    slot_uri: MIXS:0000310
+    range: float
+  ceil_area:
+    annotations:
+      Preferred_unit: square meter
+    description: The area of the ceiling space within the room
+    title: ceiling area
+    examples:
+      - value: 25 square meter
+    keywords:
+      - area
+      - ceiling
+    slot_uri: MIXS:0000148
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ceil_cond:
+    description: The physical condition of the ceiling at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas
+    title: ceiling condition
+    examples:
+      - value: damaged
+    keywords:
+      - ceiling
+      - condition
+    slot_uri: MIXS:0000779
+    range: DamagedEnum
+  ceil_finish_mat:
+    description: The type of material used to finish a ceiling
+    title: ceiling finish material
+    examples:
+      - value: stucco
+    keywords:
+      - ceiling
+      - material
+    slot_uri: MIXS:0000780
+    range: CeilFinishMatEnum
+  ceil_struc:
+    description: The construction format of the ceiling
+    title: ceiling structure
+    examples:
+      - value: concrete
+    keywords:
+      - ceiling
+    slot_uri: MIXS:0000782
+    range: CeilStrucEnum
+  ceil_texture:
+    description: The feel, appearance, or consistency of a ceiling surface
+    title: ceiling texture
+    examples:
+      - value: popcorn
+    keywords:
+      - ceiling
+      - texture
+    slot_uri: MIXS:0000783
+    range: CeilingWallTextureEnum
+  ceil_thermal_mass:
+    annotations:
+      Preferred_unit: joule per degree Celsius
+    description: The ability of the ceiling to provide inertia against temperature fluctuations. Generally this means concrete that is exposed. A metal deck that supports a concrete slab will act thermally as long as it is exposed to room air flow
+    title: ceiling thermal mass
+    keywords:
+      - ceiling
+      - mass
+    slot_uri: MIXS:0000143
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ceil_type:
+    description: The type of ceiling according to the ceiling's appearance or construction
+    title: ceiling type
+    examples:
+      - value: coffered
+    keywords:
+      - ceiling
+      - type
+    slot_uri: MIXS:0000784
+    range: CeilTypeEnum
+  ceil_water_mold:
+    description: Signs of the presence of mold or mildew on the ceiling
+    title: ceiling signs of water/mold
+    examples:
+      - value: presence of mold visible
+    keywords:
+      - ceiling
+    slot_uri: MIXS:0000781
+    range: MoldVisibilityEnum
+  chem_administration:
+    annotations:
+      Expected_value: CHEBI;timestamp
+    description: List of chemical compounds administered to the host or site where sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can include multiple compounds. For chemical entities of biological interest ontology (chebi) (v 163), http://purl.bioontology.org/ontology/chebi
+    title: chemical administration
+    examples:
+      - value: agar [CHEBI:2509];2018-05-11T20:00Z
+    keywords:
+      - administration
+    string_serialization: '{termLabel} [{termID}];{timestamp}'
+    slot_uri: MIXS:0000751
+    multivalued: true
+  chem_mutagen:
+    annotations:
+      Expected_value: mutagen name;mutagen amount;treatment interval and duration
+      Preferred_unit: milligram per liter
+    description: Treatment involving use of mutagens; should include the name of mutagen, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple mutagen regimens
+    title: chemical mutagen
+    examples:
+      - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000555
+    multivalued: true
+  chem_oxygen_dem:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: A measure of the capacity of water to consume oxygen during the decomposition of organic matter and the oxidation of inorganic chemicals such as ammonia and nitrite
+    title: chemical oxygen demand
+    keywords:
+      - oxygen
+    slot_uri: MIXS:0000656
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  chem_treat_method:
+    annotations:
+      Expected_value: measurement value;frequency;duration;duration
+      Preferred_unit: milligram per liter
+    description: Method of chemical administration(dose, frequency, duration, time elapsed between administration and sampling) (e.g. 50 mg/l; twice a week; 1 hr; 0 days)
+    title: chemical treatment method
+    keywords:
+      - method
+      - treatment
+    string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration};{duration}'
+    slot_uri: MIXS:0000457
+  chem_treatment:
+    annotations:
+      Expected_value: name;name;timestamp
+    description: List of chemical compounds administered upstream the sampling location where sampling occurred (e.g. Glycols, H2S scavenger, corrosion and scale inhibitors, demulsifiers, and other production chemicals etc.). The commercial name of the product and name of the supplier should be provided. The date of administration should also be included
+    title: chemical treatment
+    examples:
+      - value: ACCENT 1125;DOW;2010-11-17
+    keywords:
+      - treatment
+    string_serialization: '{text};{text};{timestamp}'
+    slot_uri: MIXS:0001012
+  chimera_check:
+    description: Tool(s) used for chimera checking, including version number and parameters, to discover and remove chimeric sequences. A chimeric sequence is comprised of two or more phylogenetically distinct parent sequences
+    title: chimera check software
+    examples:
+      - value: uchime;v4.1;default parameters
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    slot_uri: MIXS:0000052
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{software};{version};{parameters}$
+      interpolated: true
+      partial_match: true
+  chloride:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of chloride in the sample
+    title: chloride
+    examples:
+      - value: 5000 milligram per liter
+    slot_uri: MIXS:0000429
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  chlorophyll:
+    annotations:
+      Preferred_unit: milligram per cubic meter, microgram per liter
+    description: Concentration of chlorophyll
+    title: chlorophyll
+    examples:
+      - value: 5 milligram per cubic meter
+    slot_uri: MIXS:0000177
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  climate_environment:
+    description: Treatment involving an exposure to a particular climate; treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple climates
+    title: climate environment
+    examples:
+      - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - environment
+    slot_uri: MIXS:0001040
+    range: string
+    multivalued: true
+  coll_site_geo_feat:
+    annotations:
+      Expected_value: ENVO:00000002 or ENVO:00000070
+    description: 'Text or terms that describe the geographic feature where the food sample was obtained by the researcher. This field accepts selected terms listed under the following ontologies: anthropogenic geographic feature (http://purl.obolibrary.org/obo/ENVO_00000002), for example agricultural fairground [ENVO:01000986]; garden [ENVO:00000011} or any of its subclasses; market [ENVO:01000987]; water well [ENVO:01000002]; or human construction (http://purl.obolibrary.org/obo/ENVO_00000070)'
+    title: collection site geographic feature
+    examples:
+      - value: farm [ENVO:00000078]
+    keywords:
+      - feature
+      - geographic
+      - site
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001183
+    required: true
+  collection_date:
+    description: 'The time of sampling, either as an instance (single point in time) or interval. In case no exact time is available, the date/time can be right truncated i.e. all of these are valid times: 2008-01-23T19:23:10+00:00; 2008-01-23T19:23:10; 2008-01-23; 2008-01; 2008; Except: 2008-01; 2008 all are ISO8601 compliant'
+    title: collection date
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    in_subset:
+      - environment
+    keywords:
+      - date
+    slot_uri: MIXS:0000011
+    range: datetime
+    required: true
+  compl_appr:
+    annotations:
+      Expected_value: text
+    description: The approach used to determine the completeness of a given genomic assembly, which would typically make use of a set of conserved marker genes or a closely related reference genome. For UViG completeness, include reference genome or group used, and contig feature suggesting a complete genome
+    title: completeness approach
+    examples:
+      - value: other
+        description: was other <colon> UViG length compared to the average length of reference genomes from the P22virus genus (NCBI RefSeq v83)
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000071
+    range: ComplApprEnum
+  compl_score:
+    annotations:
+      Expected_value: quality;percent completeness
+    description: 'Completeness score is typically based on either the fraction of markers found as compared to a database or the percent of a genome found as compared to a closely related reference genome. High Quality Draft: >90%, Medium Quality Draft: >50%, and Low Quality Draft: < 50% should have the indicated completeness scores'
+    title: completeness score
+    examples:
+      - value: med;60%
+    in_subset:
+      - sequencing
+    keywords:
+      - score
+    string_serialization: '[high|med|low];{percentage}'
+    slot_uri: MIXS:0000069
+  compl_software:
+    annotations:
+      Expected_value: names and versions of software(s) used
+    description: Tools used for completion estimate, i.e. checkm, anvi'o, busco
+    title: completeness software
+    examples:
+      - value: checkm
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    string_serialization: '{software};{version}'
+    slot_uri: MIXS:0000070
+  conduc:
+    annotations:
+      Preferred_unit: milliSiemens per centimeter
+    description: Electrical conductivity of water
+    title: conductivity
+    examples:
+      - value: 10 milliSiemens per centimeter
+    slot_uri: MIXS:0000692
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  cons_food_stor_dur:
+    annotations:
+      Preferred_unit: hours or days
+    description: The storage duration of the food commodity by the consumer, prior to onset of illness or sample collection.  Indicate the timepoint written in ISO 8601 format
+    title: food stored by consumer (storage duration)
+    examples:
+      - value: P5D
+    keywords:
+      - consumer
+      - duration)
+      - food
+      - storage
+    slot_uri: MIXS:0001195
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  cons_food_stor_temp:
+    annotations:
+      Expected_value: text or measurement value
+      Preferred_unit: degree Celsius
+    description: Temperature at which food commodity was stored by the consumer, prior to onset of illness or sample collection
+    title: food stored by consumer (storage temperature)
+    examples:
+      - value: 4 degree Celsius
+    keywords:
+      - consumer
+      - food
+      - storage
+      - temperature
+    string_serialization: '{float} {unit}|{text}'
+    slot_uri: MIXS:0001196
+  cons_purch_date:
+    description: The date a food product was purchased by consumer
+    title: purchase date
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    keywords:
+      - date
+    slot_uri: MIXS:0001197
+    range: datetime
+  cons_qty_purchased:
+    description: The quantity of food purchased by consumer
+    title: quantity purchased
+    examples:
+      - value: 5 cans
+    keywords:
+      - quantity
+    slot_uri: MIXS:0001198
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  contam_score:
+    description: 'The contamination score is based on the fraction of single-copy genes that are observed more than once in a query genome. The following scores are acceptable for; High Quality Draft: < 5%, Medium Quality Draft: < 10%, Low Quality Draft: < 10%. Contamination must be below 5% for a SAG or MAG to be deposited into any of the public databases'
+    title: contamination score
+    examples:
+      - value: '0.01'
+    in_subset:
+      - sequencing
+    keywords:
+      - score
+    slot_uri: MIXS:0000072
+    range: float
+  contam_screen_input:
+    description: The type of sequence data used as input
+    title: contamination screening input
+    examples:
+      - value: contigs
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000005
+    range: ContamScreenInputEnum
+  contam_screen_param:
+    annotations:
+      Expected_value: enumeration;value or name
+    description: Specific parameters used in the decontamination sofware, such as reference database, coverage, and kmers. Combinations of these parameters may also be used, i.e. kmer and coverage, or reference database and kmer
+    title: contamination screening parameters
+    examples:
+      - value: kmer
+    in_subset:
+      - sequencing
+    keywords:
+      - parameter
+    string_serialization: '[ref db|kmer|coverage|combination];{text|integer}'
+    slot_uri: MIXS:0000073
+  cool_syst_id:
+    description: The cooling system identifier
+    title: cooling system identifier
+    examples:
+      - value: '12345'
+    keywords:
+      - identifier
+    slot_uri: MIXS:0000785
+    range: integer
+  crop_rotation:
+    annotations:
+      Expected_value: crop rotation status;schedule
+    description: Whether or not crop is rotated, and if yes, rotation schedule
+    title: history/crop rotation
+    examples:
+      - value: yes;R2/2017-01-01/2018-12-31/P6M
+    keywords:
+      - history
+    slot_uri: MIXS:0000318
+  crop_yield:
+    annotations:
+      Preferred_unit: kilogram per metre square
+    description: Amount of crop produced per unit or area of land
+    title: crop yield
+    examples:
+      - value: 570 kilogram per metre square
+    keywords:
+      - crop
+    slot_uri: MIXS:0001116
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  cult_isol_date:
+    description: The datetime marking the end of a process in which a sample yields a positive result for the target microbial analyte(s) in the form of an isolated colony or colonies
+    title: culture isolation date
+    examples:
+      - value: '2018-05-11T10:00:00+01:00'
+    keywords:
+      - culture
+      - date
+      - isolation
+    slot_uri: MIXS:0001181
+    range: datetime
+  cult_result:
+    description: Any result of a bacterial culture experiment reported as a binary assessment such as positive/negative, active/inactive
+    title: culture result
+    examples:
+      - value: positive
+    keywords:
+      - culture
+    slot_uri: MIXS:0001117
+    range: CultResultEnum
+  cult_result_org:
+    description: Taxonomic information about the cultured organism(s)
+    title: culture result organism
+    examples:
+      - value: Listeria monocytogenes [NCIT:C86502]
+    keywords:
+      - culture
+      - organism
+    slot_uri: MIXS:0001118
+    range: string
+    multivalued: true
+    pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^({termLabel} \[{termID}\])|{integer}$
+      interpolated: true
+      partial_match: true
+  cult_root_med:
+    annotations:
+      Expected_value: name, PMID,DOI or url
+    description: Name or reference for the hydroponic or in vitro culture rooting medium; can be the name of a commonly used medium or reference to a specific medium, e.g. Murashige and Skoog medium. If the medium has not been formally published, use the rooting medium descriptors
+    title: culture rooting medium
+    examples:
+      - value: http://himedialabs.com/TD/PT158.pdf
+    keywords:
+      - culture
+    string_serialization: '{text}|{PMID}|{DOI}|{URL}'
+    slot_uri: MIXS:0001041
+  cult_target:
+    annotations:
+      Expected_value: NCIT:C14250 or NCBI taxid or culture independent
+    description: The target microbial analyte in terms of investigation scope. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
+    title: culture target microbial analyte
+    examples:
+      - value: Listeria monocytogenes [NCIT:C86502]
+    keywords:
+      - culture
+      - microbial
+      - target
+    string_serialization: '{termLabel} [{termID}]|{integer}'
+    slot_uri: MIXS:0001119
+    multivalued: true
+  cur_land_use:
+    annotations:
+      Expected_value: enumeration
+    description: Present state of sample site
+    title: current land use
+    examples:
+      - value: conifers
+    keywords:
+      - land
+      - use
+    string_serialization: '[cities|farmstead|industrial areas|roads/railroads|rock|sand|gravel|mudflats|salt flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste areas|small grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands (grass,sedges,rushes)|tundra (mosses,lichens)|rangeland|pastureland (grasslands used for livestock grazing)|hayland|meadows (grasses,alfalfa,fescue,bromegrass,timothy)|shrub land (e.g. mesquite,sage-brush,creosote bush,shrub oak,eucalyptus)|successional shrub land (tree saplings,hazels,sumacs,chokecherry,shrub dogwoods,blackberries)|shrub crops (blueberries,nursery ornamentals,filberts)|vine crops (grapes)|conifers (e.g. pine,spruce,fir,cypress)|hardwoods (e.g. oak,hickory,elm,aspen)|intermixed hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen forest receiving >406 cm annual rainfall)|swamp (permanent or semi-permanent water body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery trees)]'
+    slot_uri: MIXS:0001080
+  cur_vegetation:
+    annotations:
+      Expected_value: current vegetation type
+    description: Vegetation classification from one or more standard classification systems, or agricultural crop
+    title: current vegetation
+    keywords:
+      - vegetation
+    slot_uri: MIXS:0000312
+    range: string
+  cur_vegetation_meth:
+    description: Reference or method used in vegetation classification
+    title: current vegetation method
+    keywords:
+      - method
+      - vegetation
+    slot_uri: MIXS:0000314
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  date_extr_weath:
+    description: Date of unusual weather events that may have affected microbial populations. Multiple terms can be separated by pipes, listed in reverse chronological order
+    title: extreme weather date
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    keywords:
+      - date
+      - extreme
+      - weather
+    slot_uri: MIXS:0001142
+    range: datetime
+    multivalued: true
+  date_last_rain:
+    description: The date of the last time it rained
+    title: date last rain
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    keywords:
+      - date
+      - rain
+    slot_uri: MIXS:0000786
+    range: datetime
+  decontam_software:
+    annotations:
+      Expected_value: enumeration
+    description: Tool(s) used in contamination screening
+    title: decontamination software
+    examples:
+      - value: anvi'o
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    string_serialization: '[checkm/refinem|anvi''o|prodege|bbtools:decontaminate.sh|acdc|combination]'
+    slot_uri: MIXS:0000074
+  density:
+    annotations:
+      Preferred_unit: gram per cubic meter, gram per cubic centimeter
+    description: Density of the sample, which is its mass per unit volume (aka volumetric mass density)
+    title: density
+    examples:
+      - value: 1000 kilogram per cubic meter
+    keywords:
+      - density
+    slot_uri: MIXS:0000435
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  depos_env:
+    description: Main depositional environment (https://en.wikipedia.org/wiki/Depositional_environment). If "other" is specified, please propose entry in "additional info" field
+    title: depositional environment
+    keywords:
+      - environment
+    slot_uri: MIXS:0000992
+    range: DeposEnvEnum
+    recommended: true
+  depth:
+    annotations:
+      Preferred_unit: meter
+    description: The vertical distance below local surface. For sediment or soil samples depth is measured from sediment or soil surface, respectively. Depth can be reported as an interval for subsurface samples
+    title: depth
+    in_subset:
+      - environment
+    keywords:
+      - depth
+    slot_uri: MIXS:0000018
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  dermatology_disord:
+    description: History of dermatology disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, skin disease (https://disease-ontology.org/?id=DOID:37)
+    title: dermatology disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000284
+    range: string
+    multivalued: true
+  detec_type:
+    annotations:
+      Expected_value: enumeration
+    description: Type of UViG detection
+    title: detection type
+    examples:
+      - value: independent sequence (UViG)
+    in_subset:
+      - sequencing
+    keywords:
+      - type
+    string_serialization: '[independent sequence (UViG)|provirus (UpViG)]'
+    slot_uri: MIXS:0000084
+  dew_point:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: The temperature to which a given parcel of humid air must be cooled, at constant barometric pressure, for water vapor to condense into water
+    title: dew point
+    examples:
+      - value: 22 degree Celsius
+    slot_uri: MIXS:0000129
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diet_last_six_month:
+    annotations:
+      Expected_value: diet change;current diet
+    description: Specification of major diet changes in the last six months, if yes the change should be specified
+    title: major diet change in last six months
+    examples:
+      - value: yes;vegetarian diet
+    keywords:
+      - diet
+      - months
+    string_serialization: '{boolean};{text}'
+    slot_uri: MIXS:0000266
+  dietary_claim_use:
+    annotations:
+      Expected_value: FOODON:03510023
+    description: These descriptors are used either for foods intended for special dietary use as defined in 21 CFR 105 or for foods that have special characteristics indicated in the name or labeling. This field accepts terms listed under dietary claim or use (http://purl.obolibrary.org/obo/FOODON_03510023). Multiple terms can be separated by one or more pipes, but please consider limiting this list to the most prominent dietary claim or use
+    title: dietary claim or use
+    examples:
+      - value: No preservatives [FOODON:03510113]
+    keywords:
+      - diet
+      - use
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001199
+    multivalued: true
+  diether_lipids:
+    annotations:
+      Expected_value: diether lipid name;measurement value
+      Preferred_unit: nanogram per liter
+    description: Concentration of diether lipids; can include multiple types of diether lipids
+    title: diether lipids
+    examples:
+      - value: 0.2 nanogram per liter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000178
+    multivalued: true
+  diss_carb_dioxide:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter
+    description: Concentration of dissolved carbon dioxide in the sample or liquid portion of the sample
+    title: dissolved carbon dioxide
+    examples:
+      - value: 5 milligram per liter
+    keywords:
+      - carbon
+      - dissolved
+    slot_uri: MIXS:0000436
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_hydrogen:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Concentration of dissolved hydrogen
+    title: dissolved hydrogen
+    examples:
+      - value: 0.3 micromole per liter
+    keywords:
+      - dissolved
+    slot_uri: MIXS:0000179
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_inorg_carb:
+    annotations:
+      Preferred_unit: microgram per liter, milligram per liter, parts per million
+    description: Dissolved inorganic carbon concentration in the sample, typically measured after filtering the sample using a 0.45 micrometer filter
+    title: dissolved inorganic carbon
+    examples:
+      - value: 2059 micromole per kilogram
+    keywords:
+      - carbon
+      - dissolved
+      - inorganic
+    slot_uri: MIXS:0000434
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_inorg_nitro:
+    annotations:
+      Preferred_unit: microgram per liter, micromole per liter
+    description: Concentration of dissolved inorganic nitrogen
+    title: dissolved inorganic nitrogen
+    examples:
+      - value: 761 micromole per liter
+    keywords:
+      - dissolved
+      - inorganic
+      - nitrogen
+    slot_uri: MIXS:0000698
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_inorg_phosp:
+    description: Concentration of dissolved inorganic phosphorus in the sample
+    title: dissolved inorganic phosphorus
+    examples:
+      - value: 56.5 micromole per liter
+    keywords:
+      - dissolved
+      - inorganic
+      - phosphorus
+    slot_uri: MIXS:0000106
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_iron:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: Concentration of dissolved iron in the sample
+    title: dissolved iron
+    keywords:
+      - dissolved
+    slot_uri: MIXS:0000139
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_org_carb:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter
+    description: Concentration of dissolved organic carbon in the sample, liquid portion of the sample, or aqueous phase of the fluid
+    title: dissolved organic carbon
+    examples:
+      - value: 197 micromole per liter
+    keywords:
+      - carbon
+      - dissolved
+      - organic
+    slot_uri: MIXS:0000433
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_org_nitro:
+    description: Dissolved organic nitrogen concentration measured as; total dissolved nitrogen - NH4 - NO3 - NO2
+    title: dissolved organic nitrogen
+    examples:
+      - value: 0.05 micromole per liter
+    keywords:
+      - dissolved
+      - nitrogen
+      - organic
+    slot_uri: MIXS:0000162
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_oxygen:
+    annotations:
+      Preferred_unit: micromole per kilogram, milligram per liter
+    description: Concentration of dissolved oxygen
+    title: dissolved oxygen
+    examples:
+      - value: 175 micromole per kilogram
+    keywords:
+      - dissolved
+      - oxygen
+    slot_uri: MIXS:0000119
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  diss_oxygen_fluid:
+    annotations:
+      Preferred_unit: micromole per kilogram, milligram per liter
+    description: Concentration of dissolved oxygen in the oil field produced fluids as it contributes to oxgen-corrosion and microbial activity (e.g. Mic)
+    title: dissolved oxygen in fluids
+    keywords:
+      - dissolved
+      - oxygen
+    slot_uri: MIXS:0000438
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  dominant_hand:
+    description: Dominant hand of the subject
+    title: dominant hand
+    examples:
+      - value: right
+    slot_uri: MIXS:0000944
+    range: DominantHandEnum
+  door_comp_type:
+    description: The composite type of the door
+    title: door type, composite
+    examples:
+      - value: revolving
+    keywords:
+      - door
+      - type
+    slot_uri: MIXS:0000795
+    range: DoorCompTypeEnum
+  door_cond:
+    description: The phsical condition of the door
+    title: door condition
+    examples:
+      - value: new
+    keywords:
+      - condition
+      - door
+    slot_uri: MIXS:0000788
+    range: DamagedRupturedEnum
+  door_direct:
+    description: The direction the door opens
+    title: door direction of opening
+    examples:
+      - value: inward
+    keywords:
+      - direction
+      - door
+    slot_uri: MIXS:0000789
+    range: DoorDirectEnum
+  door_loc:
+    description: The relative location of the door in the room
+    title: door location
+    examples:
+      - value: north
+    keywords:
+      - door
+      - location
+    slot_uri: MIXS:0000790
+    range: CompassDirections8Enum
+  door_mat:
+    description: The material the door is composed of
+    title: door material
+    examples:
+      - value: wood
+    keywords:
+      - door
+      - material
+    slot_uri: MIXS:0000791
+    range: DoorMatEnum
+  door_move:
+    description: The type of movement of the door
+    title: door movement
+    examples:
+      - value: swinging
+    keywords:
+      - door
+    slot_uri: MIXS:0000792
+    range: DoorMoveEnum
+  door_size:
+    annotations:
+      Preferred_unit: square meter
+    description: The size of the door
+    title: door area or size
+    examples:
+      - value: 2.5 square meter
+    keywords:
+      - area
+      - door
+      - size
+    slot_uri: MIXS:0000158
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  door_type:
+    description: The type of door material
+    title: door type
+    examples:
+      - value: wooden
+    keywords:
+      - door
+      - type
+    slot_uri: MIXS:0000794
+    range: DoorTypeEnum
+  door_type_metal:
+    description: The type of metal door
+    title: door type, metal
+    examples:
+      - value: hollow
+    keywords:
+      - door
+      - type
+    slot_uri: MIXS:0000796
+    range: DoorTypeMetalEnum
+  door_type_wood:
+    annotations:
+      Expected_value: enumeration
+    description: The type of wood door
+    title: door type, wood
+    examples:
+      - value: battened
+    keywords:
+      - door
+      - type
+    string_serialization: '[bettened and ledged|battened|ledged and braced|battened|ledged and framed|battened|ledged, braced and frame|framed and paneled|glashed or sash|flush|louvered|wire gauged]'
+    slot_uri: MIXS:0000797
+  door_water_mold:
+    description: Signs of the presence of mold or mildew on a door
+    title: door signs of water/mold
+    examples:
+      - value: presence of mold visible
+    keywords:
+      - door
+    slot_uri: MIXS:0000793
+    range: MoldVisibilityEnum
+  douche:
+    description: Date of most recent douche
+    title: douche
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    slot_uri: MIXS:0000967
+    range: datetime
+  down_par:
+    annotations:
+      Preferred_unit: microEinstein per square meter per second, microEinstein per square centimeter per second
+    description: Visible waveband radiance and irradiance measurements in the water column
+    title: downward PAR
+    examples:
+      - value: 28.71 microEinstein per square meter per second
+    slot_uri: MIXS:0000703
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  drainage_class:
+    description: Drainage classification from a standard system such as the USDA system
+    title: drainage classification
+    examples:
+      - value: well
+    keywords:
+      - classification
+    slot_uri: MIXS:0001085
+    range: DrainageClassEnum
+  drawings:
+    description: The buildings architectural drawings; if design is chosen, indicate phase-conceptual, schematic, design development, and construction documents
+    title: drawings
+    examples:
+      - value: sketch
+    keywords:
+      - drawings
+    slot_uri: MIXS:0000798
+    range: DrawingsEnum
+  drug_usage:
+    annotations:
+      Expected_value: drug name;frequency
+    description: Any drug used by subject and the frequency of usage; can include multiple drugs used
+    title: drug usage
+    examples:
+      - value: Lipitor;2/day
+    keywords:
+      - drug
+      - use
+    string_serialization: '{text};{integer}/[year|month|week|day|hour]'
+    slot_uri: MIXS:0000894
+    multivalued: true
+  efficiency_percent:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Percentage of volatile solids removed from the anaerobic digestor
+    title: efficiency percent
+    keywords:
+      - percent
+    slot_uri: MIXS:0000657
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  elev:
+    annotations:
+      Preferred_unit: meter
+    description: Elevation of the sampling site is its height above a fixed reference point, most commonly the mean sea level. Elevation is mainly used when referring to points on the earth's surface, while altitude is used for points above the surface, such as an aircraft in flight or a spacecraft in orbit
+    title: elevation
+    examples:
+      - value: 100 meter
+    in_subset:
+      - environment
+    keywords:
+      - elevation
+    slot_uri: MIXS:0000093
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  elevator:
+    description: The number of elevators within the built structure
+    title: elevator count
+    examples:
+      - value: '2'
+    keywords:
+      - count
+    slot_uri: MIXS:0000799
+    range: integer
+  emulsions:
+    annotations:
+      Expected_value: emulsion name;measurement value
+      Preferred_unit: gram per liter
+    description: Amount or concentration of substances such as paints, adhesives, mayonnaise, hair colorants, emulsified oils, etc.; can include multiple emulsion types
+    title: emulsions
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000660
+    multivalued: true
+  encoded_traits:
+    annotations:
+      Expected_value: 'for plasmid: antibiotic resistance; for phage: converting genes'
+    description: Should include key traits like antibiotic resistance or xenobiotic degradation phenotypes for plasmids, converting genes for phage
+    title: encoded traits
+    examples:
+      - value: beta-lactamase class A
+    in_subset:
+      - nucleic acid sequence source
+    slot_uri: MIXS:0000034
+    range: string
+  enrichment_protocol:
+    description: The microbiological workflow or protocol followed to test for the presence or enumeration of the target microbial analyte(s). Please provide a PubMed or DOI reference for published protocols
+    title: enrichment protocol
+    examples:
+      - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
+    keywords:
+      - enrichment
+      - protocol
+    slot_uri: MIXS:0001177
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}|{text}$
+      interpolated: true
+      partial_match: true
+  env_broad_scale:
+    description: 'Report the major environmental system the sample or specimen came from. The system(s) identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. in the desert or a rainforest). We recommend using subclasses of EnvO s biome class:  http://purl.obolibrary.org/obo/ENVO_00000428. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
+    title: broad-scale environmental context
+    examples:
+      - value: rangeland biome [ENVO:01000247]
+    in_subset:
+      - environment
+    keywords:
+      - context
+      - environmental
+    slot_uri: MIXS:0000012
+    range: string
+    required: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  env_local_scale:
+    annotations:
+      Expected_value: Environmental entities having causal influences upon the entity at time of sampling
+    description: 'Report the entity or entities which are in the sample or specimen s local vicinity and which you believe have significant causal influences on your sample or specimen. We recommend using EnvO terms which are of smaller spatial grain than your entry for env_broad_scale. Terms, such as anatomical sites, from other OBO Library ontologies which interoperate with EnvO (e.g. UBERON) are accepted in this field. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
+    title: local environmental context
+    examples:
+      - value: hillside [ENVO:01000333]
+    in_subset:
+      - environment
+    keywords:
+      - context
+      - environmental
+    slot_uri: MIXS:0000013
+    required: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  env_medium:
+    description: 'Report the environmental material(s) immediately surrounding the sample or specimen at the time of sampling. We recommend using subclasses of ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. a tree, a leaf, a table top)'
+    title: environmental medium
+    examples:
+      - value: bluegrass field soil [ENVO:00005789]
+    in_subset:
+      - environment
+    keywords:
+      - environmental
+    slot_uri: MIXS:0000014
+    range: string
+    required: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  env_monitoring_zone:
+    annotations:
+      Expected_value: ENVO
+    description: An environmental monitoring zone is a formal designation as part of an environmental monitoring program, in which areas of a food production facility are categorized, commonly as zones 1-4, based on likelihood or risk of foodborne pathogen contamination. This field accepts terms listed under food production environmental monitoring zone (http://purl.obolibrary.org/obo/ENVO). Please add a term to indicate the environmental monitoring zone the sample was taken from
+    title: food production environmental monitoring zone
+    examples:
+      - value: Zone 1
+    keywords:
+      - environmental
+      - food
+      - production
+    slot_uri: MIXS:0001254
+    range: string
+  escalator:
+    description: The number of escalators within the built structure
+    title: escalator count
+    examples:
+      - value: '4'
+    keywords:
+      - count
+    slot_uri: MIXS:0000800
+    range: integer
+  estimated_size:
+    annotations:
+      Expected_value: number of base pairs
+    description: The estimated size of the genome prior to sequencing. Of particular importance in the sequencing of (eukaryotic) genome which could remain in draft form for a long or unspecified period
+    title: estimated size
+    examples:
+      - value: 300000 bp
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - size
+    string_serialization: '{integer} bp'
+    slot_uri: MIXS:0000024
+  ethnicity:
+    annotations:
+      Expected_value: text recommend from Wikipedia list
+    description: A category of people who identify with each other, usually on the basis of presumed similarities such as a common language, ancestry, history, society, culture, nation or social treatment within their residing area. https://en.wikipedia.org/wiki/List_of_contemporary_ethnic_groups
+    title: ethnicity
+    examples:
+      - value: native american
+    slot_uri: MIXS:0000895
+    range: string
+    multivalued: true
+  ethylbenzene:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of ethylbenzene in the sample
+    title: ethylbenzene
+    slot_uri: MIXS:0000155
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  exp_duct:
+    annotations:
+      Preferred_unit: square meter
+    description: The amount of exposed ductwork in the room
+    title: exposed ductwork
+    slot_uri: MIXS:0000144
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  exp_pipe:
+    description: The number of exposed pipes in the room
+    title: exposed pipes
+    keywords:
+      - pipes
+    slot_uri: MIXS:0000220
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  experimental_factor:
+    annotations:
+      Expected_value: text or EFO and/or OBI
+    description: Variable aspects of an experiment design that can be used to describe an experiment, or set of experiments, in an increasingly detailed manner. This field accepts ontology terms from Experimental Factor Ontology (EFO) and/or Ontology for Biomedical Investigations (OBI)
+    title: experimental factor
+    examples:
+      - value: time series design [EFO:0001779]
+    in_subset:
+      - investigation
+    keywords:
+      - experimental
+      - factor
+    string_serialization: '{termLabel} [{termID}]|{text}'
+    slot_uri: MIXS:0000008
+    range: string
+    multivalued: true
+    pattern: ^\S+.*\S+ \[[a-zA-Z]{2,}:\d+\]$
+  ext_door:
+    description: The number of exterior doors in the built structure
+    title: exterior door count
+    keywords:
+      - count
+      - door
+      - exterior
+    slot_uri: MIXS:0000170
+    range: integer
+  ext_wall_orient:
+    description: The orientation of the exterior wall
+    title: orientations of exterior wall
+    examples:
+      - value: northwest
+    keywords:
+      - exterior
+      - wall
+    slot_uri: MIXS:0000817
+    range: CompassDirections8Enum
+  ext_window_orient:
+    description: The compass direction the exterior window of the room is facing
+    title: orientations of exterior window
+    examples:
+      - value: southwest
+    keywords:
+      - exterior
+      - window
+    slot_uri: MIXS:0000818
+    range: CompassDirections8Enum
+  extr_weather_event:
+    description: Unusual weather events that may have affected microbial populations. Multiple terms can be separated by pipes, listed in reverse chronological order
+    title: extreme weather event
+    examples:
+      - value: hail
+    keywords:
+      - event
+      - extreme
+      - weather
+    slot_uri: MIXS:0001141
+    range: ExtrWeatherEventEnum
+    multivalued: true
+  extrachrom_elements:
+    description: Do plasmids exist of significant phenotypic consequence (e.g. ones that determine virulence or antibiotic resistance). Megaplasmids? Other plasmids (borrelia has 15+ plasmids)
+    title: extrachromosomal elements
+    examples:
+      - value: '5'
+    in_subset:
+      - nucleic acid sequence source
+    slot_uri: MIXS:0000023
+    range: integer
+  extreme_event:
+    description: Unusual physical events that may have affected microbial populations
+    title: history/extreme events
+    keywords:
+      - event
+      - history
+    slot_uri: MIXS:0000320
+    range: datetime
+  facility_type:
+    description: Establishment details about the type of facility where the sample was taken. This is independent of the specific product(s) within the facility
+    title: facility type
+    examples:
+      - value: manufacturing-processing
+    keywords:
+      - facility
+      - type
+    slot_uri: MIXS:0001252
+    range: FacilityTypeEnum
+    multivalued: true
+  fao_class:
+    description: Soil classification from the FAO World soil distribution from International Soil Reference and Information Centre (ISRIC). The list of available soil classifications can be found at https://www.isric.org/explore/world-soil-distribution
+    title: soil_taxonomic/FAO classification
+    examples:
+      - value: Luvisols
+    keywords:
+      - classification
+    slot_uri: MIXS:0001083
+    range: FaoClassEnum
+  farm_equip:
+    description: List of equipment used for planting, fertilization, harvesting, irrigation, land levelling, residue management, weeding or transplanting during the growing season.  This field accepts terms listed under agricultural implement (http://purl.obolibrary.org/obo/AGRO_00000416). Multiple terms can be separated by pipes
+    title: farm equipment used
+    examples:
+      - value: combine harvester [AGRO:00000473]
+    keywords:
+      - equipment
+      - farm
+      - use
+    slot_uri: MIXS:0001126
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  farm_equip_san:
+    annotations:
+      Expected_value: text or commercial name of sanitizer or class of sanitizer or active ingredient in sanitizer
+      Preferred_unit: parts per million
+    description: Method used to sanitize growing and harvesting equipment. This can including type and concentration of sanitizing solution.  Multiple terms can be separated by one or more pipes
+    title: farm equipment sanitization
+    examples:
+      - value: hot water pressure wash, hypochlorite solution, 50 parts per million
+    keywords:
+      - equipment
+      - farm
+    string_serialization: '{text} {float} {unit}'
+    slot_uri: MIXS:0001124
+    multivalued: true
+  farm_equip_san_freq:
+    description: The number of times farm equipment is cleaned. Frequency of cleaning might be on a Daily basis, Weekly, Monthly, Quarterly or Annually
+    title: farm equipment sanitization frequency
+    examples:
+      - value: Biweekly
+    keywords:
+      - equipment
+      - farm
+      - frequency
+    slot_uri: MIXS:0001125
+    range: string
+  farm_equip_shared:
+    description: List of planting, growing or harvesting equipment shared with other farms. This field accepts terms listed under agricultural implement (http://purl.obolibrary.org/obo/AGRO_00000416). Multiple terms can be separated by pipes
+    title: equipment shared with other farms
+    examples:
+      - value: combine harvester [AGRO:00000473]
+    keywords:
+      - equipment
+      - farm
+    slot_uri: MIXS:0001123
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  farm_water_source:
+    description: Source of water used on the farm for irrigation of crops or watering of livestock
+    title: farm watering water source
+    examples:
+      - value: well
+        description: was water well (ENVO:01000002)
+    keywords:
+      - farm
+      - source
+      - water
+    slot_uri: MIXS:0001110
+    range: FarmWaterSourceEnum
+    recommended: true
+  feat_pred:
+    description: Method used to predict UViGs features such as ORFs, integration site, etc
+    title: feature prediction
+    examples:
+      - value: Prodigal;2.6.3;default parameters
+    in_subset:
+      - sequencing
+    keywords:
+      - feature
+      - predict
+    slot_uri: MIXS:0000061
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{software};{version};{parameters}$
+      interpolated: true
+      partial_match: true
+  ferm_chem_add:
+    annotations:
+      Expected_value: chemical ingredient
+    description: Any chemicals that are added to the fermentation process to achieve the desired final product
+    title: fermentation chemical additives
+    examples:
+      - value: salt
+    keywords:
+      - fermentation
+    string_serialization: '{float} {unit}'
+    slot_uri: MIXS:0001185
+    recommended: true
+    multivalued: true
+  ferm_chem_add_perc:
+    annotations:
+      Preferred_unit: percentage
+    description: The amount of chemical added to the fermentation process
+    title: fermentation chemical additives percentage
+    examples:
+      - value: '0.01'
+    keywords:
+      - fermentation
+      - percent
+    slot_uri: MIXS:0001186
+    range: float
+    recommended: true
+    multivalued: true
+  ferm_headspace_oxy:
+    annotations:
+      Preferred_unit: percentage
+    description: The amount of headspace oxygen in a fermentation vessel
+    title: fermentation headspace oxygen
+    examples:
+      - value: '0.05'
+    keywords:
+      - fermentation
+      - oxygen
+    slot_uri: MIXS:0001187
+    range: float
+    recommended: true
+  ferm_medium:
+    description: The growth medium used for the fermented food fermentation process, which supplies the required nutrients.  Usually this includes a carbon and nitrogen source, water, micronutrients and chemical additives
+    title: fermentation medium
+    examples:
+      - value: molasses
+    keywords:
+      - fermentation
+    slot_uri: MIXS:0001188
+    range: string
+    recommended: true
+  ferm_pH:
+    description: The pH of the fermented food fermentation process
+    title: fermentation pH
+    examples:
+      - value: '4.5'
+    keywords:
+      - fermentation
+      - ph
+    slot_uri: MIXS:0001189
+    range: float
+    recommended: true
+  ferm_rel_humidity:
+    annotations:
+      Preferred_unit: percentage
+    description: The relative humidity of the fermented food fermentation process
+    title: fermentation relative humidity
+    comments:
+      - percent or float?
+    examples:
+      - value: 95%
+    keywords:
+      - fermentation
+      - humidity
+      - relative
+    slot_uri: MIXS:0001190
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ferm_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: The temperature of the fermented food fermentation process
+    title: fermentation temperature
+    examples:
+      - value: 22 degrees Celsius
+    keywords:
+      - fermentation
+      - temperature
+    slot_uri: MIXS:0001191
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ferm_time:
+    annotations:
+      Preferred_unit: days
+    description: The time duration of the fermented food fermentation process
+    title: fermentation time
+    examples:
+      - value: P10D
+    keywords:
+      - fermentation
+      - time
+    slot_uri: MIXS:0001192
+    range: string
+    recommended: true
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  ferm_vessel:
+    description: The type of vessel used for containment of the fermentation
+    title: fermentation vessel
+    examples:
+      - value: steel drum
+    keywords:
+      - fermentation
+    slot_uri: MIXS:0001193
+    range: string
+    recommended: true
+  fertilizer_admin:
+    description: Type of fertilizer or amendment added to the soil or water for the purpose of improving substrate health and quality for plant growth. This field accepts terms listed under agronomic fertilizer (http://purl.obolibrary.org/obo/AGRO_00002062). Multiple terms may apply and can be separated by pipes, listing in reverse chronological order
+    title: fertilizer administration
+    examples:
+      - value: fish emulsion [AGRO:00000082]
+    keywords:
+      - administration
+    slot_uri: MIXS:0001127
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  fertilizer_date:
+    description: Date of administration of soil amendment or fertilizer. Multiple terms may apply and can be separated by pipes, listing in reverse chronological order
+    title: fertilizer administration date
+    examples:
+      - value: '2018-05-11T10:00:00+01:00'
+    keywords:
+      - administration
+      - date
+    slot_uri: MIXS:0001128
+    range: datetime
+  fertilizer_regm:
+    annotations:
+      Expected_value: fertilizer name;fertilizer amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving the use of fertilizers; should include the name of fertilizer, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple fertilizer regimens
+    title: fertilizer regimen
+    examples:
+      - value: urea;0.6 milligram per liter;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+    string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000556
+    multivalued: true
+  field:
+    description: Name of the hydrocarbon field (e.g. Albacora)
+    title: field name
+    slot_uri: MIXS:0000291
+    range: string
+    recommended: true
+  filter_type:
+    description: A device which removes solid particulates or airborne molecular contaminants
+    title: filter type
+    examples:
+      - value: HEPA
+    keywords:
+      - filter
+      - type
+    slot_uri: MIXS:0000765
+    range: FilterTypeEnum
+    required: true
+    multivalued: true
+  fire:
+    description: Historical and/or physical evidence of fire
+    title: history/fire
+    keywords:
+      - history
+    slot_uri: MIXS:0001086
+    range: datetime
+  fireplace_type:
+    description: A firebox with chimney
+    title: fireplace type
+    examples:
+      - value: wood burning
+    keywords:
+      - type
+    slot_uri: MIXS:0000802
+    range: FireplaceTypeEnum
+  flooding:
+    description: Historical and/or physical evidence of flooding
+    title: history/flooding
+    keywords:
+      - history
+    slot_uri: MIXS:0000319
+    range: datetime
+  floor_age:
+    annotations:
+      Preferred_unit: years, weeks, days
+    description: The time period since installment of the carpet or flooring
+    title: floor age
+    keywords:
+      - age
+      - floor
+    slot_uri: MIXS:0000164
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  floor_area:
+    annotations:
+      Preferred_unit: square meter
+    description: The area of the floor space within the room
+    title: floor area
+    keywords:
+      - area
+      - floor
+    slot_uri: MIXS:0000165
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  floor_cond:
+    description: The physical condition of the floor at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas
+    title: floor condition
+    examples:
+      - value: new
+    keywords:
+      - condition
+      - floor
+    slot_uri: MIXS:0000803
+    range: DamagedEnum
+  floor_count:
+    description: The number of floors in the building, including basements and mechanical penthouse
+    title: floor count
+    keywords:
+      - count
+      - floor
+    slot_uri: MIXS:0000225
+    range: integer
+  floor_finish_mat:
+    annotations:
+      Expected_value: enumeration
+    description: The floor covering type; the finished surface that is walked on
+    title: floor finish material
+    examples:
+      - value: carpet
+    keywords:
+      - floor
+      - material
+    string_serialization: '[tile|wood strip or parquet|carpet|rug|laminate wood|lineoleum|vinyl composition tile|sheet vinyl|stone|bamboo|cork|terrazo|concrete|none;specify unfinished|sealed|clear finish|paint]'
+    slot_uri: MIXS:0000804
+  floor_struc:
+    description: Refers to the structural elements and subfloor upon which the finish flooring is installed
+    title: floor structure
+    examples:
+      - value: concrete
+    keywords:
+      - floor
+    slot_uri: MIXS:0000806
+    range: FloorStrucEnum
+  floor_thermal_mass:
+    annotations:
+      Preferred_unit: joule per degree Celsius
+    description: The ability of the floor to provide inertia against temperature fluctuations
+    title: floor thermal mass
+    keywords:
+      - floor
+      - mass
+    slot_uri: MIXS:0000166
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  floor_water_mold:
+    description: Signs of the presence of mold or mildew in a room
+    title: floor signs of water/mold
+    examples:
+      - value: ceiling discoloration
+    keywords:
+      - floor
+    slot_uri: MIXS:0000805
+    range: FloorWaterMoldEnum
+  fluor:
+    annotations:
+      Preferred_unit: milligram chlorophyll a per cubic meter, volts
+    description: Raw or converted fluorescence of water
+    title: fluorescence
+    examples:
+      - value: 2.5 volts
+    slot_uri: MIXS:0000704
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  foetal_health_stat:
+    description: Specification of foetal health status, should also include abortion
+    title: amniotic fluid/foetal health status
+    keywords:
+      - status
+    slot_uri: MIXS:0000275
+    range: string
+  food_additive:
+    annotations:
+      Expected_value: FOODON:03412972
+    description: A substance or substances added to food to maintain or improve safety and freshness, to improve or maintain nutritional value, or improve taste, texture and appearance.  This field accepts terms listed under food additive (http://purl.obolibrary.org/obo/FOODON_03412972). Multiple terms can be separated by one or more pipes, but please consider limiting this list to the top 5 ingredients listed in order as on the food label.  See also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
+    title: food additive
+    examples:
+      - value: xanthan gum [FOODON:03413321]
+    keywords:
+      - food
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001200
+    multivalued: true
+  food_allergen_label:
+    annotations:
+      Expected_value: FOODON:03510213
+    description: A label indication that the product contains a recognized allergen. This field accepts terms listed under dietary claim or use (http://purl.obolibrary.org/obo/FOODON_03510213)
+    title: food allergen labeling
+    examples:
+      - value: food allergen labelling about crustaceans and products thereof [FOODON:03510215]
+    keywords:
+      - food
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001201
+    multivalued: true
+  food_clean_proc:
+    description: The process of cleaning food to separate other environmental materials from the food source. Multiple terms can be separated by pipes
+    title: food cleaning process
+    examples:
+      - value: rinsed with water
+        description: was rinsed with water|scrubbed with brush
+      - value: scrubbed with brush
+        description: was rinsed with water|scrubbed with brush
+    keywords:
+      - food
+      - process
+    slot_uri: MIXS:0001182
+    range: FoodCleanProcEnum
+  food_contact_surf:
+    annotations:
+      Expected_value: FOODON:03500010
+    description: The specific container or coating materials in direct contact with the food. Multiple values can be assigned.  This field accepts terms listed under food contact surface (http://purl.obolibrary.org/obo/FOODON_03500010)
+    title: food contact surface
+    examples:
+      - value: cellulose acetate [FOODON:03500034]
+    keywords:
+      - food
+      - surface
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001131
+    multivalued: true
+  food_contain_wrap:
+    annotations:
+      Expected_value: FOODON:03490100
+    description: Type of container or wrapping defined by the main container material, the container form, and the material of the liner lids or ends. Also type of container or wrapping by form; prefer description by material first, then by form. This field accepts terms listed under food container or wrapping (http://purl.obolibrary.org/obo/FOODON_03490100)
+    title: food container or wrapping
+    examples:
+      - value: Plastic shrink-pack [FOODON:03490137]
+    keywords:
+      - food
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001132
+  food_cooking_proc:
+    annotations:
+      Expected_value: FOODON:03450002
+    description: The transformation of raw food by the application of heat. This field accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
+    title: food cooking process
+    examples:
+      - value: food blanching [FOODON:03470175]
+    keywords:
+      - food
+      - process
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001202
+    multivalued: true
+  food_dis_point:
+    description: 'A reference to a place on the Earth, by its name or by its geographical location that refers to a distribution point along the food chain. This field accepts terms listed under geographic location (http://purl.obolibrary.org/obo/GAZ_00000448). Reference: Adam Diamond, James Barham. Moving Food Along the Value Chain: Innovations in Regional Food Distribution. U.S. Dept. of Agriculture, Agricultural Marketing Service. Washington, DC. March 2012. http://dx.doi.org/10.9752/MS045.03-2012'
+    title: food distribution point geographic location
+    examples:
+      - value: 'USA: Delmarva, Peninsula'
+    keywords:
+      - food
+      - geographic
+      - location
+    slot_uri: MIXS:0001203
+    range: string
+    multivalued: true
+    pattern: '^.*: .*, .*$'
+    structured_pattern:
+      syntax: '^{text}: {text}, {text}$'
+      interpolated: true
+      partial_match: true
+  food_dis_point_city:
+    annotations:
+      Expected_value: GAZ:00000448
+    description: 'A reference to a place on the Earth, by its name or by its geographical location that refers to a distribution point along the food chain. This field accepts terms listed under geographic location (http://purl.obolibrary.org/obo/GAZ_00000448). Reference: Adam Diamond, James Barham. Moving Food Along the Value Chain: Innovations in Regional Food Distribution. U.S. Dept. of Agriculture, Agricultural Marketing Service. Washington, DC. March 2012. http://dx.doi.org/10.9752/MS045.03-2012'
+    title: food distribution point geographic location (city)
+    examples:
+      - value: Atlanta[GAZ:00004445]
+    keywords:
+      - food
+      - geographic
+      - location
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001204
+    multivalued: true
+  food_harvest_proc:
+    description: A harvesting process is a process which takes in some food material from an individual or community of plant or animal organisms in a given context and time, and outputs a precursor or consumable food product. This may include a part of an organism or the whole, and may involve killing the organism
+    title: Food harvesting process
+    examples:
+      - value: hand-picked
+    keywords:
+      - food
+      - process
+    slot_uri: MIXS:0001133
+    range: string
+    multivalued: true
+  food_ingredient:
+    annotations:
+      Expected_value: FOODON
+    description: In this field, please list individual ingredients for multi-component food [FOODON:00002501] and simple foods that is not captured in food_type.  Please use terms that are present in FoodOn.  Multiple terms can be separated by one or more pipes |, but please consider limiting this list to the top 5 ingredients listed in order as on the food label.  See also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
+    title: food ingredient
+    examples:
+      - value: bean (whole) [FOODON:00002753]
+    keywords:
+      - food
+      - ingredient
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001205
+    multivalued: true
+  food_name_status:
+    description: A datum indicating that use of a food product name is regulated in some legal jurisdiction. This field accepts terms listed under food product name legal status (http://purl.obolibrary.org/obo/FOODON_03530087)
+    title: food product name legal status
+    examples:
+      - value: protected geographic indication [FOODON:03530256]
+    keywords:
+      - food
+      - product
+      - status
+    slot_uri: MIXS:0001206
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  food_origin:
+    description: A reference to a place on the Earth, by its name or by its geographical location that describes the origin of the food commodity, either in terms of its cultivation or production. This field accepts terms listed under geographic location (http://purl.obolibrary.org/obo/GAZ_00000448)
+    title: food product origin geographic location
+    examples:
+      - value: 'USA: Delmarva, Peninsula'
+    keywords:
+      - food
+      - geographic
+      - location
+      - product
+    slot_uri: MIXS:0001207
+    range: string
+    pattern: '^.*: .*, .*$'
+    structured_pattern:
+      syntax: '^{text}: {text}, {text}$'
+      interpolated: true
+      partial_match: true
+  food_pack_capacity:
+    annotations:
+      Preferred_unit: grams
+    description: The maximum number of product units within a package
+    title: food package capacity
+    examples:
+      - value: 454 grams
+    keywords:
+      - food
+      - package
+    slot_uri: MIXS:0001208
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  food_pack_integrity:
+    annotations:
+      Expected_value: FOODON:03530218
+    description: A term label and term id to describe the state of the packing material and text to explain the exact condition.  This field accepts terms listed under food packing medium integrity (http://purl.obolibrary.org/obo/FOODON_03530218)
+    title: food packing medium integrity
+    examples:
+      - value: food packing medium compromised [FOODON:00002517]
+    keywords:
+      - food
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001209
+    multivalued: true
+  food_pack_medium:
+    annotations:
+      Expected_value: FOODON:03480020
+    description: The medium in which the food is packed for preservation and handling or the medium surrounding homemade foods, e.g., peaches cooked in sugar syrup. The packing medium may provide a controlled environment for the food. It may also serve to improve palatability and consumer appeal.  This includes edible packing media (e.g. fruit juice), gas other than air (e.g. carbon dioxide), vacuum packed, or packed with aerosol propellant. This field accepts terms under food packing medium (http://purl.obolibrary.org/obo/FOODON_03480020). Multiple terms may apply and can be separated by pipes
+    title: food packing medium
+    keywords:
+      - food
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001134
+    multivalued: true
+  food_preserv_proc:
+    annotations:
+      Expected_value: FOODON:03470107
+    description: The methods contributing to the prevention or retardation of microbial, enzymatic or oxidative spoilage and thus to the extension of shelf life. This field accepts terms listed under food preservation process (http://purl.obolibrary.org/obo/FOODON_03470107)
+    title: food preservation process
+    examples:
+      - value: food slow freezing [FOODON:03470128]
+    keywords:
+      - food
+      - process
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001135
+    multivalued: true
+  food_prior_contact:
+    annotations:
+      Expected_value: FOODON:03530077
+    description: The material the food contacted (e.g., was processed in) prior to packaging. This field accepts terms listed under material of contact prior to food packaging (http://purl.obolibrary.org/obo/FOODON_03530077). If the proper descriptor is not listed please use text to describe the material of contact prior to food packaging
+    title: material of contact prior to food packaging
+    examples:
+      - value: processed in stainless steel container [FOODON:03530081]
+    keywords:
+      - food
+      - material
+      - prior
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001210
+    multivalued: true
+  food_prod:
+    description: Descriptors of the food production system or of the agricultural environment and growing conditions related to the farm production system, such as wild caught, organic, free-range, industrial, dairy, beef,  domestic or cultivated food production. This field accepts terms listed under food production (http://purl.obolibrary.org/obo/FOODON_03530206). Multiple terms may apply and can be separated by pipes
+    title: food production system characteristics
+    examples:
+      - value: organic plant cultivation [FOODON:03530253]
+    keywords:
+      - food
+      - production
+    slot_uri: MIXS:0001211
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  food_prod_char:
+    description: Descriptors of the food production system such as wild caught, free-range, organic, free-range, industrial, dairy, beef
+    title: food production characteristics
+    examples:
+      - value: wild caught
+    keywords:
+      - food
+      - production
+    slot_uri: MIXS:0001136
+    range: string
+    multivalued: true
+  food_prod_synonym:
+    description: Other names by which the food product is known by (e.g., regional or non-English names)
+    title: food product synonym
+    examples:
+      - value: pinot gris
+    keywords:
+      - food
+      - product
+    slot_uri: MIXS:0001212
+    range: string
+    multivalued: true
+  food_product_qual:
+    description: Descriptors for describing food visually or via other senses, which is useful for tasks like food inspection where little prior knowledge of how the food came to be is available. Some terms like "food (frozen)" are both a quality descriptor and the output of a process. This field accepts terms listed under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
+    title: food product by quality
+    examples:
+      - value: raw [FOODON:03311126]
+    keywords:
+      - food
+      - product
+      - quality
+    slot_uri: MIXS:0001213
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  food_product_type:
+    annotations:
+      Expected_value: FOODON:00001002 or FOODON:03309997
+    description: A food product type is a class of food products that is differentiated by its food composition (e.g., single- or multi-ingredient), processing and/or consumption characteristics. This does not include brand name products but it may include generic food dish categories. This field accepts terms under food product type (http://purl.obolibrary.org/obo/FOODON:03400361). For terms related to food product for an animal, consult food product for animal (http://purl.obolibrary.org/obo/FOODON_03309997). If the proper descriptor is not listed please use text to describe the food type. Multiple terms can be separated by one or more pipes
+    title: food product type
+    keywords:
+      - food
+      - product
+      - type
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001184
+  food_quality_date:
+    annotations:
+      Expected_value: enumeration, date
+    description: The date recommended for the use of the product while at peak quality, this date is not a reflection of safety unless used on infant formula this date is not a reflection of safety and is typically labeled on a food product as "best if used by," best by," "use by," or "freeze by."
+    title: food quality date
+    examples:
+      - value: best by 2020-05-24
+    keywords:
+      - date
+      - food
+      - quality
+    string_serialization: '[best by|best if used by|freeze by|use by]; date'
+    slot_uri: MIXS:0001178
+  food_source:
+    annotations:
+      Expected_value: FOODON term
+    description: Type of plant or animal from which the food product or its major ingredient is derived or a chemical food source [FDA CFSAN 1995]
+    title: food source
+    keywords:
+      - food
+      - source
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0001139
+  food_source_age:
+    annotations:
+      Preferred_unit: days
+    description: The age of the food source host organim. Depending on the type of host organism, age may be more appropriate to report in days, weeks, or years
+    title: food source age
+    comments:
+      - ISO 8601 period or measurement value?
+    examples:
+      - value: 6 months
+    keywords:
+      - age
+      - food
+      - source
+    slot_uri: MIXS:0001251
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  food_trace_list:
+    description: The FDA is proposing to establish additional traceability recordkeeping requirements (beyond what is already required in existing regulations) for persons who manufacture, process, pack, or hold foods the Agency has designated for inclusion on the Food Traceability List. The Food Traceability List (FTL) identifies the foods for which the additional traceability records described in the proposed rule would be required. The term  Food Traceability List  (FTL) refers not only to the foods specifically listed (https://www.fda.gov/media/142303/download), but also to any foods that contain listed foods as ingredients
+    title: food traceability list category
+    examples:
+      - value: tropical tree fruits
+    keywords:
+      - food
+    slot_uri: MIXS:0001214
+    range: FoodTraceListEnum
+  food_trav_mode:
+    description: A descriptor for the method of movement of food commodity along the food distribution system.  This field accepts terms listed under travel mode (http://purl.obolibrary.org/obo/GENEPIO_0001064). If the proper descrptor is not listed please use text to describe the mode of travel. Multiple terms can be separated by one or more pipes
+    title: food shipping transportation method
+    examples:
+      - value: train travel [GENEPIO:0001060]
+    keywords:
+      - food
+      - method
+      - transport
+    slot_uri: MIXS:0001137
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  food_trav_vehic:
+    annotations:
+      Expected_value: ENVO:01000604
+    description: A descriptor for the mobile machine which is used to transport food commodities along the food distribution system.  This field accepts terms listed under vehicle (http://purl.obolibrary.org/obo/ENVO_01000604). If the proper descrptor is not listed please use text to describe the mode of travel. Multiple terms can be separated by one or more pipes
+    title: food shipping transportation vehicle
+    examples:
+      - value: aircraft [ENVO:01001488]|car [ENVO:01000605]
+    keywords:
+      - food
+      - transport
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001138
+    multivalued: true
+  food_treat_proc:
+    annotations:
+      Expected_value: FOODON:03460111
+    description: Used to specifically characterize a food product based on the treatment or processes applied to the product or any indexed ingredient. The processes include adding, substituting or removing components or modifying the food or component, e.g., through fermentation. Multiple values can be assigned. This fields accepts terms listed under food treatment process (http://purl.obolibrary.org/obo/FOODON_03460111)
+    title: food treatment process
+    examples:
+      - value: gluten removal process [FOODON:03460750]
+    keywords:
+      - food
+      - process
+      - treatment
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001140
+    multivalued: true
+  freq_clean:
+    description: The number of times the sample location is cleaned. Frequency of cleaning might be on a Daily basis, Weekly, Monthly, Quarterly or Annually
+    title: frequency of cleaning
+    examples:
+      - value: Daily
+    keywords:
+      - frequency
+    slot_uri: MIXS:0000226
+    range: FreqCleanEnum
+  freq_cook:
+    description: The number of times a meal is cooked per week
+    title: frequency of cooking
+    keywords:
+      - frequency
+    slot_uri: MIXS:0000227
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  fungicide_regm:
+    annotations:
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving use of fungicides; should include the name of fungicide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple fungicide regimens
+    title: fungicide regimen
+    examples:
+      - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+    slot_uri: MIXS:0000557
+    range: string
+    multivalued: true
+  furniture:
+    description: The types of furniture present in the sampled room
+    title: furniture
+    examples:
+      - value: chair
+    slot_uri: MIXS:0000807
+    range: FurnitureEnum
+  gaseous_environment:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Use of conditions with differing gaseous environments; should include the name of gaseous compound, amount administered, treatment duration, interval and total experimental duration; can include multiple gaseous environment regimens
+    title: gaseous environment
+    examples:
+      - value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - environment
+    slot_uri: MIXS:0000558
+    range: string
+    multivalued: true
+  gaseous_substances:
+    annotations:
+      Expected_value: gaseous substance name;measurement value
+      Preferred_unit: micromole per liter
+    description: Amount or concentration of substances such as hydrogen sulfide, carbon dioxide, methane, etc.; can include multiple substances
+    title: gaseous substances
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000661
+    multivalued: true
+  gastrointest_disord:
+    description: History of gastrointestinal tract disorders; can include multiple disorders. History of blood disorders; can include multiple disorders.  The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, gastrointestinal system disease (https://disease-ontology.org/?id=DOID:77)
+    title: gastrointestinal tract disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000280
+    range: string
+    multivalued: true
+  gender_restroom:
+    description: The gender type of the restroom
+    title: gender of restroom
+    examples:
+      - value: male
+    slot_uri: MIXS:0000808
+    range: GenderRestroomEnum
+  genetic_mod:
+    annotations:
+      Expected_value: PMID, DOI, URL or text
+    description: Genetic modifications of the genome of an organism, which may occur naturally by spontaneous mutation, or be introduced by some experimental means, e.g. specification of a transgene or the gene knocked-out or details of transient transfection
+    title: genetic modification
+    examples:
+      - value: aox1A transgenic
+    string_serialization: '{PMID}|{DOI}|{URL}'
+    slot_uri: MIXS:0000859
+  geo_loc_name:
+    description: The geographical origin of the sample as defined by the country or sea name followed by specific region name. Country or sea names should be chosen from the INSDC country list (http://insdc.org/country.html), or the GAZ ontology (http://purl.bioontology.org/ontology/GAZ)
+    title: geographic location (country and/or sea,region)
+    examples:
+      - value: 'USA: Maryland, Bethesda'
+    in_subset:
+      - environment
+    keywords:
+      - geographic
+      - location
+    slot_uri: MIXS:0000010
+    range: string
+    required: true
+    pattern: '^.*: .*, .*$'
+    structured_pattern:
+      syntax: '^{text}: {text}, {text}$'
+      interpolated: true
+      partial_match: true
+  gestation_state:
+    description: Specification of the gestation state
+    title: amniotic fluid/gestation state
+    slot_uri: MIXS:0000272
+    range: string
+  glucosidase_act:
+    annotations:
+      Preferred_unit: mol per liter per hour
+    description: Measurement of glucosidase activity
+    title: glucosidase activity
+    examples:
+      - value: 5 mol per liter per hour
+    slot_uri: MIXS:0000137
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  gravidity:
+    description: Whether or not subject is gravid, and if yes date due or date post-conception, specifying which is used
+    title: gravidity
+    examples:
+      - value: yes;due date:2018-05-11
+    string_serialization: '{boolean};{timestamp}'
+    slot_uri: MIXS:0000875
+  gravity:
+    annotations:
+      Expected_value: gravity factor value;treatment interval and duration
+      Preferred_unit: meter per square second, g
+    description: Information about treatment involving use of gravity factor to study various types of responses in presence, absence or modified levels of gravity; treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple treatments
+    title: gravity
+    examples:
+      - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000559
+    multivalued: true
+  growth_facil:
+    annotations:
+      Expected_value: free text or CO
+    description: 'Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
+    title: growth facility
+    examples:
+      - value: Growth chamber [CO_715:0000189]
+    keywords:
+      - facility
+      - growth
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001043
+  growth_habit:
+    description: Characteristic shape, appearance or growth form of a plant species
+    title: growth habit
+    examples:
+      - value: spreading
+    keywords:
+      - growth
+    slot_uri: MIXS:0001044
+    range: GrowthHabitEnum
+  growth_hormone_regm:
+    annotations:
+      Expected_value: growth hormone name;growth hormone amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving use of growth hormones; should include the name of growth hormone, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple growth hormone regimens
+    title: growth hormone regimen
+    examples:
+      - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - growth
+      - regimen
+    string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000560
+    multivalued: true
+  growth_medium:
+    description: A liquid or gel containing nutrients, salts, and other factors formulated to support the growth of microorganisms, cells, or plants (National Cancer Institute Thesaurus).  The name of the medium used to grow the microorganism
+    title: growth medium
+    examples:
+      - value: LB broth
+    keywords:
+      - growth
+    slot_uri: MIXS:0001108
+    range: string
+  gynecologic_disord:
+    description: History of gynecological disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, female reproductive system disease (https://disease-ontology.org/?id=DOID:229)
+    title: gynecological disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000288
+    range: string
+    multivalued: true
+  hall_count:
+    description: The total count of hallways and cooridors in the built structure
+    title: hallway/corridor count
+    keywords:
+      - corridor
+      - count
+      - hallway
+    slot_uri: MIXS:0000228
+    range: integer
+  handidness:
+    description: The handidness of the individual sampled
+    title: handidness
+    examples:
+      - value: right handedness
+    slot_uri: MIXS:0000809
+    range: HandidnessEnum
+  hc_produced:
+    description: Main hydrocarbon type produced from resource (i.e. Oil, gas, condensate, etc). If "other" is specified, please propose entry in "additional info" field
+    title: hydrocarbon type produced
+    examples:
+      - value: Gas
+    keywords:
+      - hydrocarbon
+      - type
+    slot_uri: MIXS:0000989
+    range: HcProducedEnum
+    required: true
+  hcr:
+    description: Main Hydrocarbon Resource type. The term "Hydrocarbon Resource" HCR defined as a natural environmental feature containing large amounts of hydrocarbons at high concentrations potentially suitable for commercial exploitation. This term should not be confused with the Hydrocarbon Occurrence term which also includes hydrocarbon-rich environments with currently limited commercial interest such as seeps, outcrops, gas hydrates etc. If "other" is specified, please propose entry in "additional info" field
+    title: hydrocarbon resource type
+    examples:
+      - value: Oil Sand
+    keywords:
+      - hydrocarbon
+      - resource
+      - type
+    slot_uri: MIXS:0000988
+    range: HcrEnum
+    required: true
+  hcr_fw_salinity:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: Original formation water salinity (prior to secondary recovery e.g. Waterflooding) expressed as TDS
+    title: formation water salinity
+    keywords:
+      - salinity
+      - water
+    slot_uri: MIXS:0000406
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  hcr_geol_age:
+    description: 'Geological age of hydrocarbon resource (Additional info: https://en.wikipedia.org/wiki/Period_(geology)). If "other" is specified, please propose entry in "additional info" field'
+    title: hydrocarbon resource geological age
+    examples:
+      - value: Silurian
+    keywords:
+      - age
+      - hydrocarbon
+      - resource
+    slot_uri: MIXS:0000993
+    range: GeolAgeEnum
+    recommended: true
+  hcr_pressure:
+    annotations:
+      Preferred_unit: atmosphere, kilopascal
+    description: Original pressure of the hydrocarbon resource
+    title: hydrocarbon resource original pressure
+    keywords:
+      - hydrocarbon
+      - pressure
+      - resource
+    slot_uri: MIXS:0000395
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{float} *- *{float} {unit}$
+      interpolated: true
+      partial_match: true
+  hcr_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Original temperature of the hydrocarbon resource
+    title: hydrocarbon resource original temperature
+    examples:
+      - value: 150-295 degree Celsius
+    keywords:
+      - hydrocarbon
+      - resource
+      - temperature
+    slot_uri: MIXS:0000393
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{float} *- *{float} {unit}$
+      interpolated: true
+      partial_match: true
+  heat_cool_type:
+    description: Methods of conditioning or heating a room or building
+    title: heating and cooling system type
+    examples:
+      - value: heat pump
+    keywords:
+      - type
+    slot_uri: MIXS:0000766
+    range: HeatCoolTypeEnum
+    required: true
+    multivalued: true
+  heat_deliv_loc:
+    description: The location of heat delivery within the room
+    title: heating delivery locations
+    examples:
+      - value: north
+    keywords:
+      - delivery
+      - location
+      - locations
+    slot_uri: MIXS:0000810
+    range: CompassDirections8Enum
+  heat_sys_deliv_meth:
+    description: The method by which the heat is delivered through the system
+    title: heating system delivery method
+    examples:
+      - value: radiant
+    keywords:
+      - delivery
+      - method
+    slot_uri: MIXS:0000812
+    range: HeatSysDelivMethEnum
+  heat_system_id:
+    description: The heating system identifier
+    title: heating system identifier
+    keywords:
+      - identifier
+    slot_uri: MIXS:0000833
+    range: integer
+  heavy_metals:
+    annotations:
+      Expected_value: heavy metal name;measurement value unit
+      Preferred_unit: microgram per gram
+    description: Heavy metals present in the sequenced sample and their concentrations. For multiple heavy metals and concentrations, add multiple copies of this field
+    title: extreme_unusual_properties/heavy metals
+    examples:
+      - value: mercury;0.09 micrograms per gram
+    keywords:
+      - extreme
+      - properties
+      - unusual
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000652
+    multivalued: true
+  heavy_metals_meth:
+    description: Reference or method used in determining heavy metals
+    title: extreme_unusual_properties/heavy metals method
+    keywords:
+      - extreme
+      - method
+      - properties
+      - unusual
+    slot_uri: MIXS:0000343
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  height_carper_fiber:
+    annotations:
+      Preferred_unit: centimeter
+    description: The average carpet fiber height in the indoor environment
+    title: height carpet fiber mat
+    keywords:
+      - height
+    slot_uri: MIXS:0000167
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  herbicide_regm:
+    annotations:
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving use of herbicides; information about treatment involving use of growth hormones; should include the name of herbicide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
+    title: herbicide regimen
+    examples:
+      - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+    slot_uri: MIXS:0000561
+    range: string
+    multivalued: true
+  horizon_meth:
+    description: Reference or method used in determining the horizon
+    title: horizon method
+    keywords:
+      - horizon
+      - method
+    slot_uri: MIXS:0000321
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  host_age:
+    annotations:
+      Preferred_unit: year, day, hour
+    description: Age of host at the time of sampling; relevant scale depends on species and study, e.g. Could be seconds for amoebae or centuries for trees
+    title: host age
+    keywords:
+      - age
+      - host
+      - host.
+    slot_uri: MIXS:0000255
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_body_habitat:
+    description: Original body habitat where the sample was obtained from
+    title: host body habitat
+    keywords:
+      - body
+      - habitat
+      - host
+      - host.
+    slot_uri: MIXS:0000866
+    range: string
+  host_body_mass_index:
+    annotations:
+      Preferred_unit: kilogram per square meter
+    description: Body mass index, calculated as weight/(height)squared
+    title: host body-mass index
+    examples:
+      - value: 22 kilogram per square meter
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000317
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_body_product:
+    annotations:
+      Expected_value: FMA or UBERON
+    description: Substance produced by the body, e.g. Stool, mucus, where the sample was obtained from. Use terms from the foundational model of anatomy ontology (fma) or Uber-anatomy ontology (UBERON)
+    title: host body product
+    examples:
+      - value: mucus [FMA:66938]
+    keywords:
+      - body
+      - host
+      - host.
+      - product
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0000888
+  host_body_site:
+    annotations:
+      Expected_value: FMA or UBERON
+    description: Name of body site where the sample was obtained from, such as a specific organ or tissue (tongue, lung etc...). Use terms from the foundational model of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
+    title: host body site
+    keywords:
+      - body
+      - host
+      - site
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0000867
+  host_body_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Core body temperature of the host when sample was collected
+    title: host body temperature
+    keywords:
+      - body
+      - host
+      - host.
+      - temperature
+    slot_uri: MIXS:0000274
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_cellular_loc:
+    description: 'The localization of the symbiotic host organism within the host from which it was sampled: e.g. intracellular if the symbiotic host organism is localized within the cells or extracellular if the symbiotic host organism is localized outside of cells'
+    title: host cellular location
+    examples:
+      - value: extracellular
+    keywords:
+      - host
+      - host.
+      - location
+    slot_uri: MIXS:0001313
+    range: HostCellularLocEnum
+    recommended: true
+  host_color:
+    description: The color of host
+    title: host color
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000260
+    range: string
+  host_common_name:
+    annotations:
+      Preferred_unit: ''
+    description: Common name of the host
+    title: host common name
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000248
+    range: string
+  host_dependence:
+    description: Type of host dependence for the symbiotic host organism to its host
+    title: host dependence
+    examples:
+      - value: obligate
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0001315
+    range: HostDependenceEnum
+    required: true
+  host_diet:
+    description: Type of diet depending on the host, for animals omnivore, herbivore etc., for humans high-fat, meditteranean etc.; can include multiple diet types
+    title: host diet
+    keywords:
+      - diet
+      - host
+      - host.
+    slot_uri: MIXS:0000869
+    range: string
+    multivalued: true
+  host_disease_stat:
+    annotations:
+      Expected_value: disease name or Disease Ontology term
+    description: List of diseases with which the host has been diagnosed; can include multiple diagnoses. The value of the field depends on host; for humans the terms should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org, non-human host diseases are free text
+    title: host disease status
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - disease
+      - host
+      - host.
+      - status
+    string_serialization: '{termLabel} [{termID}]|{text}'
+    slot_uri: MIXS:0000031
+  host_dry_mass:
+    annotations:
+      Preferred_unit: kilogram, gram
+    description: Measurement of dry mass
+    title: host dry mass
+    examples:
+      - value: 500 gram
+    keywords:
+      - dry
+      - host
+      - host.
+      - mass
+    slot_uri: MIXS:0000257
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_fam_rel:
+    annotations:
+      Expected_value: relationship type;arbitrary identifier
+    description: Relationships to other hosts in the same study; can include multiple relationships
+    title: host family relationship
+    keywords:
+      - family
+      - host
+      - host.
+      - relationship
+    string_serialization: '{text};{text}'
+    slot_uri: MIXS:0000872
+    multivalued: true
+  host_genotype:
+    description: Observed genotype
+    title: host genotype
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000365
+    range: string
+  host_growth_cond:
+    description: Literature reference giving growth conditions of the host
+    title: host growth conditions
+    examples:
+      - value: https://academic.oup.com/icesjms/article/68/2/349/617247
+    keywords:
+      - condition
+      - growth
+      - host
+      - host.
+    slot_uri: MIXS:0000871
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}|{text}$
+      interpolated: true
+      partial_match: true
+  host_height:
+    annotations:
+      Preferred_unit: centimeter, millimeter, meter
+    description: The height of subject
+    title: host height
+    keywords:
+      - height
+      - host
+      - host.
+    slot_uri: MIXS:0000264
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_hiv_stat:
+    annotations:
+      Expected_value: HIV status;HAART initiation status
+    description: HIV status of subject, if yes HAART initiation status should also be indicated as [YES or NO]
+    title: host HIV status
+    examples:
+      - value: yes;yes
+    keywords:
+      - host
+      - host.
+      - status
+    string_serialization: '{boolean};{boolean}'
+    slot_uri: MIXS:0000265
+  host_infra_spec_name:
+    description: Taxonomic information about the host below subspecies level
+    title: host infra-specific name
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000253
+    range: string
+  host_infra_spec_rank:
+    description: Taxonomic rank information about the host below subspecies level, such as variety, form, rank etc
+    title: host infra-specific rank
+    keywords:
+      - host
+      - host.
+      - rank
+    slot_uri: MIXS:0000254
+    range: string
+  host_last_meal:
+    annotations:
+      Expected_value: content;duration
+    description: Content of last meal and time since feeding; can include multiple values
+    title: host last meal
+    keywords:
+      - host
+      - host.
+    string_serialization: '{text};{duration}'
+    slot_uri: MIXS:0000870
+    multivalued: true
+  host_length:
+    annotations:
+      Preferred_unit: centimeter, millimeter, meter
+    description: The length of subject
+    title: host length
+    examples:
+      - value: 1 meter
+    keywords:
+      - host
+      - host.
+      - length
+    slot_uri: MIXS:0000256
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_life_stage:
+    annotations:
+      Expected_value: stage
+    description: Description of life stage of host
+    title: host life stage
+    keywords:
+      - host
+      - host.
+      - life
+    slot_uri: MIXS:0000251
+    range: string
+  host_number:
+    annotations:
+      Expected_value: count
+    description: Number of symbiotic host individuals pooled at the time of collection
+    title: host number individual
+    examples:
+      - value: '3'
+    keywords:
+      - host
+      - host.
+      - number
+    string_serialization: '{float} m'
+    slot_uri: MIXS:0001305
+  host_occupation:
+    description: Most frequent job performed by subject
+    title: host occupation
+    comments:
+      - Couldn't convert host_occupation with value veterinary to integer
+      - almost all host_occupation values in the NCBI biosample_set are strings, not integers
+    examples:
+      - value: veterinary
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000896
+    range: string
+  host_of_host_coinf:
+    annotations:
+      Expected_value: species name of coinfecting organism(s)
+    description: The taxonomic name of any coinfecting organism observed in a symbiotic relationship with the host of the sampled host organism. e.g. where a sample collected from a host trematode species (A) which was collected from a host_of_host fish (B) that was also infected with a nematode (C), the value here would be (C) the nematode {species name} or {common name}. Multiple co-infecting species may be added in a comma-separated list. For listing symbiotic organisms associated with the host (A) use the term Observed host symbiont
+    title: observed coinfecting organisms in host of host
+    examples:
+      - value: Maritrema novaezealandense
+    keywords:
+      - host
+      - host.
+      - observed
+      - organism
+    slot_uri: MIXS:0001310
+    range: string
+  host_of_host_disease:
+    annotations:
+      Expected_value: disease name or Disease Ontology term
+    description: List of diseases with which the host of the symbiotic host organism has been diagnosed; can include multiple diagnoses. The value of the field depends on host; for humans the terms should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org, non-human host diseases are free text
+    title: host of the symbiotic host disease status
+    examples:
+      - value: rabies [DOID:11260]
+    keywords:
+      - disease
+      - host
+      - host.
+      - status
+      - symbiosis
+    string_serialization: '{termLabel} [{termID}]|{text}'
+    slot_uri: MIXS:0001319
+    multivalued: true
+  host_of_host_env_loc:
+    annotations:
+      Expected_value: UBERON term(s), multiple values can be separated by pipes
+    description: For a symbiotic host organism the local anatomical environment within its host may have causal influences. Report the anatomical entity(s) which are in the direct environment of the symbiotic host organism being sampled and which you believe have significant causal influences on your sample or specimen. For example, if the symbiotic host organism being sampled is an intestinal worm, its local environmental context will be the term for intestine from UBERON (http://uberon.github.io/)
+    title: host of the symbiotic host local environmental context
+    examples:
+      - value: small intestine[uberon:0002108]
+    keywords:
+      - context
+      - environmental
+      - host
+      - host.
+      - symbiosis
+    string_serialization: small intestine [UBERON:0002108]
+    slot_uri: MIXS:0001325
+    multivalued: true
+  host_of_host_env_med:
+    annotations:
+      Expected_value: An ontology term for a material such as a tissue type or excreted substance
+    description: 'Report the environmental material(s) immediately surrounding the symbiotic host organism at the time of sampling. This usually will be a tissue or substance type from the host, but may be another material if the symbiont is external to the host. We recommend using classes from the UBERON ontology, but subclasses of ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483) may also be used. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. intestines, heart).MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. intestines, heart)'
+    title: host of the symbiotic host environemental medium
+    examples:
+      - value: feces[uberon:0001988]
+    keywords:
+      - environmental
+      - host
+      - host.
+      - symbiosis
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0001326
+  host_of_host_fam_rel:
+    annotations:
+      Expected_value: relationship type;arbitrary identifier
+    description: Familial relationship of the host of the symbiotic host organisms to other hosts of symbiotic host organism in the same study; can include multiple relationships
+    title: host of the symbiotic host family relationship
+    keywords:
+      - family
+      - host
+      - host.
+      - relationship
+      - symbiosis
+    string_serialization: '{text};{text}'
+    slot_uri: MIXS:0001328
+    multivalued: true
+  host_of_host_geno:
+    description: Observed genotype of the host of the symbiotic host organism
+    title: host of the symbiotic host genotype
+    keywords:
+      - host
+      - host.
+      - symbiosis
+    slot_uri: MIXS:0001331
+    range: string
+  host_of_host_gravid:
+    annotations:
+      Expected_value: gravidity status;timestamp
+    description: Whether or not the host of the symbiotic host organism is gravid, and if yes date due or date post-conception, specifying which is used
+    title: host of the symbiotic host gravidity
+    keywords:
+      - host
+      - host.
+      - symbiosis
+    string_serialization: '{boolean};{timestamp}'
+    slot_uri: MIXS:0001333
+  host_of_host_infname:
+    description: Taxonomic name information of the host of the symbiotic host organism below subspecies level
+    title: host of the symbiotic host infra-specific name
+    keywords:
+      - host
+      - host.
+      - symbiosis
+    slot_uri: MIXS:0001329
+    range: string
+  host_of_host_infrank:
+    description: Taxonomic rank information about the host of the symbiotic host organism below subspecies level, such as variety, form, rank etc
+    title: host of the symbiotic host infra-specific rank
+    keywords:
+      - host
+      - host.
+      - rank
+      - symbiosis
+    slot_uri: MIXS:0001330
+    range: string
+  host_of_host_name:
+    description: Common name of the host of the symbiotic host organism
+    title: host of the symbiotic host common name
+    examples:
+      - value: snail
+    keywords:
+      - host
+      - host.
+      - symbiosis
+    slot_uri: MIXS:0001324
+    range: string
+  host_of_host_pheno:
+    annotations:
+      Expected_value: phenotype of the host of the symbiotic organism; PATO
+    description: Phenotype of the host of the symbiotic host organism. For phenotypic quality ontology (PATO) terms, see http://purl.bioontology.org/ontology/pato
+    title: host of the symbiotic host phenotype
+    keywords:
+      - host
+      - host.
+      - symbiosis
+    string_serialization: '{term}'
+    slot_uri: MIXS:0001332
+  host_of_host_sub_id:
+    description: 'A unique identifier by which each host of the symbiotic host organism subject can be referred to, de-identified, e.g. #H14'
+    title: host of the symbiotic host subject id
+    examples:
+      - value: H3
+    keywords:
+      - host
+      - host.
+      - identifier
+      - symbiosis
+    slot_uri: MIXS:0001327
+    range: string
+  host_of_host_taxid:
+    annotations:
+      Expected_value: NCBI taxon identifier of the host of the symbiotic taxon organism
+    description: NCBI taxon id of the host of the symbiotic host organism
+    title: host of the symbiotic host taxon id
+    examples:
+      - value: '145637'
+    keywords:
+      - host
+      - host.
+      - identifier
+      - symbiosis
+      - taxon
+    string_serialization: '{integer}'
+    slot_uri: MIXS:0001306
+  host_of_host_totmass:
+    description: Total mass of the host of the symbiotic host organism at collection, the unit depends on the host
+    title: host of the symbiotic host total mass
+    keywords:
+      - host
+      - host.
+      - mass
+      - symbiosis
+      - total
+    slot_uri: MIXS:0001334
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_phenotype:
+    annotations:
+      Expected_value: PATO or HP
+    description: Phenotype of human or other host. Use terms from the phenotypic quality ontology (pato) or the Human Phenotype Ontology (HP)
+    title: host phenotype
+    keywords:
+      - host
+      - host.
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0000874
+  host_pred_appr:
+    description: Tool or approach used for host prediction
+    title: host prediction approach
+    examples:
+      - value: CRISPR spacer match
+    in_subset:
+      - sequencing
+    keywords:
+      - host
+      - host.
+      - predict
+    slot_uri: MIXS:0000088
+    range: HostPredApprEnum
+  host_pred_est_acc:
+    description: For each tool or approach used for host prediction, estimated false discovery rates should be included, either computed de novo or from the literature
+    title: host prediction estimated accuracy
+    examples:
+      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
+    in_subset:
+      - sequencing
+    keywords:
+      - host
+      - host.
+      - predict
+    slot_uri: MIXS:0000089
+    range: string
+  host_pulse:
+    annotations:
+      Preferred_unit: beats per minute
+    description: Resting pulse, measured as beats per minute
+    title: host pulse
+    examples:
+      - value: 65 beats per minute
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000333
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_sex:
+    annotations:
+      Expected_value: enumeration
+    description: Gender or physical sex of the host
+    title: host sex
+    comments:
+      - example of non-binary from Excel sheets does not match any of the enumerated values
+    keywords:
+      - host
+      - host.
+    string_serialization: '[female|hermaphrodite|non-binary|male|transgender|transgender (female to male)|transgender (male to female)
+
+      |undeclared]'
+    slot_uri: MIXS:0000811
+  host_shape:
+    description: Morphological shape of host
+    title: host shape
+    examples:
+      - value: round
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000261
+    range: string
+  host_spec_range:
+    annotations:
+      Expected_value: NCBI taxid
+    description: The range and diversity of host species that an organism is capable of infecting, defined by NCBI taxonomy identifier
+    title: host specificity or range
+    examples:
+      - value: '9606'
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - host
+      - host.
+      - range
+    string_serialization: '{integer}'
+    slot_uri: MIXS:0000030
+    multivalued: true
+  host_specificity:
+    description: 'Level of specificity of symbiont-host interaction: e.g. generalist (symbiont able to establish associations with distantly related hosts) or species-specific'
+    title: host specificity
+    examples:
+      - value: species-specific
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0001308
+    range: HostSpecificityEnum
+    recommended: true
+  host_subject_id:
+    description: A unique identifier by which each subject can be referred to, de-identified
+    title: host subject id
+    keywords:
+      - host
+      - host.
+      - identifier
+    slot_uri: MIXS:0000861
+    range: string
+  host_subspecf_genlin:
+    annotations:
+      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies, e.g. serovar, biotype, ecotype, variety, cultivar
+    description: Information about the genetic distinctness of the host organism below the subspecies level e.g., serovar, serotype, biotype, ecotype, variety, cultivar, or any relevant genetic typing schemes like Group I plasmid. Subspecies should not be recorded in this term, but in the NCBI taxonomy. Supply both the lineage name and the lineage rank separated by a colon, e.g., biovar:abc123
+    title: host subspecific genetic lineage
+    examples:
+      - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
+    keywords:
+      - host
+      - host.
+      - lineage
+    string_serialization: '{rank name}:{text}'
+    slot_uri: MIXS:0001318
+    multivalued: true
+  host_substrate:
+    description: The growth substrate of the host
+    title: host substrate
+    examples:
+      - value: rock
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000252
+    range: string
+  host_symbiont:
+    annotations:
+      Expected_value: species name or common name
+    description: The taxonomic name of the organism(s) found living in mutualistic, commensalistic, or parasitic symbiosis with the specific host. The sampled symbiont can have its own symbionts. For example, parasites may have hyperparasites (=parasites of the parasite)
+    title: observed host symbionts
+    keywords:
+      - host
+      - host.
+      - observed
+      - symbiosis
+    slot_uri: MIXS:0001298
+    range: string
+    multivalued: true
+  host_taxid:
+    annotations:
+      Expected_value: NCBI taxon identifier
+    description: NCBI taxon id of the host, e.g. 9606
+    title: host taxid
+    keywords:
+      - host
+      - host.
+      - taxon
+    slot_uri: MIXS:0000250
+  host_tot_mass:
+    annotations:
+      Preferred_unit: kilogram, gram
+    description: Total mass of the host at collection, the unit depends on host
+    title: host total mass
+    keywords:
+      - host
+      - host.
+      - mass
+      - total
+    slot_uri: MIXS:0000263
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  host_wet_mass:
+    annotations:
+      Preferred_unit: kilogram, gram
+    description: Measurement of wet mass
+    title: host wet mass
+    examples:
+      - value: 1500 gram
+    keywords:
+      - host
+      - host.
+      - mass
+      - wet
+    slot_uri: MIXS:0000567
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  hrt:
+    description: Whether subject had hormone replacement theraphy, and if yes start date
+    title: HRT
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    slot_uri: MIXS:0000969
+    range: datetime
+  humidity:
+    description: Amount of water vapour in the air, at the time of sampling
+    title: humidity
+    keywords:
+      - humidity
+    slot_uri: MIXS:0000100
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  humidity_regm:
+    annotations:
+      Expected_value: humidity value;treatment interval and duration
+      Preferred_unit: gram per cubic meter
+    description: Information about treatment involving an exposure to varying degree of humidity; information about treatment involving use of growth hormones; should include amount of humidity administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
+    title: humidity regimen
+    examples:
+      - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - humidity
+      - regimen
+    string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000568
+    multivalued: true
+  hygienic_area:
+    annotations:
+      Expected_value: Expected value
+    description: The subdivision of areas within a food production facility according to hygienic requirements. This field accepts terms listed under hygienic food production area (http://purl.obolibrary.org/obo/ENVO). Please add a term that most accurately indicates the hygienic area your sample was taken from according to the definitions provided
+    title: hygienic food production area
+    examples:
+      - value: Low Hygiene Area
+    keywords:
+      - area
+      - food
+      - production
+    slot_uri: MIXS:0001253
+    range: string
+  hysterectomy:
+    description: Specification of whether hysterectomy was performed
+    title: hysterectomy
+    examples:
+      - value: 'no'
+    slot_uri: MIXS:0000287
+    range: boolean
+  ihmc_medication_code:
+    description: Can include multiple medication codes
+    title: IHMC medication code
+    examples:
+      - value: '810'
+    keywords:
+      - code
+    slot_uri: MIXS:0000884
+    range: integer
+    multivalued: true
+  indoor_space:
+    description: A distinguishable space within a structure, the purpose for which discrete areas of a building is used
+    title: indoor space
+    examples:
+      - value: foyer
+    keywords:
+      - indoor
+    slot_uri: MIXS:0000763
+    range: IndoorSpaceEnum
+    required: true
+  indoor_surf:
+    description: Type of indoor surface
+    title: indoor surface
+    examples:
+      - value: wall
+    keywords:
+      - indoor
+      - surface
+    slot_uri: MIXS:0000764
+    range: IndoorSurfEnum
+  indust_eff_percent:
+    annotations:
+      Preferred_unit: percentage
+    description: Percentage of industrial effluents received by wastewater treatment plant
+    title: industrial effluent percent
+    keywords:
+      - percent
+    slot_uri: MIXS:0000662
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  inorg_particles:
+    annotations:
+      Expected_value: inorganic particle name;measurement value
+      Preferred_unit: mole per liter, milligram per liter
+    description: Concentration of particles such as sand, grit, metal particles, ceramics, etc.; can include multiple particles
+    title: inorganic particles
+    keywords:
+      - inorganic
+      - particle
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000664
+    multivalued: true
+  inside_lux:
+    annotations:
+      Preferred_unit: kilowatt per square metre
+    description: The recorded value at sampling time (power density)
+    title: inside lux light
+    keywords:
+      - inside
+      - light
+    slot_uri: MIXS:0000168
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  int_wall_cond:
+    description: The physical condition of the wall at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas
+    title: interior wall condition
+    examples:
+      - value: damaged
+    keywords:
+      - condition
+      - interior
+      - wall
+    slot_uri: MIXS:0000813
+    range: DamagedEnum
+  intended_consumer:
+    annotations:
+      Expected_value: FOODON_03510136 or NCBI taxid
+    description: Food consumer type, human or animal, for which the food product is produced and marketed. This field accepts terms listed under food consumer group (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
+    title: intended consumer
+    examples:
+      - value: 9606 o rsenior as food consumer [FOODON:03510254]
+    keywords:
+      - consumer
+    string_serialization: '{integer}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001144
+    multivalued: true
+  isol_growth_condt:
+    description: Publication reference in the form of pubmed ID (pmid), digital object identifier (doi) or url for isolation and growth condition specifications of the organism/material
+    title: isolation and growth condition
+    examples:
+      - value: doi:10.1016/j.syapm.2018.01.009
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - condition
+      - growth
+      - isolation
+    slot_uri: MIXS:0000003
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  iw_bt_date_well:
+    description: Injection water breakthrough date per well following a secondary and/or tertiary recovery
+    title: injection water breakthrough date of specific well
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    keywords:
+      - date
+      - water
+    slot_uri: MIXS:0001010
+    range: datetime
+  iwf:
+    annotations:
+      Preferred_unit: percent
+    description: Proportion of the produced fluids derived from injected water at the time of sampling. (e.g. 87%)
+    title: injection water fraction
+    comments:
+      - pattern was "[0-9]*\\.?[0-9]+ ?%"
+      - percent or float?
+    examples:
+      - value: '0.79'
+    keywords:
+      - fraction
+      - water
+    slot_uri: MIXS:0000455
+    range: float
+    required: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  kidney_disord:
+    description: History of kidney disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, kidney disease (https://disease-ontology.org/?id=DOID:557)
+    title: urine/kidney disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000277
+    range: string
+    multivalued: true
+  last_clean:
+    description: The last time the floor was cleaned (swept, mopped, vacuumed)
+    title: last time swept/mopped/vacuumed
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    keywords:
+      - time
+    slot_uri: MIXS:0000814
+    range: datetime
+  lat_lon:
+    description: The geographical origin of the sample as defined by latitude and longitude. The values should be reported in decimal degrees, limited to 8 decimal points, and in WGS84 system
+    title: geographic location (latitude and longitude)
+    examples:
+      - value: 50.586825 6.408977
+    in_subset:
+      - environment
+    keywords:
+      - geographic
+      - location
+    slot_uri: MIXS:0000009
+    required: true
+    pattern: ^(-?((?:[0-8]?[0-9](?:\.\d{0,8})?)|90)) -?[0-9]+(?:\.[0-9]{0,8})?$|^-?(1[0-7]{1,2})$
+    structured_pattern:
+      syntax: ^{lat} {lon}$
+      interpolated: true
+      partial_match: true
+  lib_layout:
+    description: Specify whether to expect single, paired, or other configuration of reads
+    title: library layout
+    examples:
+      - value: paired
+    in_subset:
+      - sequencing
+    keywords:
+      - library
+    slot_uri: MIXS:0000041
+    range: LibLayoutEnum
+  lib_reads_seqd:
+    description: Total number of clones sequenced from the library
+    title: library reads sequenced
+    examples:
+      - value: '20'
+    in_subset:
+      - sequencing
+    keywords:
+      - library
+    slot_uri: MIXS:0000040
+    range: integer
+  lib_screen:
+    annotations:
+      Expected_value: screening strategy name
+    description: Specific enrichment or screening methods applied before and/or after creating libraries
+    title: library screening strategy
+    examples:
+      - value: enriched, screened, normalized
+    in_subset:
+      - sequencing
+    keywords:
+      - library
+    slot_uri: MIXS:0000043
+    range: string
+  lib_size:
+    description: Total number of clones in the library prepared for the project
+    title: library size
+    examples:
+      - value: '50'
+    in_subset:
+      - sequencing
+    keywords:
+      - library
+      - size
+    slot_uri: MIXS:0000039
+    range: integer
+  lib_vector:
+    annotations:
+      Expected_value: vector
+    description: Cloning vector type(s) used in construction of libraries
+    title: library vector
+    examples:
+      - value: Bacteriophage P1
+    in_subset:
+      - sequencing
+    keywords:
+      - library
+    slot_uri: MIXS:0000042
+    range: string
+  library_prep_kit:
+    annotations:
+      Expected_value: name of library preparation kit
+    description: Packaged kits (containing adapters, indexes, enzymes, buffers etc.), tailored for specific sequencing workflows, which allow the simplified preparation of sequencing-ready libraries for small genomes, amplicons, and plasmids
+    title: library preparation kit
+    keywords:
+      - kit
+      - library
+      - preparation
+    slot_uri: MIXS:0001145
+    range: string
+  light_intensity:
+    annotations:
+      Preferred_unit: lux
+    description: Measurement of light intensity
+    title: light intensity
+    examples:
+      - value: 0.3 lux
+    keywords:
+      - intensity
+      - light
+    slot_uri: MIXS:0000706
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  light_regm:
+    annotations:
+      Expected_value: exposure type;light intensity;light quality
+      Preferred_unit: lux; micrometer, nanometer, angstrom
+    description: Information about treatment(s) involving exposure to light, including both light intensity and quality
+    title: light regimen
+    examples:
+      - value: incandescant light;10 lux;450 nanometer
+    keywords:
+      - light
+      - regimen
+    string_serialization: '{text};{float} {unit};{float} {unit}'
+    slot_uri: MIXS:0000569
+  light_type:
+    description: Application of light to achieve some practical or aesthetic effect. Lighting includes the use of both artificial light sources such as lamps and light fixtures, as well as natural illumination by capturing daylight. Can also include absence of light
+    title: light type
+    examples:
+      - value: desk lamp
+    keywords:
+      - light
+      - type
+    slot_uri: MIXS:0000769
+    range: LightTypeEnum
+    required: true
+    multivalued: true
+  link_addit_analys:
+    description: Link to additional analysis results performed on the sample
+    title: links to additional analysis
+    keywords:
+      - link
+    slot_uri: MIXS:0000340
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  link_class_info:
+    annotations:
+      Expected_value: PMID,DOI or url
+    description: Link to digitized soil maps or other soil classification information
+    title: link to classification information
+    keywords:
+      - classification
+      - information
+      - link
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0000329
+  link_climate_info:
+    description: Link to climate resource
+    title: link to climate information
+    keywords:
+      - information
+      - link
+    slot_uri: MIXS:0000328
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  lithology:
+    description: 'Hydrocarbon resource main lithology (Additional information: http://petrowiki.org/Lithology_and_rock_type_determination). If "other" is specified, please propose entry in "additional info" field'
+    title: lithology
+    examples:
+      - value: Volcanic
+    keywords:
+      - lithology
+    slot_uri: MIXS:0000990
+    range: LithologyEnum
+    recommended: true
+  liver_disord:
+    description: History of liver disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, liver disease (https://disease-ontology.org/?id=DOID:409)
+    title: liver disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000282
+    range: string
+    multivalued: true
+  local_class:
+    annotations:
+      Expected_value: local classification name
+    description: Soil classification based on local soil classification system
+    title: soil_taxonomic/local classification
+    keywords:
+      - classification
+    slot_uri: MIXS:0000330
+    range: string
+  local_class_meth:
+    description: Reference or method used in determining the local soil classification
+    title: soil_taxonomic/local classification method
+    keywords:
+      - classification
+      - method
+    slot_uri: MIXS:0000331
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  lot_number:
+    annotations:
+      Expected_value: lot number, item
+    description: 'A distinctive alpha-numeric identification code assigned by the manufacturer or distributor to a specific quantity of manufactured material or product within a batch. Synonym: Batch Number.  The submitter should provide lot number of the item followed by the item name for which the lot number was provided'
+    title: lot number
+    examples:
+      - value: 1239ABC01A, split Cornish hens
+    keywords:
+      - number
+    string_serialization: '{integer}, {text}'
+    slot_uri: MIXS:0001147
+    multivalued: true
+  mag_cov_software:
+    description: Tool(s) used to determine the genome coverage if coverage is used as a binning parameter in the extraction of genomes from metagenomic datasets
+    title: MAG coverage software
+    examples:
+      - value: bbmap
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    slot_uri: MIXS:0000080
+    range: MagCovSoftwareEnum
+  magnesium:
+    annotations:
+      Preferred_unit: mole per liter, milligram per liter, parts per million, micromole per kilogram
+    description: Concentration of magnesium in the sample
+    title: magnesium
+    examples:
+      - value: 52.8 micromole per kilogram
+    slot_uri: MIXS:0000431
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  maternal_health_stat:
+    description: Specification of the maternal health status
+    title: amniotic fluid/maternal health status
+    keywords:
+      - status
+    slot_uri: MIXS:0000273
+    range: string
+  max_occup:
+    description: The maximum amount of people allowed in the indoor environment
+    title: maximum occupancy
+    keywords:
+      - maximum
+    slot_uri: MIXS:0000229
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  mean_frict_vel:
+    annotations:
+      Preferred_unit: meter per second
+    description: Measurement of mean friction velocity
+    title: mean friction velocity
+    examples:
+      - value: 0.5 meter per second
+    keywords:
+      - mean
+      - velocity
+    slot_uri: MIXS:0000498
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  mean_peak_frict_vel:
+    annotations:
+      Preferred_unit: meter per second
+    description: Measurement of mean peak friction velocity
+    title: mean peak friction velocity
+    examples:
+      - value: 1 meter per second
+    keywords:
+      - mean
+      - peak
+      - velocity
+    slot_uri: MIXS:0000502
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  mech_struc:
+    description: 'mechanical structure: a moving structure'
+    title: mechanical structure
+    examples:
+      - value: elevator
+    slot_uri: MIXS:0000815
+    range: MechStrucEnum
+  mechanical_damage:
+    annotations:
+      Expected_value: damage type;body site
+    description: Information about any mechanical damage exerted on the plant; can include multiple damages and sites
+    title: mechanical damage
+    examples:
+      - value: pruning;bark
+    string_serialization: '{text};{text}'
+    slot_uri: MIXS:0001052
+    multivalued: true
+  medic_hist_perform:
+    description: Whether full medical history was collected
+    title: medical history performed
+    examples:
+      - value: '1'
+    keywords:
+      - history
+    slot_uri: MIXS:0000897
+    range: boolean
+  menarche:
+    description: Date of most recent menstruation
+    title: menarche
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    slot_uri: MIXS:0000965
+    range: datetime
+  menopause:
+    description: Date of onset of menopause
+    title: menopause
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    slot_uri: MIXS:0000968
+    range: datetime
+  methane:
+    annotations:
+      Preferred_unit: micromole per liter, parts per billion, parts per million
+    description: Methane (gas) amount or concentration at the time of sampling
+    title: methane
+    slot_uri: MIXS:0000101
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  micro_biomass_meth:
+    description: Reference or method used in determining microbial biomass
+    title: microbial biomass method
+    comments:
+      - slot name/scn was microbial_biomass_meth
+    examples:
+      - value: http://dx.doi.org/10.1016/j.soilbio.2005.01.021
+    keywords:
+      - biomass
+      - method
+      - microbial
+    slot_uri: MIXS:0000339
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  microb_cult_med:
+    description: A culture medium used to select for, grow, and maintain prokaryotic microorganisms. Can be in either liquid (broth) or solidified (e.g. with agar) forms. This field accepts terms listed under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067). If the proper descriptor is not listed please use text to describe the culture medium
+    title: microbiological culture medium
+    examples:
+      - value: brain heart infusion agar [MICRO:0000566]
+    keywords:
+      - culture
+      - microbiological
+    slot_uri: MIXS:0001216
+    range: string
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    structured_pattern:
+      syntax: ^{text}|({termLabel} \[{termID}\])$
+      interpolated: true
+      partial_match: true
+  microb_start:
+    annotations:
+      Expected_value: FOODON:03544453
+    description: Any type of microorganisms used in food production.  This field accepts terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
+    title: microbial starter
+    examples:
+      - value: starter cultures [FOODON:03544454]
+    keywords:
+      - microbial
+    string_serialization: '{term label} [{termID}]|{text}'
+    slot_uri: MIXS:0001217
+  microb_start_count:
+    annotations:
+      Expected_value: organism name; measurement value; enumeration
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram of dry weight
+    description: 'Total cell count of starter culture per gram, volume or area of sample and the method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) should also be provided. (example : total prokaryotes; 3.5e7 cells per ml; qPCR)'
+    title: microbial starter organism count
+    examples:
+      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
+    keywords:
+      - count
+      - microbial
+      - organism
+    string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|spread plate|other]'
+    slot_uri: MIXS:0001218
+  microb_start_inoc:
+    annotations:
+      Preferred_unit: milligram or gram
+    description: The amount of starter culture used to inoculate a new batch
+    title: microbial starter inoculation
+    examples:
+      - value: 100 milligrams
+    keywords:
+      - microbial
+    slot_uri: MIXS:0001219
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  microb_start_prep:
+    description: Information about the protocol or method used to prepare the starter inoculum
+    title: microbial starter preparation
+    examples:
+      - value: liquid starter culture, propagated 3 cycles in milk prior to inoculation
+    keywords:
+      - microbial
+      - preparation
+    slot_uri: MIXS:0001220
+    range: string
+  microb_start_source:
+    description: The source from which the microbial starter culture was sourced.  If commercially supplied, list supplier
+    title: microbial starter source
+    examples:
+      - value: backslopped, GetCulture
+    keywords:
+      - microbial
+      - source
+    slot_uri: MIXS:0001221
+    range: string
+  microb_start_taxID:
+    description: Please include Genus species and strain ID, if known of microorganisms used in food production. For complex communities, pipes can be used to separate two or more microbes
+    title: microbial starter NCBI taxonomy ID
+    examples:
+      - value: Lactobacillus rhamnosus [NCIT:C123495]
+    keywords:
+      - identifier
+      - microbial
+      - ncbi
+      - taxon
+    slot_uri: MIXS:0001222
+    range: string
+    pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^({termLabel} \[{termID}\])|{integer}$
+      interpolated: true
+      partial_match: true
+  microbial_biomass:
+    annotations:
+      Preferred_unit: ton, kilogram, gram per kilogram soil
+    description: The part of the organic matter in the soil that constitutes living microorganisms smaller than 5-10 micrometer. If you keep this, you would need to have correction factors used for conversion to the final units
+    title: microbial biomass
+    keywords:
+      - biomass
+      - microbial
+    slot_uri: MIXS:0000650
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  mid:
+    description: Molecular barcodes, called Multiplex Identifiers (MIDs), that are used to specifically tag unique samples in a sequencing run. Sequence should be reported in uppercase letters
+    title: multiplex identifiers
+    examples:
+      - value: GTGAATAT
+    in_subset:
+      - sequencing
+    keywords:
+      - identifier
+    slot_uri: MIXS:0000047
+    range: string
+    pattern: ^[ACGTRKSYMWBHDVN]+$
+    structured_pattern:
+      syntax: ^{ambiguous_nucleotides}$
+      interpolated: true
+      partial_match: true
+  mineral_nutr_regm:
+    annotations:
+      Expected_value: mineral nutrient name;mineral nutrient amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving the use of mineral supplements; should include the name of mineral nutrient, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple mineral nutrient regimens
+    title: mineral nutrient regimen
+    examples:
+      - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - mineral
+      - nutrient
+      - regimen
+    string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000570
+    multivalued: true
+  misc_param:
+    annotations:
+      Expected_value: parameter name;measurement value
+    description: Any other measurement performed or parameter collected, that is not listed here
+    title: miscellaneous parameter
+    examples:
+      - value: Bicarbonate ion concentration;2075 micromole per kilogram
+    keywords:
+      - parameter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000752
+    multivalued: true
+  mode_transmission:
+    description: The process through which the symbiotic host organism entered the host from which it was sampled
+    title: mode of transmission
+    examples:
+      - value: horizontal:castrator
+    slot_uri: MIXS:0001312
+    range: ModeTransmissionEnum
+    recommended: true
+  n_alkanes:
+    annotations:
+      Expected_value: n-alkane name;measurement value
+    description: Concentration of n-alkanes; can include multiple n-alkanes
+    title: n-alkanes
+    examples:
+      - value: n-hexadecane;100 milligram per liter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000503
+    multivalued: true
+  neg_cont_type:
+    annotations:
+      Expected_value: enumeration or text
+    description: The substance or equipment used as a negative control in an investigation
+    title: negative control type
+    in_subset:
+      - investigation
+    keywords:
+      - type
+    slot_uri: MIXS:0001321
+    range: NegContTypeEnum
+    recommended: true
+  nitrate:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: Concentration of nitrate in the sample
+    title: nitrate
+    examples:
+      - value: 65 micromole per liter
+    keywords:
+      - nitrate
+    slot_uri: MIXS:0000425
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  nitrite:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: Concentration of nitrite in the sample
+    title: nitrite
+    examples:
+      - value: 0.5 micromole per liter
+    keywords:
+      - nitrite
+    slot_uri: MIXS:0000426
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  nitro:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Concentration of nitrogen (total)
+    title: nitrogen
+    examples:
+      - value: 4.2 micromole per liter
+    keywords:
+      - nitrogen
+    slot_uri: MIXS:0000504
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  non_min_nutr_regm:
+    annotations:
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving the exposure of plant to non-mineral nutrient such as oxygen, hydrogen or carbon; should include the name of non-mineral nutrient, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple non-mineral nutrient regimens
+    title: non-mineral nutrient regimen
+    examples:
+      - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
+    keywords:
+      - non-mineral
+      - nutrient
+      - regimen
+    slot_uri: MIXS:0000571
+    range: string
+    multivalued: true
+  nose_mouth_teeth_throat_disord:
+    description: History of nose/mouth/teeth/throat disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, nose disease (https://disease-ontology.org/?id=DOID:2825), mouth disease (https://disease-ontology.org/?id=DOID:403), tooth disease (https://disease-ontology.org/?id=DOID:1091), or upper respiratory tract disease (https://disease-ontology.org/?id=DOID:974)
+    title: nose/mouth/teeth/throat disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000283
+    range: string
+    multivalued: true
+  nose_throat_disord:
+    description: History of nose-throat disorders; can include multiple disorders,  The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, lung disease (https://disease-ontology.org/?id=DOID:850), upper respiratory tract disease (https://disease-ontology.org/?id=DOID:974)
+    title: nose throat disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000270
+    range: string
+    multivalued: true
+  nucl_acid_amp:
+    description: A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the enzymatic amplification (PCR, TMA, NASBA) of specific nucleic acids
+    title: nucleic acid amplification
+    examples:
+      - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000038
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  nucl_acid_ext:
+    description: A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the material separation to recover the nucleic acid fraction from a sample
+    title: nucleic acid extraction
+    examples:
+      - value: https://mobio.com/media/wysiwyg/pdfs/protocols/12888.pdf
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000037
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  nucl_acid_ext_kit:
+    annotations:
+      Expected_value: The name of an extraction kit
+    description: The name of the extraction kit used to recover the nucleic acid fraction of an input material is performed
+    title: nucleic acid extraction kit
+    examples:
+      - value: Qiagen PowerSoil Kit
+    keywords:
+      - kit
+    slot_uri: MIXS:0001223
+    range: string
+    multivalued: true
+  num_replicons:
+    annotations:
+      Expected_value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses: segments'
+    description: Reports the number of replicons in a nuclear genome of eukaryotes, in the genome of a bacterium or archaea or the number of segments in a segmented virus. Always applied to the haploid chromosome count of a eukaryote
+    title: number of replicons
+    examples:
+      - value: '2'
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - number
+    string_serialization: '{integer}'
+    slot_uri: MIXS:0000022
+    range: integer
+  num_samp_collect:
+    description: The number of samples collected during the current sampling event
+    title: number of samples collected
+    examples:
+      - value: 116 samples
+    keywords:
+      - number
+      - sample
+    slot_uri: MIXS:0001224
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  number_contig:
+    description: Total number of contigs in the cleaned/submitted assembly that makes up a given genome, SAG, MAG, or UViG
+    title: number of contigs
+    examples:
+      - value: '40'
+    in_subset:
+      - sequencing
+    keywords:
+      - number
+    slot_uri: MIXS:0000060
+    range: integer
+  number_pets:
+    description: The number of pets residing in the sampled space
+    title: number of pets
+    keywords:
+      - number
+    slot_uri: MIXS:0000231
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  number_plants:
+    description: The number of plant(s) in the sampling space
+    title: number of houseplants
+    keywords:
+      - number
+    slot_uri: MIXS:0000230
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  number_resident:
+    description: The number of individuals currently occupying in the sampling location
+    title: number of residents
+    keywords:
+      - number
+    slot_uri: MIXS:0000232
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  occup_density_samp:
+    description: Average number of occupants at time of sampling per square footage
+    title: occupant density at sampling
+    examples:
+      - value: '0.1'
+    keywords:
+      - density
+    slot_uri: MIXS:0000217
+    range: float
+    required: true
+  occup_document:
+    description: The type of documentation of occupancy
+    title: occupancy documentation
+    examples:
+      - value: estimate
+    keywords:
+      - documentation
+    slot_uri: MIXS:0000816
+    range: OccupDocumentEnum
+  occup_samp:
+    description: Number of occupants present at time of sample within the given space
+    title: occupancy at sampling
+    examples:
+      - value: '10'
+    slot_uri: MIXS:0000772
+    range: float
+    required: true
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  org_carb:
+    description: Concentration of organic carbon
+    title: organic carbon
+    examples:
+      - value: 1.5 microgram per liter
+    keywords:
+      - carbon
+      - organic
+    slot_uri: MIXS:0000508
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  org_count_qpcr_info:
+    annotations:
+      Expected_value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes; total cycles
+      Preferred_unit: number of cells per gram (or ml or cm^2)
+    description: 'If qpcr was used for the cell count, the target gene name, the primer sequence and the cycling conditions should also be provided. (Example: 16S rrna; FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min; denaturation:90C_2min; annealing:52C_30 sec; elongation:72C_30 sec; 90 C for 1 min; final elongation:72C_5min; 30 cycles)'
+    title: organism count qPCR information
+    keywords:
+      - count
+      - information
+      - organism
+    string_serialization: '{text};FWD:{dna};REV:{dna};initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes; total cycles'
+    slot_uri: MIXS:0000099
+  org_matter:
+    annotations:
+      Preferred_unit: microgram per liter
+    description: Concentration of organic matter
+    title: organic matter
+    examples:
+      - value: 1.75 milligram per cubic meter
+    keywords:
+      - organic
+    slot_uri: MIXS:0000204
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  org_nitro:
+    description: Concentration of organic nitrogen
+    title: organic nitrogen
+    examples:
+      - value: 4 micromole per liter
+    keywords:
+      - nitrogen
+      - organic
+    slot_uri: MIXS:0000205
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  org_particles:
+    annotations:
+      Expected_value: particle name;measurement value
+      Preferred_unit: gram per liter
+    description: Concentration of particles such as faeces, hairs, food, vomit, paper fibers, plant material, humus, etc
+    title: organic particles
+    keywords:
+      - organic
+      - particle
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000665
+    multivalued: true
+  organism_count:
+    annotations:
+      Expected_value: organism name;measurement value;enumeration
+    description: 'Total cell count of any organism (or group of organisms) per gram, volume or area of sample, should include name of organism followed by count. The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should also be provided. (example: total prokaryotes; 3.5e7 cells per ml; qpcr)'
+    title: organism count
+    keywords:
+      - count
+      - organism
+    string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|other]'
+    slot_uri: MIXS:0000103
+    multivalued: true
+  otu_class_appr:
+    annotations:
+      Expected_value: cutoffs and method used
+    description: Cutoffs and approach used when clustering  species-level  OTUs. Note that results from standard 95% ANI / 85% AF clustering should be provided alongside OTUS defined from another set of thresholds, even if the latter are the ones primarily used during the analysis
+    title: OTU classification approach
+    examples:
+      - value: 95% ANI;85% AF; greedy incremental clustering
+    in_subset:
+      - sequencing
+    keywords:
+      - classification
+      - otu
+    string_serialization: '{ANI cutoff};{AF cutoff};{clustering method}'
+    slot_uri: MIXS:0000085
+  otu_db:
+    annotations:
+      Expected_value: database and version
+    description: Reference database (i.e. sequences not generated as part of the current study) used to cluster new genomes in "species-level" OTUs, if any
+    title: OTU database
+    examples:
+      - value: NCBI Viral RefSeq;83
+    in_subset:
+      - sequencing
+    keywords:
+      - database
+      - otu
+    string_serialization: '{database};{version}'
+    slot_uri: MIXS:0000087
+  otu_seq_comp_appr:
+    annotations:
+      Expected_value: software name, version and relevant parameters
+    description: Tool and thresholds used to compare sequences when computing "species-level" OTUs
+    title: OTU sequence comparison approach
+    examples:
+      - value: 'blastn;2.6.0+;e-value cutoff: 0.001'
+    in_subset:
+      - sequencing
+    keywords:
+      - otu
+    string_serialization: '{software};{version};{parameters}'
+    slot_uri: MIXS:0000086
+  owc_tvdss:
+    annotations:
+      Preferred_unit: meter
+    description: Depth of the original oil water contact (OWC) zone (average) (m TVDSS)
+    title: oil water contact depth
+    keywords:
+      - depth
+      - oil
+      - water
+    slot_uri: MIXS:0000405
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  oxy_stat_samp:
+    description: Oxygenation status of sample
+    title: oxygenation status of sample
+    examples:
+      - value: aerobic
+    keywords:
+      - oxygen
+      - sample
+      - status
+    slot_uri: MIXS:0000753
+    range: OxyStatSampEnum
+  oxygen:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Oxygen (gas) amount or concentration at the time of sampling
+    title: oxygen
+    examples:
+      - value: 600 parts per million
+    keywords:
+      - oxygen
+    slot_uri: MIXS:0000104
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  part_org_carb:
+    description: Concentration of particulate organic carbon
+    title: particulate organic carbon
+    examples:
+      - value: 1.92 micromole per liter
+    keywords:
+      - carbon
+      - organic
+      - particle
+      - particulate
+    slot_uri: MIXS:0000515
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  part_org_nitro:
+    annotations:
+      Preferred_unit: microgram per liter, micromole per liter
+    description: Concentration of particulate organic nitrogen
+    title: particulate organic nitrogen
+    examples:
+      - value: 0.3 micromole per liter
+    keywords:
+      - nitrogen
+      - organic
+      - particle
+      - particulate
+    slot_uri: MIXS:0000719
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  part_plant_animal:
+    annotations:
+      Expected_value: FOODON:03420116
+    description: The anatomical part of the organism being involved in food production or consumption; e.g., a carrot is the root of the plant (root vegetable). This field accepts terms listed under part of plant or animal (http://purl.obolibrary.org/obo/FOODON_03420116)
+    title: part of plant or animal
+    examples:
+      - value: chuck [FOODON:03530021]
+    keywords:
+      - animal
+      - plant
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001149
+    multivalued: true
+  particle_class:
+    annotations:
+      Expected_value: particle name;measurement value
+      Preferred_unit: micrometer
+    description: Particles are classified, based on their size, into six general categories:clay, silt, sand, gravel, cobbles, and boulders; should include amount of particle preceded by the name of the particle type; can include multiple values
+    title: particle classification
+    keywords:
+      - classification
+      - particle
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000206
+    multivalued: true
+  pathogenicity:
+    annotations:
+      Expected_value: names of organisms that the entity is pathogenic to
+    description: To what is the entity pathogenic
+    title: known pathogenicity
+    examples:
+      - value: human, animal, plant, fungi, bacteria
+    in_subset:
+      - nucleic acid sequence source
+    slot_uri: MIXS:0000027
+    range: string
+  pcr_cond:
+    annotations:
+      Expected_value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles
+    description: Description of reaction conditions and components of polymerase chain reaction performed during library preparation.
+    title: pcr conditions
+    examples:
+      - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
+      - value: initial denaturation:94degC_1.5min
+    in_subset:
+      - sequencing
+    keywords:
+      - condition
+      - pcr
+    string_serialization: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles
+    slot_uri: MIXS:0000049
+  pcr_primers:
+    annotations:
+      Expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
+    description: PCR primers that were used to amplify the sequence of the targeted gene, locus or subfragment. This field should contain all the primers used for a single PCR reaction if multiple forward or reverse primers are present in a single PCR reaction. The primer sequence should be reported in uppercase letters
+    title: pcr primers
+    examples:
+      - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
+    in_subset:
+      - sequencing
+    keywords:
+      - pcr
+    string_serialization: FWD:{dna};REV:{dna}
+    slot_uri: MIXS:0000046
+  permeability:
+    annotations:
+      Expected_value: measurement value range
+      Preferred_unit: mD
+    description: 'Measure of the ability of a hydrocarbon resource to allow fluids to pass through it. (Additional information: https://en.wikipedia.org/wiki/Permeability_(earth_sciences))'
+    title: permeability
+    string_serialization: '{integer} - {integer} {unit}'
+    slot_uri: MIXS:0000404
+  perturbation:
+    annotations:
+      Expected_value: perturbation type name;perturbation interval and duration
+    description: Type of perturbation, e.g. chemical administration, physical disturbance, etc., coupled with perturbation regimen including how many times the perturbation was repeated, how long each perturbation lasted, and the start and end time of the entire perturbation period; can include multiple perturbation types
+    title: perturbation
+    examples:
+      - value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
+    keywords:
+      - perturbation
+    string_serialization: '{text};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000754
+    multivalued: true
+  pesticide_regm:
+    annotations:
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving use of insecticides; should include the name of pesticide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple pesticide regimens
+    title: pesticide regimen
+    examples:
+      - value: pyrethrum;0.6 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+    slot_uri: MIXS:0000573
+    range: string
+    multivalued: true
+  pet_farm_animal:
+    annotations:
+      Expected_value: presence status;type of animal or pet
+    description: Specification of presence of pets or farm animals in the environment of subject, if yes the animals should be specified; can include multiple animals present
+    title: presence of pets or farm animals
+    examples:
+      - value: yes; 5 cats
+    keywords:
+      - animal
+      - farm
+      - presence
+    string_serialization: '{boolean};{text}'
+    slot_uri: MIXS:0000267
+    multivalued: true
+  petroleum_hydrocarb:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Concentration of petroleum hydrocarbon
+    title: petroleum hydrocarbon
+    examples:
+      - value: 0.05 micromole per liter
+    keywords:
+      - hydrocarbon
+      - petroleum
+    slot_uri: MIXS:0000516
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ph:
+    description: Ph measurement of the sample, or liquid portion of sample, or aqueous phase of the fluid
+    title: pH
+    examples:
+      - value: '7.2'
+    keywords:
+      - ph
+    slot_uri: MIXS:0001001
+    range: float
+  ph_meth:
+    description: Reference or method used in determining pH
+    title: pH method
+    examples:
+      - value: https://www.epa.gov/sites/production/files/2015-12/documents/9040c.pdf
+    keywords:
+      - method
+      - ph
+    slot_uri: MIXS:0001106
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  ph_regm:
+    description: Information about treatment involving exposure of plants to varying levels of ph of the growth media, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimen
+    title: pH regimen
+    examples:
+      - value: 7.6;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - ph
+      - regimen
+    slot_uri: MIXS:0001056
+    range: string
+    multivalued: true
+  phaeopigments:
+    annotations:
+      Expected_value: phaeopigment name;measurement value
+      Preferred_unit: milligram per cubic meter
+    description: Concentration of phaeopigments; can include multiple phaeopigments
+    title: phaeopigments
+    examples:
+      - value: 2.5 milligram per cubic meter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000180
+    multivalued: true
+  phosphate:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Concentration of phosphate
+    title: phosphate
+    examples:
+      - value: 0.7 micromole per liter
+    keywords:
+      - phosphate
+    slot_uri: MIXS:0000505
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  phosplipid_fatt_acid:
+    annotations:
+      Expected_value: phospholipid fatty acid name;measurement value
+    description: Concentration of phospholipid fatty acids; can include multiple values
+    title: phospholipid fatty acid
+    examples:
+      - value: 2.98 milligram per liter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000181
+    multivalued: true
+  photon_flux:
+    annotations:
+      Preferred_unit: number of photons per second per unit area
+    description: Measurement of photon flux
+    title: photon flux
+    examples:
+      - value: 3.926 micromole photons per second per square meter
+    slot_uri: MIXS:0000725
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  photosynt_activ:
+    annotations:
+      Preferred_unit: mol m-2 s-1
+    description: Measurement of photosythetic activity (i.e. leaf gas exchange / chlorophyll fluorescence emissions / reflectance / transpiration) Please also include the term method term detailing the method of activity measurement
+    title: photosynthetic activity
+    examples:
+      - value: 0.1 mol CO2 m-2 s-1
+        description: added a magnitude to the example from the XLSX file, " mol CO2 m-2 s-1"
+    slot_uri: MIXS:0001296
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  photosynt_activ_meth:
+    description: Reference or method used in measurement of photosythetic activity
+    title: photosynthetic activity method
+    keywords:
+      - method
+    slot_uri: MIXS:0001336
+    range: string
+    recommended: true
+    multivalued: true
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}|{text}$
+      interpolated: true
+      partial_match: true
+  plant_growth_med:
+    annotations:
+      Expected_value: EO or enumeration
+    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from EO:plant growth medium (follow this link for terms http://purl.obolibrary.org/obo/EO_0007147) or other controlled vocabulary
+    title: plant growth medium
+    keywords:
+      - growth
+      - plant
+    string_serialization: '{termLabel} [{termID}] or [husk|other artificial liquid medium|other artificial solid medium|peat moss|perlite|pumice|sand|soil|vermiculite|water]'
+    slot_uri: MIXS:0001057
+  plant_part_maturity:
+    annotations:
+      Expected_value: FOODON:03530050
+    description: A description of the stage of development of a plant or plant part based on maturity or ripeness. This field accepts terms listed under degree of plant maturity (http://purl.obolibrary.org/obo/FOODON_03530050)
+    title: degree of plant part maturity
+    examples:
+      - value: ripe or mature [FOODON:03530052]
+    keywords:
+      - degree
+      - plant
+    string_serialization: '{term label}{term ID}'
+    slot_uri: MIXS:0001120
+  plant_product:
+    annotations:
+      Expected_value: product name
+    description: Substance produced by the plant, where the sample was obtained from
+    title: plant product
+    examples:
+      - value: xylem sap [PO:0025539]
+    keywords:
+      - plant
+      - product
+    slot_uri: MIXS:0001058
+    range: string
+  plant_reprod_crop:
+    description: Plant reproductive part used in the field during planting to start the crop
+    title: plant reproductive part
+    examples:
+      - value: seedling
+    keywords:
+      - plant
+    slot_uri: MIXS:0001150
+    range: PlantReprodCropEnum
+    multivalued: true
+  plant_sex:
+    description: Sex of the reproductive parts on the whole plant, e.g. pistillate, staminate, monoecieous, hermaphrodite
+    title: plant sex
+    examples:
+      - value: Hermaphroditic
+    keywords:
+      - plant
+    slot_uri: MIXS:0001059
+    range: PlantSexEnum
+  plant_struc:
+    description: Name of plant structure the sample was obtained from; for Plant Ontology (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO, e.g. petiole epidermis (PO_0000051). If an individual flower is sampled, the sex of it can be recorded here
+    title: plant structure
+    examples:
+      - value: epidermis [PO:0005679]
+    keywords:
+      - plant
+    slot_uri: MIXS:0001060
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  plant_water_method:
+    description: Description of the equipment or method used to distribute water to crops. This field accepts termed listed under irrigation process (http://purl.obolibrary.org/obo/AGRO_00000006). Multiple terms can be separated by pipes
+    title: plant water delivery method
+    examples:
+      - value: drip irrigation process [AGRO:00000056]
+    keywords:
+      - delivery
+      - method
+      - plant
+      - water
+    slot_uri: MIXS:0001111
+    range: string
+    recommended: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  ploidy:
+    description: The ploidy level of the genome (e.g. allopolyploid, haploid, diploid, triploid, tetraploid). It has implications for the downstream study of duplicated gene and regions of the genomes (and perhaps for difficulties in assembly). For terms, please select terms listed under class ploidy (PATO:001374) of Phenotypic Quality Ontology (PATO), and for a browser of PATO (v 2018-03-27) please refer to http://purl.bioontology.org/ontology/PATO
+    title: ploidy
+    examples:
+      - value: allopolyploidy [PATO:0001379]
+    in_subset:
+      - nucleic acid sequence source
+    slot_uri: MIXS:0000021
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  pollutants:
+    annotations:
+      Expected_value: pollutant name;measurement value
+      Preferred_unit: gram, mole per liter, milligram per liter, microgram per cubic meter
+    description: Pollutant types and, amount or concentrations measured at the time of sampling; can report multiple pollutants by entering numeric values preceded by name of pollutant
+    title: pollutants
+    examples:
+      - value: lead;0.15 microgram per cubic meter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000107
+    multivalued: true
+  pool_dna_extracts:
+    annotations:
+      Expected_value: pooling status;number of pooled extracts
+      Preferred_unit: gram, milliliter, microliter
+    description: Indicate whether multiple DNA extractions were mixed. If the answer yes, the number of extracts that were pooled should be given
+    title: pooling of DNA extracts (if done)
+    examples:
+      - value: yes, 5
+    keywords:
+      - dna
+      - pooling
+    slot_uri: MIXS:0000325
+  porosity:
+    annotations:
+      Expected_value: measurement value or range
+      Preferred_unit: percentage
+    description: Porosity of deposited sediment is volume of voids divided by the total volume of sample
+    title: porosity
+    keywords:
+      - porosity
+    string_serialization: '{float} - {float} {unit}'
+    slot_uri: MIXS:0000211
+  pos_cont_type:
+    description: The substance, mixture, product, or apparatus used to verify that a process which is part of an investigation delivers a true positive
+    title: positive control type
+    in_subset:
+      - investigation
+    keywords:
+      - type
+    string_serialization: '{term} or {text}'
+    slot_uri: MIXS:0001322
+    recommended: true
+  potassium:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of potassium in the sample
+    title: potassium
+    examples:
+      - value: 463 milligram per liter
+    slot_uri: MIXS:0000430
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  pour_point:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: 'Temperature at which a liquid becomes semi solid and loses its flow characteristics. In crude oil a high  pour point  is generally associated with a high paraffin content, typically found in crude deriving from a larger proportion of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
+    title: pour point
+    slot_uri: MIXS:0000127
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  pre_treatment:
+    annotations:
+      Expected_value: pre-treatment type
+    description: The process of pre-treatment removes materials that can be easily collected from the raw wastewater
+    title: pre-treatment
+    slot_uri: MIXS:0000348
+    range: string
+  pred_genome_struc:
+    description: Expected structure of the viral genome
+    title: predicted genome structure
+    examples:
+      - value: non-segmented
+    in_subset:
+      - sequencing
+    keywords:
+      - predict
+    slot_uri: MIXS:0000083
+    range: PredGenomeStrucEnum
+  pred_genome_type:
+    annotations:
+      Expected_value: enumeration
+    description: Type of genome predicted for the UViG
+    title: predicted genome type
+    examples:
+      - value: dsDNA
+    in_subset:
+      - sequencing
+    keywords:
+      - predict
+      - type
+    string_serialization: '[DNA|dsDNA|ssDNA|RNA|dsRNA|ssRNA|ssRNA (+)|ssRNA (-)|mixed|uncharacterized]'
+    slot_uri: MIXS:0000082
+  pregnancy:
+    description: Date due of pregnancy
+    title: pregnancy
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    slot_uri: MIXS:0000966
+    range: datetime
+  pres_animal_insect:
+    annotations:
+      Expected_value: enumeration;count
+    description: The type and number of animals or insects present in the sampling space
+    title: presence of pets, animals, or insects
+    examples:
+      - value: cat;5
+    keywords:
+      - animal
+      - presence
+    string_serialization: '[cat|dog|rodent|snake|other];{integer}'
+    slot_uri: MIXS:0000819
+  pressure:
+    annotations:
+      Preferred_unit: atmosphere
+    description: Pressure to which the sample is subject to, in atmospheres
+    title: pressure
+    examples:
+      - value: 50 atmosphere
+    keywords:
+      - pressure
+    slot_uri: MIXS:0000412
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  prev_land_use_meth:
+    description: Reference or method used in determining previous land use and dates
+    title: history/previous land use method
+    keywords:
+      - history
+      - land
+      - method
+      - use
+    slot_uri: MIXS:0000316
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  previous_land_use:
+    annotations:
+      Expected_value: land use name;date
+    description: Previous land use and dates
+    title: history/previous land use
+    examples:
+      - value: fallow; 2018-05-11:T14:30Z
+    keywords:
+      - history
+      - land
+      - use
+    string_serialization: '{text};{timestamp}'
+    slot_uri: MIXS:0000315
+  primary_prod:
+    annotations:
+      Preferred_unit: milligram per cubic meter per day, gram per square meter per day
+    description: Measurement of primary production, generally measured as isotope uptake
+    title: primary production
+    examples:
+      - value: 100 milligram per cubic meter per day
+    keywords:
+      - primary
+      - production
+    slot_uri: MIXS:0000728
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  primary_treatment:
+    annotations:
+      Expected_value: primary treatment type
+    description: The process to produce both a generally homogeneous liquid capable of being treated biologically and a sludge that can be separately treated or processed
+    title: primary treatment
+    keywords:
+      - primary
+      - treatment
+    slot_uri: MIXS:0000349
+    range: string
+  prod_label_claims:
+    description: Labeling claims containing descriptors such as wild caught, free-range, organic, free-range, industrial, hormone-free, antibiotic free, cage free. Can include more than one term, separated by ";"
+    title: production labeling claims
+    examples:
+      - value: free range
+    keywords:
+      - production
+    slot_uri: MIXS:prod_label_claims
+    range: string
+    multivalued: true
+  prod_rate:
+    annotations:
+      Preferred_unit: cubic meter per day
+    description: Oil and/or gas production rates per well (e.g. 524 m3 / day)
+    title: production rate
+    keywords:
+      - production
+      - rate
+    slot_uri: MIXS:0000452
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  prod_start_date:
+    description: Date of field's first production
+    title: production start date
+    examples:
+      - value: '2013-03-25T12:42:31+01:00'
+    keywords:
+      - date
+      - production
+      - start
+    slot_uri: MIXS:0001008
+    range: datetime
+    recommended: true
+  profile_position:
+    description: Cross-sectional position in the hillslope where sample was collected.sample area position in relation to surrounding areas
+    title: profile position
+    examples:
+      - value: summit
+    slot_uri: MIXS:0001084
+    range: ProfilePositionEnum
+  project_name:
+    description: Name of the project within which the sequencing was organized
+    title: project name
+    examples:
+      - value: Forest soil metagenome
+    in_subset:
+      - investigation
+    keywords:
+      - project
+    slot_uri: MIXS:0000092
+    range: string
+    required: true
+  propagation:
+    annotations:
+      Expected_value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid: incompatibility group; for eukaryote: asexual, sexual; other more specific values (e.g., incompatibility group) are allowed'
+    description: 'The type of reproduction from the parent stock. Values for this field is specific to different taxa. For phage or virus: lytic/lysogenic/temperate/obligately lytic. For plasmids: incompatibility group. For eukaryotes: sexual/asexual'
+    title: propagation
+    examples:
+      - value: lytic
+    in_subset:
+      - nucleic acid sequence source
+    slot_uri: MIXS:0000033
+    range: string
+  pulmonary_disord:
+    description: History of pulmonary disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, lung disease (https://disease-ontology.org/?id=DOID:850)
+    title: lung/pulmonary disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000269
+    range: string
+    multivalued: true
+  quad_pos:
+    description: The quadrant position of the sampling room within the building
+    title: quadrant position
+    examples:
+      - value: West side
+    slot_uri: MIXS:0000820
+    range: QuadPosEnum
+  radiation_regm:
+    annotations:
+      Expected_value: radiation type name;radiation amount;treatment interval and duration
+      Preferred_unit: rad, gray
+    description: Information about treatment involving exposure of plant or a plant part to a particular radiation regimen; should include the radiation type, amount or intensity administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple radiation regimens
+    title: radiation regimen
+    examples:
+      - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+    string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000575
+    multivalued: true
+  rainfall_regm:
+    annotations:
+      Expected_value: measurement value;treatment interval and duration
+      Preferred_unit: millimeter
+    description: Information about treatment involving an exposure to a given amount of rainfall, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
+    title: rainfall regimen
+    examples:
+      - value: 15 millimeter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - rain
+      - regimen
+    string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
+    slot_uri: MIXS:0000576
+    multivalued: true
+  reactor_type:
+    annotations:
+      Expected_value: reactor type name
+    description: Anaerobic digesters can be designed and engineered to operate using a number of different process configurations, as batch or continuous, mesophilic, high solid or low solid, and single stage or multistage
+    title: reactor type
+    keywords:
+      - type
+    slot_uri: MIXS:0000350
+    range: string
+  reassembly_bin:
+    description: Has an assembly been performed on a genome bin extracted from a metagenomic assembly?
+    title: reassembly post binning
+    examples:
+      - value: 'no'
+    in_subset:
+      - sequencing
+    keywords:
+      - post
+    slot_uri: MIXS:0000079
+    range: boolean
+  redox_potential:
+    annotations:
+      Preferred_unit: millivolt
+    description: Redox potential, measured relative to a hydrogen cell, indicating oxidation or reduction potential
+    title: redox potential
+    examples:
+      - value: 300 millivolt
+    slot_uri: MIXS:0000182
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ref_biomaterial:
+    description: Primary publication if isolated before genome publication; otherwise, primary genome report
+    title: reference for biomaterial
+    examples:
+      - value: doi:10.1016/j.syapm.2018.01.009
+    in_subset:
+      - nucleic acid sequence source
+    slot_uri: MIXS:0000025
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  ref_db:
+    annotations:
+      Expected_value: names, versions, and references of databases
+    description: List of database(s) used for ORF annotation, along with version number and reference to website or publication
+    title: reference database(s)
+    examples:
+      - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017 doi:10.1093/nar/gkw975
+    in_subset:
+      - sequencing
+    keywords:
+      - database
+    string_serialization: '{database};{version};{reference}'
+    slot_uri: MIXS:0000062
+  rel_air_humidity:
+    annotations:
+      Preferred_unit: percentage
+    description: Partial vapor and air pressure, density of the vapor and air, or by the actual mass of the vapor and air
+    title: relative air humidity
+    comments:
+      - percent or float?
+    examples:
+      - value: '0.8'
+    keywords:
+      - air
+      - humidity
+      - relative
+    slot_uri: MIXS:0000121
+    range: float
+    required: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  rel_humidity_out:
+    annotations:
+      Preferred_unit: gram of air, kilogram of air
+    description: The recorded outside relative humidity value at the time of sampling
+    title: outside relative humidity
+    examples:
+      - value: 12 per kilogram of air
+    keywords:
+      - humidity
+      - relative
+    slot_uri: MIXS:0000188
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  rel_location:
+    description: Location of sampled soil to other parts of the farm e.g. under crop plant, near irrigation ditch, from the dirt road
+    title: relative location of sample
+    examples:
+      - value: furrow
+    keywords:
+      - location
+      - relative
+      - sample
+    slot_uri: MIXS:0001161
+    range: string
+  rel_samp_loc:
+    description: The sampling location within the train car
+    title: relative sampling location
+    examples:
+      - value: center of car
+    keywords:
+      - location
+      - relative
+    slot_uri: MIXS:0000821
+    range: RelSampLocEnum
+  rel_to_oxygen:
+    description: Is this organism an aerobe, anaerobe? Please note that aerobic and anaerobic are valid descriptors for microbial environments
+    title: relationship to oxygen
+    examples:
+      - value: aerobe
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - oxygen
+      - relationship
+    slot_uri: MIXS:0000015
+    range: RelToOxygenEnum
+  repository_name:
+    annotations:
+      Expected_value: Institution
+    description: The name of the institution where the sample or DNA extract is held or "sample not available" if the sample was used in its entirety for analysis or otherwise not retained
+    title: repository name
+    examples:
+      - value: FDA CFSAN Microbiology Laboratories
+    slot_uri: MIXS:0001152
+    range: string
+    multivalued: true
+  reservoir:
+    description: Name of the reservoir (e.g. Carapebus)
+    title: reservoir name
+    slot_uri: MIXS:0000303
+    range: string
+    recommended: true
+  resins_pc:
+    annotations:
+      Preferred_unit: percent
+    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis method that divides  crude oil  components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+    title: resins wt%
+    slot_uri: MIXS:0000134
+    range: string
+    recommended: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{name};{float} {unit}$
+      interpolated: true
+      partial_match: true
+  room_air_exch_rate:
+    annotations:
+      Preferred_unit: liter per hour
+    description: The rate at which outside air replaces indoor air in a given space
+    title: room air exchange rate
+    keywords:
+      - air
+      - rate
+      - room
+    slot_uri: MIXS:0000169
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  room_architec_elem:
+    description: The unique details and component parts that, together, form the architecture of a distinguisahable space within a built structure
+    title: room architectural elements
+    keywords:
+      - room
+    slot_uri: MIXS:0000233
+    range: string
+  room_condt:
+    description: The condition of the room at the time of sampling
+    title: room condition
+    examples:
+      - value: new
+    keywords:
+      - condition
+      - room
+    slot_uri: MIXS:0000822
+    range: RoomCondtEnum
+  room_connected:
+    description: List of rooms connected to the sampling room by a doorway
+    title: rooms connected by a doorway
+    examples:
+      - value: office
+    keywords:
+      - doorway
+      - room
+    slot_uri: MIXS:0000826
+    range: RoomConnectedEnum
+  room_count:
+    description: The total count of rooms in the built structure including all room types
+    title: room count
+    keywords:
+      - count
+      - room
+    slot_uri: MIXS:0000234
+    range: integer
+  room_dim:
+    annotations:
+      Expected_value: measurement value
+      Preferred_unit: meter
+    description: The length, width and height of sampling room
+    title: room dimensions
+    examples:
+      - value: 4 meter x 4 meter x 4 meter
+    keywords:
+      - dimensions
+      - room
+    string_serialization: '{integer} {unit} x {integer} {unit} x {integer} {unit}'
+    slot_uri: MIXS:0000192
+  room_door_dist:
+    annotations:
+      Preferred_unit: meter
+    description: Distance between doors (meters) in the hallway between the sampling room and adjacent rooms
+    title: room door distance
+    keywords:
+      - distance
+      - door
+      - room
+    slot_uri: MIXS:0000193
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  room_door_share:
+    description: List of room(s) (room number, room name) sharing a door with the sampling room
+    title: rooms that share a door with sampling room
+    keywords:
+      - door
+      - room
+    slot_uri: MIXS:0000242
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^{room_name};{room_number}$
+      interpolated: true
+      partial_match: true
+  room_hallway:
+    description: List of room(s) (room number, room name) located in the same hallway as sampling room
+    title: rooms that are on the same hallway
+    keywords:
+      - hallway
+      - room
+    slot_uri: MIXS:0000238
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^{room_name};{room_number}$
+      interpolated: true
+      partial_match: true
+  room_loc:
+    description: The position of the room within the building
+    title: room location in building
+    examples:
+      - value: interior room
+    keywords:
+      - location
+      - room
+    slot_uri: MIXS:0000823
+    range: RoomLocEnum
+  room_moist_dam_hist:
+    description: The history of moisture damage or mold in the past 12 months. Number of events of moisture damage or mold observed
+    title: room moisture damage or mold history
+    keywords:
+      - history
+      - moisture
+      - room
+    slot_uri: MIXS:0000235
+    range: integer
+  room_net_area:
+    annotations:
+      Preferred_unit: square feet, square meter
+    description: The net floor area of sampling room. Net area excludes wall thicknesses
+    title: room net area
+    keywords:
+      - area
+      - room
+    slot_uri: MIXS:0000194
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  room_occup:
+    description: Count of room occupancy at time of sampling
+    title: room occupancy
+    keywords:
+      - room
+    slot_uri: MIXS:0000236
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  room_samp_pos:
+    description: The horizontal sampling position in the room relative to architectural elements
+    title: room sampling position
+    examples:
+      - value: south corner
+    keywords:
+      - room
+    slot_uri: MIXS:0000824
+    range: RoomSampPosEnum
+  room_type:
+    annotations:
+      Expected_value: enumeration
+    description: The main purpose or activity of the sampling room. A room is any distinguishable space within a structure
+    title: room type
+    examples:
+      - value: bathroom
+    keywords:
+      - room
+      - type
+    string_serialization: '[attic|bathroom|closet|conference room|elevator|examining room|hallway|kitchen|mail room|private office|open office|stairwell|,restroom|lobby|vestibule|mechanical or electrical room|data center|laboratory_wet|laboratory_dry|gymnasium|natatorium|auditorium|lockers|cafe|warehouse]'
+    slot_uri: MIXS:0000825
+  room_vol:
+    annotations:
+      Preferred_unit: cubic feet, cubic meter
+    description: Volume of sampling room
+    title: room volume
+    keywords:
+      - room
+      - volume
+    slot_uri: MIXS:0000195
+    range: string
+    pattern: ^[1-9][0-9]* .*$
+    structured_pattern:
+      syntax: ^{integer} {text}$
+      interpolated: true
+      partial_match: true
+  room_wall_share:
+    description: List of room(s) (room number, room name) sharing a wall with the sampling room
+    title: rooms that share a wall with sampling room
+    keywords:
+      - room
+      - wall
+    slot_uri: MIXS:0000243
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^{room_name};{room_number}$
+      interpolated: true
+      partial_match: true
+  room_window_count:
+    description: Number of windows in the room
+    title: room window count
+    keywords:
+      - count
+      - room
+      - window
+    slot_uri: MIXS:0000237
+    range: integer
+  root_cond:
+    description: Relevant rooting conditions such as field plot size, sowing density, container dimensions, number of plants per container
+    title: rooting conditions
+    examples:
+      - value: http://himedialabs.com/TD/PT158.pdf
+    keywords:
+      - condition
+    slot_uri: MIXS:0001061
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}|{text}$
+      interpolated: true
+      partial_match: true
+  root_med_carbon:
+    annotations:
+      Expected_value: carbon source name;measurement value
+      Preferred_unit: milligram per liter
+    description: Source of organic carbon in the culture rooting medium; e.g. sucrose
+    title: rooting medium carbon
+    examples:
+      - value: sucrose
+    keywords:
+      - carbon
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000577
+  root_med_macronutr:
+    annotations:
+      Expected_value: macronutrient name;measurement value
+      Preferred_unit: milligram per liter
+    description: Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
+    title: rooting medium macronutrients
+    examples:
+      - value: KH2PO4;170  milligram per liter
+    keywords:
+      - macronutrients
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000578
+  root_med_micronutr:
+    annotations:
+      Expected_value: micronutrient name;measurement value
+      Preferred_unit: milligram per liter
+    description: Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
+    title: rooting medium micronutrients
+    examples:
+      - value: H3BO3;6.2  milligram per liter
+    keywords:
+      - micronutrients
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000579
+  root_med_ph:
+    description: pH measurement of the culture rooting medium; e.g. 5.5
+    title: rooting medium pH
+    examples:
+      - value: '7.5'
+    keywords:
+      - ph
+    slot_uri: MIXS:0001062
+    range: float
+  root_med_regl:
+    annotations:
+      Expected_value: regulator name;measurement value
+      Preferred_unit: milligram per liter
+    description: Growth regulators in the culture rooting medium such as cytokinins, auxins, gybberellins, abscisic acid; e.g. 0.5  mg/L NAA
+    title: rooting medium regulators
+    examples:
+      - value: abscisic acid;0.75 milligram per liter
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000581
+  root_med_solid:
+    description: Specification of the solidifying agent in the culture rooting medium; e.g. agar
+    title: rooting medium solidifier
+    examples:
+      - value: agar
+    slot_uri: MIXS:0001063
+    range: string
+  root_med_suppl:
+    annotations:
+      Expected_value: supplement name;measurement value
+      Preferred_unit: milligram per liter
+    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid (0.5  mg/L)
+    title: rooting medium organic supplements
+    examples:
+      - value: nicotinic acid;0.5 milligram per liter
+    keywords:
+      - organic
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000580
+  route_transmission:
+    description: Description of path taken by the symbiotic host organism being sampled in order to establish a symbiotic relationship with the host (with which it was observed at the time of sampling) via a mode of transmission (specified in mode_transmission)
+    title: route of transmission
+    keywords:
+      - route
+    slot_uri: MIXS:0001316
+    range: RouteTransmissionEnum
+  salinity:
+    annotations:
+      Preferred_unit: practical salinity unit, percentage
+    description: The total concentration of all dissolved salts in a liquid or solid sample. While salinity can be measured by a complete chemical analysis, this method is difficult and time consuming. More often, it is instead derived from the conductivity measurement. This is known as practical salinity. These derivations compare the specific conductance of the sample to a salinity standard such as seawater
+    title: salinity
+    examples:
+      - value: 25 practical salinity unit
+    keywords:
+      - salinity
+    slot_uri: MIXS:0000183
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  salt_regm:
+    annotations:
+      Preferred_unit: gram, microgram, mole per liter, gram per liter
+    description: Information about treatment involving use of salts as supplement to liquid and soil growth media; should include the name of salt, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple salt regimens
+    title: salt regimen
+    examples:
+      - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+      - salt
+    slot_uri: MIXS:0000582
+    range: string
+    multivalued: true
+  samp_capt_status:
+    description: Reason for the sample
+    title: sample capture status
+    examples:
+      - value: farm sample
+    keywords:
+      - sample
+      - status
+    slot_uri: MIXS:0000860
+    range: SampCaptStatusEnum
+  samp_collect_device:
+    annotations:
+      Expected_value: device name
+    description: The device used to collect an environmental sample. This field accepts terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094)
+    title: sample collection device
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - device
+      - sample
+    string_serialization: '{termLabel} [{termID}]|{text}'
+    slot_uri: MIXS:0000002
+  samp_collect_method:
+    description: The method employed for collecting the sample
+    title: sample collection method
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - method
+      - sample
+    slot_uri: MIXS:0001225
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}|{text}$
+      interpolated: true
+      partial_match: true
+  samp_collect_point:
+    description: Sampling point on the asset were sample was collected (e.g. Wellhead, storage tank, separator, etc). If "other" is specified, please propose entry in "additional info" field
+    title: sample collection point
+    examples:
+      - value: well
+    keywords:
+      - sample
+    slot_uri: MIXS:0001015
+    range: SampCollectPointEnum
+    required: true
+  samp_dis_stage:
+    description: Stage of the disease at the time of sample collection, e.g. inoculation, penetration, infection, growth and reproduction, dissemination of pathogen
+    title: sample disease stage
+    examples:
+      - value: infection
+    keywords:
+      - disease
+      - sample
+    slot_uri: MIXS:0000249
+    range: SampDisStageEnum
+  samp_floor:
+    annotations:
+      Expected_value: enumeration
+    description: The floor of the building, where the sampling room is located
+    title: sampling floor
+    examples:
+      - value: 4th floor
+    keywords:
+      - floor
+    string_serialization: '[1st floor|2nd floor|{integer} floor|basement|lobby]'
+    slot_uri: MIXS:0000828
+  samp_loc_condition:
+    description: The condition of the sample location at the time of sampling
+    title: sample location condition
+    examples:
+      - value: new
+    keywords:
+      - condition
+      - location
+      - sample
+    slot_uri: MIXS:0001257
+    range: SampLocConditionEnum
+  samp_loc_corr_rate:
+    annotations:
+      Preferred_unit: millimeter per year
+    description: Metal corrosion rate is the speed of metal deterioration due to environmental conditions. As environmental conditions change corrosion rates change accordingly. Therefore, long term corrosion rates are generally more informative than short term rates and for that reason they are preferred during reporting. In the case of suspected MIC, corrosion rate measurements at the time of sampling might provide insights into the involvement of certain microbial community members in MIC as well as potential microbial interplays
+    title: corrosion rate at sample location
+    keywords:
+      - location
+      - rate
+      - sample
+    slot_uri: MIXS:0000136
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+ *- *[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{float} *- *{float} {unit}$
+      interpolated: true
+      partial_match: true
+  samp_mat_process:
+    description: A brief description of any processing applied to the sample during or after retrieving the sample from environment, or a link to the relevant protocol(s) performed
+    title: sample material processing
+    examples:
+      - value: filtering of seawater, storing samples in ethanol
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - material
+      - process
+      - sample
+    slot_uri: MIXS:0000016
+    range: string
+  samp_md:
+    annotations:
+      Expected_value: measurement value;enumeration
+      Preferred_unit: meter
+    description: In non deviated well, measured depth is equal to the true vertical depth, TVD (TVD=TVDSS plus the reference or datum it refers to). In deviated wells, the MD is the length of trajectory of the borehole measured from the same reference or datum. Common datums used are ground level (GL), drilling rig floor (DF), rotary table (RT), kelly bushing (KB) and mean sea level (MSL). If "other" is specified, please propose entry in "additional info" field
+    title: sample measured depth
+    examples:
+      - value: 1534 meter;MSL
+    keywords:
+      - depth
+      - measurement
+      - sample
+    string_serialization: '{float} {unit};[GL|DF|RT|KB|MSL|other]'
+    slot_uri: MIXS:0000413
+  samp_name:
+    annotations:
+      Preferred_unit: ''
+    description: A local identifier or name that for the material sample used for extracting nucleic acids, and subsequent sequencing. It can refer either to the original material collected or to any derived sub-samples. It can have any format, but we suggest that you make it concise, unique and consistent within your lab, and as informative as possible. INSDC requires every sample name from a single Submitter to be unique. Use of a globally unique identifier for the field source_mat_id is recommended in addition to sample_name
+    title: sample name
+    examples:
+      - value: ISDsoil1
+    in_subset:
+      - investigation
+    keywords:
+      - sample
+    slot_uri: MIXS:0001107
+    range: string
+    required: true
+  samp_pooling:
+    description: Physical combination of several instances of like material, e.g. RNA extracted from samples or dishes of cell cultures into one big aliquot of cells. Please provide a short description of the samples that were pooled
+    title: sample pooling
+    examples:
+      - value: 5uL of extracted genomic DNA from 5 leaves were pooled
+    keywords:
+      - pooling
+      - sample
+    slot_uri: MIXS:0001153
+    range: string
+    multivalued: true
+  samp_preserv:
+    annotations:
+      Preferred_unit: milliliter
+    description: Preservative added to the sample (e.g. Rnalater, alcohol, formaldehyde, etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)
+    title: preservative added to sample
+    keywords:
+      - sample
+    slot_uri: MIXS:0000463
+    range: string
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{name};{float} {unit}$
+      interpolated: true
+      partial_match: true
+  samp_purpose:
+    annotations:
+      Expected_value: enumeration or {text}
+    description: The reason that the sample was collected
+    title: purpose of sampling
+    examples:
+      - value: field trial
+    keywords:
+      - purpose
+    string_serialization: '[active surveillance in response to an outbreak|active surveillance not initiated by an outbreak|clinical trial|cluster investigation|environmental assessment|farm sample|field trial|for cause|industry internal investigation|market sample|passive surveillance|population based studies|research|research and development] or {text}'
+    slot_uri: MIXS:0001151
+  samp_rep_biol:
+    description: Measurements of biologically distinct samples that show biological variation
+    title: biological sample replicate
+    examples:
+      - value: 6 replicates
+    keywords:
+      - sample
+    slot_uri: MIXS:0001226
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  samp_rep_tech:
+    description: Repeated measurements of the same sample that show independent measures of the noise associated with the equipment and the protocols
+    title: technical sample replicate
+    examples:
+      - value: 10 replicates
+    keywords:
+      - sample
+    slot_uri: MIXS:0001227
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  samp_room_id:
+    description: Sampling room number. This ID should be consistent with the designations on the building floor plans
+    title: sampling room ID or name
+    keywords:
+      - identifier
+      - room
+    slot_uri: MIXS:0000244
+    range: integer
+  samp_size:
+    description: The total amount or size (volume (ml), mass (g) or area (m2) ) of sample collected
+    title: amount or size of sample collected
+    examples:
+      - value: 5 liter
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - sample
+      - size
+    slot_uri: MIXS:0000001
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  samp_sort_meth:
+    description: Method by which samples are sorted; open face filter collecting total suspended particles, prefilter to remove particles larger than X micrometers in diameter, where common values of X would be 10 and 2.5 full size sorting in a cascade impactor
+    title: sample size sorting method
+    keywords:
+      - method
+      - sample
+      - size
+    slot_uri: MIXS:0000216
+    range: string
+    multivalued: true
+  samp_source_mat_cat:
+    annotations:
+      Expected_value: GENEPIO:0001237
+    description: This is the scientific role or category that the subject organism or material has with respect to an investigation.  This field accepts terms listed under specimen source material category (http://purl.obolibrary.org/obo/GENEPIO_0001237 or http://purl.obolibrary.org/obo/OBI_0100051)
+    title: sample source material category
+    examples:
+      - value: environmental (swab or sampling) [GENEPIO:0001732]
+    keywords:
+      - material
+      - sample
+      - source
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0001154
+  samp_stor_device:
+    annotations:
+      Expected_value: NCIT:C4318
+    description: The container used to store the  sample. This field accepts terms listed under container (http://purl.obolibrary.org/obo/NCIT_C43186). If the proper descriptor is not listed please use text to describe the storage device
+    title: sample storage device
+    examples:
+      - value: Whirl Pak sampling bag [GENEPIO:0002122]
+    keywords:
+      - device
+      - sample
+      - storage
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001228
+  samp_stor_media:
+    description: The liquid that is added to the sample collection device prior to sampling. If the sample is pre-hydrated, indicate the liquid media the sample is pre-hydrated with for storage purposes. This field accepts terms listed under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067). If the proper descriptor is not listed please use text to describe the sample storage media
+    title: sample storage media
+    examples:
+      - value: peptone water medium [MICRO:0000548]
+    keywords:
+      - sample
+      - storage
+    slot_uri: MIXS:0001229
+    range: string
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    structured_pattern:
+      syntax: ^{text}|({termLabel} \[{termID}\])$
+      interpolated: true
+      partial_match: true
+  samp_store_dur:
+    description: Duration for which the sample was stored. Indicate the duration for which the sample was stored written in ISO 8601 format
+    title: sample storage duration
+    examples:
+      - value: P1Y6M
+    keywords:
+      - duration
+      - period
+      - sample
+      - storage
+    slot_uri: MIXS:0000116
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  samp_store_loc:
+    annotations:
+      Expected_value: location name
+    description: Location at which sample was stored, usually name of a specific freezer/room
+    title: sample storage location
+    examples:
+      - value: Freezer no:5
+    keywords:
+      - location
+      - sample
+      - storage
+    slot_uri: MIXS:0000755
+    range: string
+  samp_store_sol:
+    annotations:
+      Expected_value: solution name
+    description: Solution within which sample was stored, if any
+    title: sample storage solution
+    examples:
+      - value: 5% ethanol
+    keywords:
+      - sample
+      - storage
+    slot_uri: MIXS:0001317
+    range: string
+  samp_store_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Temperature at which sample was stored, e.g. -80 degree Celsius
+    title: sample storage temperature
+    examples:
+      - value: -80 degree Celsius
+    keywords:
+      - sample
+      - storage
+      - temperature
+    slot_uri: MIXS:0000110
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  samp_subtype:
+    description: Name of sample sub-type. For example if "sample type" is "Produced Water" then subtype could be "Oil Phase" or "Water Phase". If "other" is specified, please propose entry in "additional info" field
+    title: sample subtype
+    examples:
+      - value: biofilm
+    keywords:
+      - sample
+    slot_uri: MIXS:0000999
+    range: SampSubtypeEnum
+    recommended: true
+  samp_surf_moisture:
+    description: Degree of water held on a sampled surface.  If present, user can state the degree of water held on surface (intermittent moisture, submerged). If no surface moisture is present indicate not present
+    title: sample surface moisture
+    examples:
+      - value: submerged
+    keywords:
+      - moisture
+      - sample
+      - surface
+    slot_uri: MIXS:0001256
+    range: SampSurfMoistureEnum
+    multivalued: true
+  samp_taxon_id:
+    description: NCBI taxon id of the sample.  Maybe be a single taxon or mixed taxa sample. Use 'synthetic metagenome  for mock community/positive controls, or 'blank sample' for negative controls
+    title: taxonomy ID of DNA sample
+    examples:
+      - value: Gut Metagenome [NCBITaxon:749906]
+    in_subset:
+      - investigation
+    keywords:
+      - dna
+      - identifier
+      - sample
+      - taxon
+    slot_uri: MIXS:0001320
+    range: string
+    required: true
+    pattern: ^.* \[NCBITaxon:\d+\]$
+    structured_pattern:
+      syntax: ^{text} \[{NCBItaxon_id}\]$
+      interpolated: true
+      partial_match: true
+  samp_time_out:
+    annotations:
+      Expected_value: time
+      Preferred_unit: hour
+    description: The recent and long term history of outside sampling
+    title: sampling time outside
+    keywords:
+      - time
+    string_serialization: '{float}'
+    slot_uri: MIXS:0000196
+  samp_transport_cond:
+    annotations:
+      Expected_value: measurement value;measurement value
+      Preferred_unit: days;degree Celsius
+    description: Sample transport duration (in days or hrs) and temperature the sample was exposed to (e.g. 5.5 days; 20   C)
+    title: sample transport conditions
+    examples:
+      - value: 5 days;-20 degree Celsius
+    keywords:
+      - condition
+      - sample
+      - transport
+    string_serialization: '{float} {unit};{float} {unit}'
+    slot_uri: MIXS:0000410
+  samp_transport_cont:
+    description: Conatiner in which the sample was stored during transport. Indicate the location name
+    title: sample transport  container
+    examples:
+      - value: cooler
+    keywords:
+      - sample
+      - transport
+    slot_uri: MIXS:0001230
+    range: SampTransportContEnum
+  samp_transport_dur:
+    annotations:
+      Preferred_unit: days
+    description: The duration of time from when the sample was collected until processed. Indicate the duration for which the sample was stored written in ISO 8601 format
+    title: sample transport duration
+    examples:
+      - value: P10D
+    keywords:
+      - duration
+      - period
+      - sample
+      - transport
+    slot_uri: MIXS:0001231
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  samp_transport_temp:
+    annotations:
+      Expected_value: text or measurement value
+      Preferred_unit: degree Celsius
+    description: Temperature at which sample was transported, e.g. -20 or 4 degree Celsius
+    title: sample transport temperature
+    examples:
+      - value: 4 degree Celsius
+    keywords:
+      - sample
+      - temperature
+      - transport
+    string_serialization: '{float} {unit} {text}'
+    slot_uri: MIXS:0001232
+  samp_tvdss:
+    annotations:
+      Expected_value: measurement value or measurement value range
+      Preferred_unit: meter
+    description: Depth of the sample i.e. The vertical distance between the sea level and the sampled position in the subsurface. Depth can be reported as an interval for subsurface samples e.g. 1325.75-1362.25 m
+    title: sample true vertical depth subsea
+    keywords:
+      - depth
+      - sample
+    string_serialization: '{float}-{float} {unit}'
+    slot_uri: MIXS:0000409
+    recommended: true
+  samp_type:
+    description: The type of material from which the sample was obtained. For the Hydrocarbon package, samples include types like core, rock trimmings, drill cuttings, piping section, coupon, pigging debris, solid deposit, produced fluid, produced water, injected water, swabs, etc. For the Food Package, samples are usually categorized as food, body products or tissues, or environmental material. This field accepts terms listed under environmental specimen (http://purl.obolibrary.org/obo/GENEPIO_0001246)
+    title: sample type
+    examples:
+      - value: built environment sample [GENEPIO:0001248]
+    keywords:
+      - sample
+      - type
+    slot_uri: MIXS:0000998
+    range: string
+    required: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  samp_vol_we_dna_ext:
+    annotations:
+      Preferred_unit: milliliter, gram, milligram, square centimeter
+    description: 'Volume (ml) or mass (g) of total collected sample processed for DNA extraction. Note: total sample collected should be entered under the term Sample Size (MIXS:0000001)'
+    title: sample volume or weight for DNA extraction
+    examples:
+      - value: 1500 milliliter
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - dna
+      - sample
+      - volume
+      - weight
+    slot_uri: MIXS:0000111
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  samp_weather:
+    description: The weather on the sampling day
+    title: sampling day weather
+    examples:
+      - value: foggy
+    keywords:
+      - day
+      - weather
+    slot_uri: MIXS:0000827
+    range: SampWeatherEnum
+  samp_well_name:
+    description: Name of the well (e.g. BXA1123) where sample was taken
+    title: sample well name
+    keywords:
+      - sample
+    slot_uri: MIXS:0000296
+    range: string
+    recommended: true
+  saturates_pc:
+    annotations:
+      Preferred_unit: percent
+    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis method that divides  crude oil  components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+    title: saturates wt%
+    slot_uri: MIXS:0000131
+    range: string
+    recommended: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{name};{float} {unit}$
+      interpolated: true
+      partial_match: true
+  sc_lysis_approach:
+    description: Method used to free DNA from interior of the cell(s) or particle(s)
+    title: single cell or viral particle lysis approach
+    examples:
+      - value: enzymatic
+    in_subset:
+      - sequencing
+    keywords:
+      - particle
+      - single
+    slot_uri: MIXS:0000076
+    range: ScLysisApproachEnum
+  sc_lysis_method:
+    annotations:
+      Expected_value: kit, protocol name
+    description: Name of the kit or standard protocol used for cell(s) or particle(s) lysis
+    title: single cell or viral particle lysis kit protocol
+    examples:
+      - value: ambion single cell lysis kit
+    in_subset:
+      - sequencing
+    keywords:
+      - kit
+      - particle
+      - protocol
+      - single
+    slot_uri: MIXS:0000054
+    range: string
+  season:
+    annotations:
+      Expected_value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732], winter [NCIT:C94730]
+    description: The season when sampling occurred. Any of the four periods into which the year is divided by the equinoxes and solstices. This field accepts terms listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
+    title: season
+    comments:
+      - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
+      - would require ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:[a-zA-Z0-9]\\]$
+    examples:
+      - value: autumn [NCIT:C94733]
+    keywords:
+      - season
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: MIXS:0000829
+    range: string
+    pattern: ^\S+.*\S+ \[[a-zA-Z]{2,}:[a-zA-Z0-9]+\]$
+  season_environment:
+    description: Treatment involving an exposure to a particular season (e.g. Winter, summer, rabi, rainy etc.), treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment
+    title: seasonal environment
+    examples:
+      - value: rainy;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - environment
+      - season
+    slot_uri: MIXS:0001068
+    range: string
+    multivalued: true
+  season_humidity:
+    description: Average humidity of the region throughout the growing season
+    title: mean seasonal humidity
+    comments:
+      - percent or float?
+    examples:
+      - value: '0.25'
+    keywords:
+      - humidity
+      - mean
+      - season
+    slot_uri: MIXS:0001148
+    range: float
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  season_precpt:
+    annotations:
+      Preferred_unit: millimeter
+    description: The average of all seasonal precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps
+    title: mean seasonal precipitation
+    examples:
+      - value: 75 millimeters
+    keywords:
+      - mean
+      - season
+    slot_uri: MIXS:0000645
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  season_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Mean seasonal temperature
+    title: mean seasonal temperature
+    examples:
+      - value: 18 degree Celsius
+    keywords:
+      - mean
+      - season
+      - temperature
+    slot_uri: MIXS:0000643
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  season_use:
+    description: The seasons the space is occupied
+    title: seasonal use
+    examples:
+      - value: Winter
+    keywords:
+      - season
+      - use
+    slot_uri: MIXS:0000830
+    range: SeasonUseEnum
+  secondary_treatment:
+    annotations:
+      Expected_value: secondary treatment type
+    description: The process for substantially degrading the biological content of the sewage
+    title: secondary treatment
+    keywords:
+      - secondary
+      - treatment
+    slot_uri: MIXS:0000351
+    range: string
+  sediment_type:
+    description: Information about the sediment type based on major constituents
+    title: sediment type
+    examples:
+      - value: biogenous
+    keywords:
+      - sediment
+      - type
+    slot_uri: MIXS:0001078
+    range: SedimentTypeEnum
+  seq_meth:
+    description: Sequencing machine used. Where possible the term should be taken from the OBI list of DNA sequencers (http://purl.obolibrary.org/obo/OBI_0400103)
+    title: sequencing method
+    examples:
+      - value: 454 Genome Sequencer FLX [OBI:0000702]
+    in_subset:
+      - sequencing
+    keywords:
+      - method
+    slot_uri: MIXS:0000050
+    range: string
+    required: true
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    structured_pattern:
+      syntax: ^{text}|({termLabel} \[{termID}\])$
+      interpolated: true
+      partial_match: true
+  seq_quality_check:
+    annotations:
+      Expected_value: none or manually edited
+    description: Indicate if the sequence has been called by automatic systems (none) or undergone a manual editing procedure (e.g. by inspecting the raw data or chromatograms). Applied only for sequences that are not submitted to SRA,ENA or DRA
+    title: sequence quality check
+    examples:
+      - value: none
+    in_subset:
+      - sequencing
+    keywords:
+      - quality
+    slot_uri: MIXS:0000051
+    range: SeqQualityCheckEnum
+  sequencing_kit:
+    annotations:
+      Expected_value: name of sequencing kit used
+    description: Pre-filled, ready-to-use reagent cartridges. Used to produce improved chemistry, cluster density and read length as well as improve quality (Q) scores. Reagent components are encoded to interact with the sequencing system to validate compatibility with user-defined applications. Indicate name of the sequencing kit
+    title: sequencing kit
+    examples:
+      - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
+    keywords:
+      - kit
+    slot_uri: MIXS:0001155
+    range: string
+  sequencing_location:
+    description: The location the sequencing run was performed. Indicate the name of the lab or core facility where samples were sequenced
+    title: sequencing location
+    examples:
+      - value: University of Maryland Genomics Resource Center
+    keywords:
+      - location
+    slot_uri: MIXS:0001156
+    range: string
+  serovar_or_serotype:
+    description: A characterization of a cell or microorganism based on the antigenic properties of the molecules on its surface. Indicate the name of a serovar or serotype of interest. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
+    title: serovar or serotype
+    examples:
+      - value: Escherichia coli strain O157:H7 [NCIT:C86883]
+    slot_uri: MIXS:0001157
+    range: string
+    multivalued: true
+    pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^({termLabel} \[{termID}\])|{integer}$
+      interpolated: true
+      partial_match: true
+  sewage_type:
+    annotations:
+      Expected_value: sewage type name
+    description: Type of wastewater treatment plant as municipial or industrial
+    title: sewage type
+    keywords:
+      - type
+    slot_uri: MIXS:0000215
+    range: string
+  sexual_act:
+    annotations:
+      Expected_value: partner sex;frequency
+    description: Current sexual partner and frequency of sex
+    title: sexual activity
+    slot_uri: MIXS:0000285
+    range: string
+  shad_dev_water_mold:
+    description: Signs of the presence of mold or mildew on the shading device
+    title: shading device signs of water/mold
+    examples:
+      - value: no presence of mold visible
+    keywords:
+      - device
+    slot_uri: MIXS:0000834
+    range: MoldVisibilityEnum
+  shading_device_cond:
+    description: The physical condition of the shading device at the time of sampling
+    title: shading device condition
+    examples:
+      - value: new
+    keywords:
+      - condition
+      - device
+    slot_uri: MIXS:0000831
+    range: DamagedRupturedEnum
+  shading_device_loc:
+    description: The location of the shading device in relation to the built structure
+    title: shading device location
+    examples:
+      - value: exterior
+    keywords:
+      - device
+      - location
+    slot_uri: MIXS:0000832
+    range: ShadingDeviceLocEnum
+  shading_device_mat:
+    annotations:
+      Expected_value: material name
+    description: The material the shading device is composed of
+    title: shading device material
+    keywords:
+      - device
+      - material
+    slot_uri: MIXS:0000245
+    range: string
+  shading_device_type:
+    description: The type of shading device
+    title: shading device type
+    examples:
+      - value: slatted aluminum
+        description: was slatted aluminum awning
+    keywords:
+      - device
+      - type
+    slot_uri: MIXS:0000835
+    range: ShadingDeviceTypeEnum
+  sieving:
+    annotations:
+      Expected_value: design name and/or size;amount
+    description: Collection design of pooled samples and/or sieve size and amount of sample sieved
+    title: sieving
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000322
+  silicate:
+    annotations:
+      Preferred_unit: micromole per liter
+    description: Concentration of silicate
+    title: silicate
+    examples:
+      - value: 0.05 micromole per liter
+    slot_uri: MIXS:0000184
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  sim_search_meth:
+    description: Tool used to compare ORFs with database, along with version and cutoffs used
+    title: similarity search method
+    examples:
+      - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
+    in_subset:
+      - sequencing
+    keywords:
+      - method
+    slot_uri: MIXS:0000063
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{software};{version};{parameters}$
+      interpolated: true
+      partial_match: true
+  size_frac:
+    annotations:
+      Expected_value: filter size value range
+    description: Filtering pore size used in sample preparation
+    title: size fraction selected
+    examples:
+      - value: 0-0.22 micrometer
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - fraction
+      - size
+    string_serialization: '{float}-{float} {unit}'
+    slot_uri: MIXS:0000017
+  size_frac_low:
+    annotations:
+      Preferred_unit: micrometer
+    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials smaller than the size threshold are excluded from the sample
+    title: size-fraction lower threshold
+    examples:
+      - value: 0.2 micrometer
+    keywords:
+      - lower
+    slot_uri: MIXS:0000735
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  size_frac_up:
+    annotations:
+      Preferred_unit: micrometer
+    description: Mesh or pore size of the device used to retain the sample. Materials larger than the size threshold are excluded from the sample.
+    title: size-fraction upper threshold
+    examples:
+      - value: 20 micrometer
+    keywords:
+      - upper
+    slot_uri: MIXS:0000736
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  slope_aspect:
+    annotations:
+      Preferred_unit: degree
+    description: The direction a slope faces. While looking down a slope use a compass to record the direction you are facing (direction or degrees); e.g., nw or 315 degrees. This measure provides an indication of sun and wind exposure that will influence soil temperature and evapotranspiration
+    title: slope aspect
+    keywords:
+      - slope
+    slot_uri: MIXS:0000647
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  slope_gradient:
+    annotations:
+      Preferred_unit: percentage
+    description: Commonly called 'slope'. The angle between ground surface and a horizontal line (in percent). This is the direction that overland water would flow. This measure is usually taken with a hand level meter or clinometer
+    title: slope gradient
+    keywords:
+      - slope
+    slot_uri: MIXS:0000646
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  sludge_retent_time:
+    annotations:
+      Preferred_unit: hours
+    description: The time activated sludge remains in reactor
+    title: sludge retention time
+    keywords:
+      - time
+    slot_uri: MIXS:0000669
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  smoker:
+    description: Specification of smoking status
+    title: smoker
+    examples:
+      - value: 'yes'
+    slot_uri: MIXS:0000262
+    range: boolean
+  sodium:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Sodium concentration in the sample
+    title: sodium
+    examples:
+      - value: 10.5 milligram per liter
+    slot_uri: MIXS:0000428
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  soil_conductivity:
+    annotations:
+      Preferred_unit: milliSiemens per centimeter
+    title: soil conductivity
+    examples:
+      - value: 10 milliSiemens per centimeter
+    keywords:
+      - soil
+    slot_uri: MIXS:0001158
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  soil_cover:
+    annotations:
+      Expected_value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
+    description: Material covering the sampled soil. This field accepts terms under ENVO:00010483, environmental material
+    title: soil cover
+    examples:
+      - value: bare soil [ENVO01001616]
+    keywords:
+      - soil
+    string_serialization: bare soil [ENVO:01001616]
+    slot_uri: MIXS:0001159
+  soil_horizon:
+    description: Specific layer in the land area which measures parallel to the soil surface and possesses physical characteristics which differ from the layers above and beneath
+    title: soil horizon
+    examples:
+      - value: A horizon
+    keywords:
+      - horizon
+      - soil
+    slot_uri: MIXS:0001082
+    range: SoilHorizonEnum
+  soil_pH:
+    title: soil pH
+    examples:
+      - value: '7.2'
+    keywords:
+      - ph
+      - soil
+    slot_uri: MIXS:0001160
+    range: float
+  soil_porosity:
+    annotations:
+      Expected_value: percent porosity
+      Preferred_unit: percentage
+    description: Porosity of soil or deposited sediment is volume of voids divided by the total volume of sample
+    title: soil sediment porosity
+    examples:
+      - value: '0.2'
+    keywords:
+      - porosity
+      - sediment
+      - soil
+    string_serialization: '{percentage}'
+    slot_uri: MIXS:0001162
+  soil_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Temperature of soil at the time of sampling
+    title: soil temperature
+    examples:
+      - value: 25 degrees Celsius
+    keywords:
+      - soil
+      - temperature
+    slot_uri: MIXS:0001163
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  soil_texture:
+    description: The relative proportion of different grain sizes of mineral particles in a soil, as described using a standard system; express as % sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty clay loam) optional
+    title: soil texture
+    keywords:
+      - soil
+      - texture
+    slot_uri: MIXS:0000335
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  soil_texture_class:
+    description: One of the 12 soil texture classes use to describe soil texture based on the relative proportion of different grain sizes  of mineral particles [sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
+    title: soil texture classification
+    examples:
+      - value: silty clay loam
+    keywords:
+      - classification
+      - soil
+      - texture
+    slot_uri: MIXS:0001164
+    range: SoilTextureClassEnum
+  soil_texture_meth:
+    description: Reference or method used in determining soil texture
+    title: soil texture method
+    examples:
+      - value: https://uwlab.soils.wisc.edu/wp-content/uploads/sites/17/2015/09/particle_size.pdf
+    keywords:
+      - method
+      - soil
+      - texture
+    slot_uri: MIXS:0000336
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  soil_type:
+    annotations:
+      Expected_value: ENVO:00001998
+    description: Description of the soil type or classification. This field accepts terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple terms can be separated by pipes
+    title: soil type
+    examples:
+      - value: plinthosol [ENVO:00002250]
+    keywords:
+      - soil
+      - type
+    slot_uri: MIXS:0000332
+  soil_type_meth:
+    description: Reference or method used in determining soil series name or other lower-level classification
+    title: soil type method
+    examples:
+      - value: https://www.lrh.usace.army.mil/Portals/38/docs/PR/BluestoneSFEIS/Appendix%20K-Soil%20Descriptions.pdf
+    keywords:
+      - method
+      - soil
+      - type
+    slot_uri: MIXS:0000334
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  solar_irradiance:
+    annotations:
+      Preferred_unit: kilowatts per square meter per day, ergs per square centimeter per second
+    description: The amount of solar energy that arrives at a specific area of a surface during a specific time interval
+    title: solar irradiance
+    examples:
+      - value: 1.36 kilowatts per square meter per day
+    slot_uri: MIXS:0000112
+    range: string
+    multivalued: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  soluble_inorg_mat:
+    annotations:
+      Expected_value: soluble inorganic material name;measurement value
+      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
+    description: Concentration of substances such as ammonia, road-salt, sea-salt, cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc
+    title: soluble inorganic material
+    keywords:
+      - inorganic
+      - material
+      - soluble
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000672
+    multivalued: true
+  soluble_org_mat:
+    annotations:
+      Expected_value: soluble organic material name;measurement value
+      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
+    description: Concentration of substances such as urea, fruit sugars, soluble proteins, drugs, pharmaceuticals, etc
+    title: soluble organic material
+    keywords:
+      - material
+      - organic
+      - soluble
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000673
+    multivalued: true
+  soluble_react_phosp:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: Concentration of soluble reactive phosphorus
+    title: soluble reactive phosphorus
+    examples:
+      - value: 0.1 milligram per liter
+    keywords:
+      - phosphorus
+      - soluble
+    slot_uri: MIXS:0000738
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  sop:
+    annotations:
+      Expected_value: reference to SOP
+    description: Standard operating procedures used in assembly and/or annotation of genomes, metagenomes or environmental sequences
+    title: relevant standard operating procedures
+    examples:
+      - value: http://press.igsb.anl.gov/earthmicrobiome/protocols-and-standards/its/
+    in_subset:
+      - sequencing
+    keywords:
+      - procedures
+    string_serialization: '{PMID}|{DOI}|{URL}'
+    slot_uri: MIXS:0000090
+    multivalued: true
+  sort_tech:
+    description: Method used to sort/isolate cells or particles of interest
+    title: sorting technology
+    examples:
+      - value: optical manipulation
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000075
+    range: SortTechEnum
+  source_mat_id:
+    annotations:
+      Expected_value: 'for cultures of microorganisms: identifiers for two culture collections; for other material a unique arbitrary identifer'
+    description: A unique identifier assigned to a material sample (as defined by http://rs.tdwg.org/dwc/terms/materialSampleID, and as opposed to a particular digital record of a material sample) used for extracting nucleic acids, and subsequent sequencing. The identifier can refer either to the original material collected or to any derived sub-samples. The INSDC qualifiers /specimen_voucher, /bio_material, or /culture_collection may or may not share the same value as the source_mat_id field. For instance, the /specimen_voucher qualifier and source_mat_id may both contain 'UAM:Herps:14' , referring to both the specimen voucher and sampled tissue with the same identifier. However, the /culture_collection qualifier may refer to a value from an initial culture (e.g. ATCC:11775) while source_mat_id would refer to an identifier from some derived culture from which the nucleic acids were extracted (e.g. xatc123 or ark:/2154/R2)
+    title: source material identifiers
+    examples:
+      - value: MPI012345
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - identifier
+      - material
+      - source
+    slot_uri: MIXS:0000026
+    range: string
+    multivalued: true
+  source_uvig:
+    annotations:
+      Expected_value: enumeration
+    description: Type of dataset from which the UViG was obtained
+    title: source of UViGs
+    examples:
+      - value: viral fraction metagenome (virome)
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - source
+    string_serialization: '[metagenome (not viral targeted)|viral fraction metagenome (virome)|sequence-targeted metagenome|metatranscriptome (not viral targeted)|viral fraction RNA metagenome (RNA virome)|sequence-targeted RNA metagenome|microbial single amplified genome (SAG)|viral single amplified genome (vSAG)|isolate microbial genome|other]'
+    slot_uri: MIXS:0000035
+  space_typ_state:
+    description: Customary or normal state of the space
+    title: space typical state
+    examples:
+      - value: typically occupied
+    slot_uri: MIXS:0000770
+    range: SpaceTypStateEnum
+    required: true
+  spec_intended_cons:
+    description: Food consumer type, human or animal, for which the food product is produced and marketed. This field accepts terms listed under food consumer group (http://purl.obolibrary.org/obo/FOODON_03510136)
+    title: specific intended consumer
+    examples:
+      - value: senior as food consumer [FOODON:03510254]
+    keywords:
+      - consumer
+    slot_uri: MIXS:0001234
+    range: string
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  special_diet:
+    annotations:
+      Expected_value: enumeration
+    description: Specification of special diet; can include multiple special diets
+    title: special diet
+    examples:
+      - value: other:vegan
+    keywords:
+      - diet
+    string_serialization: '[low carb|reduced calorie|vegetarian|other(to be specified)]'
+    slot_uri: MIXS:0000905
+    multivalued: true
+  specific:
+    description: 'The building specifications. If design is chosen, indicate phase: conceptual, schematic, design development, construction documents'
+    title: specifications
+    examples:
+      - value: construction
+    slot_uri: MIXS:0000836
+    range: SpecificEnum
+  specific_host:
+    annotations:
+      Expected_value: host scientific name, taxonomy ID
+    description: Report the host's taxonomic name and/or NCBI taxonomy ID
+    title: host scientific name
+    examples:
+      - value: Homo sapiens and/or 9606
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - host
+      - host.
+    string_serialization: '{text}|{NCBI taxid}'
+    slot_uri: MIXS:0000029
+  specific_humidity:
+    annotations:
+      Preferred_unit: gram of air, kilogram of air
+    description: The mass of water vapour in a unit mass of moist air, usually expressed as grams of vapour per kilogram of air, or, in air conditioning, as grains per pound
+    title: specific humidity
+    examples:
+      - value: 15 per kilogram of air
+    keywords:
+      - humidity
+    slot_uri: MIXS:0000214
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  spikein_AMR:
+    annotations:
+      Expected_value: measurement value ARO:3004299
+    description: Qualitative description of a microbial response to antimicrobial agents. Bacteria may be susceptible or resistant to a broad range of antibiotic drugs or drug classes, with several intermediate states or phases. This field accepts terms under antimicrobial phenotype (http://purl.obolibrary.org/obo/ARO_3004299)
+    title: antimicrobial phenotype of spike-in bacteria
+    examples:
+      - value: wild type [ARO:3004432]
+    keywords:
+      - antimicrobial
+      - spike
+    string_serialization: '{float} {unit};{termLabel} [{termID}]'
+    slot_uri: MIXS:0001235
+    multivalued: true
+  spikein_antibiotic:
+    annotations:
+      Expected_value: drug name; concentration
+    description: Antimicrobials used in research study to assess effects of exposure on microbiome of a specific site.  Please list antimicrobial, common name and/or class and concentration used for spike-in
+    title: spike-in with antibiotics
+    examples:
+      - value: Tetracycline at 5 mg/ml
+    keywords:
+      - spike
+    string_serialization: '{text} {integer}'
+    slot_uri: MIXS:0001171
+    multivalued: true
+  spikein_count:
+    annotations:
+      Expected_value: organism name;measurement value;enumeration
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram of dry weight
+    description: 'Total cell count of any organism (or group of organisms) per gram, volume or area of sample, should include name of organism followed by count. The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) should also be provided (example: total prokaryotes; 3.5e7 cells per ml; qPCR)'
+    title: spike-in organism count
+    examples:
+      - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+    keywords:
+      - count
+      - organism
+      - spike
+    string_serialization: '{text};{float} {unit};[ATP|MPN|qPCR|other]'
+    slot_uri: MIXS:0001335
+  spikein_growth_med:
+    description: A liquid or gel containing nutrients, salts, and other factors formulated to support the growth of microorganisms, cells, or plants (National Cancer Institute Thesaurus).  A growth medium is a culture medium which has the disposition to encourage growth of particular bacteria to the exclusion of others in the same growth environment.  In this case, list the culture medium used to propagate the spike-in bacteria during preparation of spike-in inoculum. This field accepts terms listed under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067). If the proper descriptor is not listed please use text to describe the spike in growth media
+    title: spike-in growth medium
+    examples:
+      - value: LB broth [MCO:0000036]
+    keywords:
+      - growth
+      - spike
+    slot_uri: MIXS:0001169
+    range: string
+    multivalued: true
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    structured_pattern:
+      syntax: ^{text}|({termLabel} \[{termID}\])$
+      interpolated: true
+      partial_match: true
+  spikein_metal:
+    annotations:
+      Expected_value: heavy metal name or chemical symbol; concentration
+    description: Heavy metals used in research study to assess effects of exposure on microbiome of a specific site.  Please list heavy metals and concentration used for spike-in
+    title: spike-in with heavy metals
+    examples:
+      - value: Cd at 20 ppm
+    keywords:
+      - heavy
+      - spike
+    string_serialization: '{text} {integer}'
+    slot_uri: MIXS:0001172
+    multivalued: true
+  spikein_org:
+    description: Taxonomic information about the spike-in organism(s). This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy. Multiple terms can be separated by pipes
+    title: spike in organism
+    examples:
+      - value: Listeria monocytogenes [NCIT:C86502]|28901
+    keywords:
+      - organism
+      - spike
+    slot_uri: MIXS:0001167
+    range: string
+    multivalued: true
+    pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
+    structured_pattern:
+      syntax: ^({termLabel} \[{termID}\])|{integer}$
+      interpolated: true
+      partial_match: true
+  spikein_serovar:
+    annotations:
+      Expected_value: NCIT:C14250 or antigenic formula or serovar name
+    description: Taxonomic information about the spike-in organism(s) at the serovar or serotype level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy. Multiple terms can be separated by pipes
+    title: spike-in bacterial serovar or serotype
+    examples:
+      - value: Escherichia coli strain O157:H7 [NCIT:C86883]|83334
+    keywords:
+      - spike
+    string_serialization: '{termLabel} [{termID}]|{integer}'
+    slot_uri: MIXS:0001168
+    multivalued: true
+  spikein_strain:
+    annotations:
+      Expected_value: NCIT:C14250 or NCBI taxid or text
+    description: Taxonomic information about the spike-in organism(s) at the strain level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy. Multiple terms can be separated by pipes
+    title: spike-in microbial strain
+    examples:
+      - value: '169963'
+    keywords:
+      - microbial
+      - spike
+    string_serialization: '{termLabel} [{termID}]|{integer}'
+    slot_uri: MIXS:0001170
+    multivalued: true
+  sr_dep_env:
+    description: Source rock depositional environment (https://en.wikipedia.org/wiki/Source_rock). If "other" is specified, please propose entry in "additional info" field
+    title: source rock depositional environment
+    examples:
+      - value: Marine
+    keywords:
+      - environment
+      - source
+    slot_uri: MIXS:0000996
+    range: SrDepEnvEnum
+  sr_geol_age:
+    description: 'Geological age of source rock (Additional info: https://en.wikipedia.org/wiki/Period_(geology)). If "other" is specified, please propose entry in "additional info" field'
+    title: source rock geological age
+    examples:
+      - value: Silurian
+    keywords:
+      - age
+      - source
+    slot_uri: MIXS:0000997
+    range: GeolAgeEnum
+  sr_kerog_type:
+    description: 'Origin of kerogen. Type I: Algal (aquatic), Type II: planktonic and soft plant material (aquatic or terrestrial), Type III: terrestrial woody/ fibrous plant material (terrestrial), Type IV: oxidized recycled woody debris (terrestrial) (additional information: https://en.wikipedia.org/wiki/Kerogen). If "other" is specified, please propose entry in "additional info" field'
+    title: source rock kerogen type
+    examples:
+      - value: Type IV
+    keywords:
+      - source
+      - type
+    slot_uri: MIXS:0000994
+    range: SrKerogTypeEnum
+  sr_lithology:
+    description: Lithology of source rock (https://en.wikipedia.org/wiki/Source_rock). If "other" is specified, please propose entry in "additional info" field
+    title: source rock lithology
+    examples:
+      - value: Coal
+    keywords:
+      - lithology
+      - source
+    slot_uri: MIXS:0000995
+    range: SrLithologyEnum
+  standing_water_regm:
+    description: Treatment involving an exposure to standing water during a plant's life span, types can be flood water or standing water, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
+    title: standing water regimen
+    examples:
+      - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+      - water
+    slot_uri: MIXS:0001069
+    range: string
+    multivalued: true
+  ster_meth_samp_room:
+    annotations:
+      Expected_value: ENVO:01001026
+    description: The method used to sterilize the sampling room. This field accepts terms listed under electromagnetic radiation (http://purl.obolibrary.org/obo/ENVO_01001026). If the proper descriptor is not listed, please use text to describe the sampling room sterilization method. Multiple terms can be separated by pipes
+    title: sampling room sterilization method
+    examples:
+      - value: ultraviolet radiation [ENVO:21001216]|infrared radiation [ENVO:21001214]
+    keywords:
+      - method
+      - room
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001259
+    multivalued: true
+  store_cond:
+    annotations:
+      Expected_value: storage condition type;duration
+    description: Explain how and for how long the soil sample was stored before DNA extraction (fresh/frozen/other)
+    title: storage conditions
+    examples:
+      - value: -20 degree Celsius freezer;P2Y10D
+    keywords:
+      - condition
+      - storage
+    string_serialization: '{text};{period}'
+    slot_uri: MIXS:0000327
+  study_complt_stat:
+    annotations:
+      Expected_value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow up (4)other-specify
+    description: Specification of study completion status, if no the reason should be specified
+    title: study completion status
+    examples:
+      - value: no;non-compliance
+    keywords:
+      - status
+    string_serialization: '{boolean};[adverse event|non-compliance|lost to follow up|other-specify]'
+    slot_uri: MIXS:0000898
+  study_design:
+    annotations:
+      Expected_value: OBI:0500000
+    description: A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution. This field accepts terms under study design (http://purl.obolibrary.org/obo/OBI_0500000). If the proper descriptor is not listed please use text to describe the study design. Multiple terms can be separated by pipes
+    title: study design
+    examples:
+      - value: in vitro design [OBI:0001285]
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001236
+    multivalued: true
+  study_inc_dur:
+    annotations:
+      Preferred_unit: hours or days
+    description: Sample incubation duration if unpublished or unvalidated method is used. Indicate the timepoint written in ISO 8601 format
+    title: study incubation duration
+    examples:
+      - value: PT24H
+    keywords:
+      - duration
+      - incubation
+      - period
+    slot_uri: MIXS:0001237
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  study_inc_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Sample incubation temperature if unpublished or unvalidated method is used
+    title: study incubation temperature
+    examples:
+      - value: 37 degree Celsius
+    keywords:
+      - incubation
+      - temperature
+    slot_uri: MIXS:0001238
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  study_timecourse:
+    annotations:
+      Preferred_unit: dpi
+    description: For time-course research studies involving samples of the food commodity, indicate the total duration of the time-course study
+    title: time-course duration
+    examples:
+      - value: 2 days post inoculation
+    keywords:
+      - duration
+      - period
+      - time
+    slot_uri: MIXS:0001239
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  study_tmnt:
+    annotations:
+      Expected_value: MCO:0000866
+    description: A process in which the act is intended to modify or alter some other material entity.  From the study design, each treatment is comprised of one level of one or multiple factors. This field accepts terms listed under treatment (http://purl.obolibrary.org/obo/MCO_0000866). If the proper descriptor is not listed please use text to describe the study treatment. Multiple terms can be separated by one or more pipes
+    title: study treatment
+    examples:
+      - value: Factor A|spike-in|levels high, medium, low
+    keywords:
+      - treatment
+    string_serialization: '{text}|{termLabel} [{termID}]'
+    slot_uri: MIXS:0001240
+    multivalued: true
+  subspecf_gen_lin:
+    annotations:
+      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies, e.g. serovar, biotype, ecotype, variety, cultivar
+    description: Information about the genetic distinctness of the sequenced organism below the subspecies level, e.g., serovar, serotype, biotype, ecotype, or any relevant genetic typing schemes like Group I plasmid. Subspecies should not be recorded in this term, but in the NCBI taxonomy. Supply both the lineage name and the lineage rank separated by a colon, e.g., biovar:abc123
+    title: subspecific genetic lineage
+    examples:
+      - value: serovar:Newport
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - lineage
+    string_serialization: '{rank name}:{text}'
+    slot_uri: MIXS:0000020
+  substructure_type:
+    description: The substructure or under building is that largely hidden section of the building which is built off the foundations to the ground floor level
+    title: substructure type
+    examples:
+      - value: basement
+    keywords:
+      - type
+    slot_uri: MIXS:0000767
+    range: SubstructureTypeEnum
+    multivalued: true
+  sulfate:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: Concentration of sulfate in the sample
+    title: sulfate
+    examples:
+      - value: 5 micromole per liter
+    keywords:
+      - sulfate
+    slot_uri: MIXS:0000423
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  sulfate_fw:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: Original sulfate concentration in the hydrocarbon resource
+    title: sulfate in formation water
+    keywords:
+      - sulfate
+      - water
+    slot_uri: MIXS:0000407
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  sulfide:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: Concentration of sulfide in the sample
+    title: sulfide
+    examples:
+      - value: 2 micromole per liter
+    keywords:
+      - sulfide
+    slot_uri: MIXS:0000424
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  surf_air_cont:
+    description: Contaminant identified on surface
+    title: surface-air contaminant
+    examples:
+      - value: radon
+    slot_uri: MIXS:0000759
+    range: SurfAirContEnum
+    recommended: true
+    multivalued: true
+  surf_humidity:
+    annotations:
+      Preferred_unit: percentage
+    description: 'Surfaces: water activity as a function of air and material moisture'
+    title: surface humidity
+    comments:
+      - percent or float?
+    examples:
+      - value: '0.1'
+    keywords:
+      - humidity
+      - surface
+    slot_uri: MIXS:0000123
+    range: float
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  surf_material:
+    description: Surface materials at the point of sampling
+    title: surface material
+    examples:
+      - value: wood
+    keywords:
+      - material
+      - surface
+    slot_uri: MIXS:0000758
+    range: SurfMaterialEnum
+  surf_moisture:
+    annotations:
+      Preferred_unit: parts per million, gram per cubic meter, gram per square meter
+    description: Water held on a surface
+    title: surface moisture
+    examples:
+      - value: 0.01 gram per square meter
+    keywords:
+      - moisture
+      - surface
+    slot_uri: MIXS:0000128
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  surf_moisture_ph:
+    description: ph measurement of surface
+    title: surface moisture pH
+    examples:
+      - value: '7'
+    keywords:
+      - moisture
+      - ph
+      - surface
+    slot_uri: MIXS:0000760
+    range: float
+    recommended: true
+  surf_temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Temperature of the surface at the time of sampling
+    title: surface temperature
+    examples:
+      - value: 15 degree Celsius
+    keywords:
+      - surface
+      - temperature
+    slot_uri: MIXS:0000125
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  suspend_part_matter:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: Concentration of suspended particulate matter
+    title: suspended particulate matter
+    examples:
+      - value: 0.5 milligram per liter
+    keywords:
+      - particle
+      - particulate
+      - suspended
+    slot_uri: MIXS:0000741
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  suspend_solids:
+    annotations:
+      Expected_value: suspended solid name;measurement value
+      Preferred_unit: gram, microgram, milligram per liter, mole per liter, gram per liter, part per million
+    description: Concentration of substances including a wide variety of material, such as silt, decaying plant and animal matter; can include multiple substances
+    title: suspended solids
+    keywords:
+      - solids
+      - suspended
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000150
+    multivalued: true
+  sym_life_cycle_type:
+    annotations:
+      Expected_value: type of life cycle of the symbiotic organism (host of the samples)
+    description: Type of life cycle of the symbiotic host species (the thing being sampled). Simple life cycles occur within a single host, complex ones within multiple different hosts over the course of their normal life cycle
+    title: symbiotic host organism life cycle type
+    examples:
+      - value: complex life cycle
+    keywords:
+      - host
+      - host.
+      - life
+      - organism
+      - symbiosis
+      - type
+    slot_uri: MIXS:0001300
+    range: SymLifeCycleTypeEnum
+    required: true
+  symbiont_host_role:
+    description: Role of the host in the life cycle of the symbiotic organism
+    title: host of the symbiont role
+    examples:
+      - value: intermediate
+    keywords:
+      - host
+      - host.
+      - symbiosis
+    slot_uri: MIXS:0001303
+    range: SymbiontHostRoleEnum
+    recommended: true
+  tan:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: 'Total Acid Number  (TAN) is a measurement of acidity that is determined by the amount of  potassium hydroxide  in milligrams that is needed to neutralize the acids in one gram of oil.  It is an important quality measurement of  crude oil. (source: https://en.wikipedia.org/wiki/Total_acid_number)'
+    title: total acid number
+    keywords:
+      - number
+      - total
+    slot_uri: MIXS:0000120
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  target_gene:
+    description: Targeted gene or locus name for marker gene studies
+    title: target gene
+    examples:
+      - value: 16S rRNA, 18S rRNA, nif, amoA, rpo
+    in_subset:
+      - sequencing
+    keywords:
+      - target
+    slot_uri: MIXS:0000044
+    range: string
+  target_subfragment:
+    description: Name of subfragment of a gene or locus. Important to e.g. identify special regions on marker genes like V6 on 16S rRNA
+    title: target subfragment
+    examples:
+      - value: V6, V9, ITS
+    in_subset:
+      - sequencing
+    keywords:
+      - target
+    slot_uri: MIXS:0000045
+    range: string
+  tax_class:
+    description: Method used for taxonomic classification, along with reference database used, classification rank, and thresholds used to classify new genomes
+    title: taxonomic classification
+    examples:
+      - value: vConTACT vContact2 (references from NCBI RefSeq v83, genus rank classification, default parameters)
+    in_subset:
+      - sequencing
+    keywords:
+      - classification
+      - taxon
+    slot_uri: MIXS:0000064
+    range: string
+  tax_ident:
+    description: The phylogenetic marker(s) used to assign an organism name to the SAG or MAG
+    title: taxonomic identity marker
+    examples:
+      - value: other
+        description: was other <colon> rpoB gene
+    in_subset:
+      - sequencing
+    keywords:
+      - identifier
+      - marker
+      - taxon
+    slot_uri: MIXS:0000053
+    range: TaxIdentEnum
+  temp:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Temperature of the sample at the time of sampling
+    title: temperature
+    examples:
+      - value: 25 degree Celsius
+    in_subset:
+      - environment
+    keywords:
+      - temperature
+    slot_uri: MIXS:0000113
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  temp_out:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: The recorded temperature value at sampling time outside
+    title: temperature outside house
+    examples:
+      - value: 5 degree Celsius
+    keywords:
+      - house
+      - temperature
+    slot_uri: MIXS:0000197
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tertiary_treatment:
+    annotations:
+      Expected_value: tertiary treatment type
+    description: The process providing a final treatment stage to raise the effluent quality before it is discharged to the receiving environment
+    title: tertiary treatment
+    keywords:
+      - treatment
+    slot_uri: MIXS:0000352
+    range: string
+  tidal_stage:
+    description: Stage of tide
+    title: tidal stage
+    examples:
+      - value: high tide
+    slot_uri: MIXS:0000750
+    range: TidalStageEnum
+  tillage:
+    description: Note method(s) used for tilling
+    title: history/tillage
+    examples:
+      - value: chisel
+    keywords:
+      - history
+    slot_uri: MIXS:0001081
+    range: TillageEnum
+    multivalued: true
+  time_last_toothbrush:
+    description: Specification of the time since last toothbrushing
+    title: time since last toothbrushing
+    comments:
+      - P2H45M does not match ^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d+[HMS])(\\d+H)?(\\d+M)?(\\d+S)?)?$
+      - problematic ISO 8601 period validation
+    examples:
+      - value: PT2H45M
+    keywords:
+      - time
+    slot_uri: MIXS:0000924
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  time_since_last_wash:
+    description: Specification of the time since last wash
+    title: time since last wash
+    examples:
+      - value: P1D
+    keywords:
+      - time
+    slot_uri: MIXS:0000943
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  timepoint:
+    annotations:
+      Preferred_unit: hours or days
+    description: Time point at which a sample or observation is made or taken from a biomaterial as measured from some reference point. Indicate the timepoint written in ISO 8601 format
+    title: timepoint
+    examples:
+      - value: PT24H
+    keywords:
+      - time
+    slot_uri: MIXS:0001173
+    range: string
+    pattern: ^P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)$
+    structured_pattern:
+      syntax: ^{duration}$
+      interpolated: true
+      partial_match: true
+  tiss_cult_growth_med:
+    description: Description of plant tissue culture growth media used
+    title: tissue culture growth media
+    examples:
+      - value: https://link.springer.com/content/pdf/10.1007/BF02796489.pdf
+    keywords:
+      - culture
+      - growth
+    slot_uri: MIXS:0001070
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}|{text}$
+      interpolated: true
+      partial_match: true
+  toluene:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of toluene in the sample
+    title: toluene
+    slot_uri: MIXS:0000154
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_carb:
+    description: Total carbon content
+    title: total carbon
+    keywords:
+      - carbon
+      - total
+    slot_uri: MIXS:0000525
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_depth_water_col:
+    annotations:
+      Preferred_unit: meter
+    description: Measurement of total depth of water column
+    title: total depth of water column
+    examples:
+      - value: 500 meter
+    keywords:
+      - depth
+      - total
+      - water
+    slot_uri: MIXS:0000634
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_diss_nitro:
+    annotations:
+      Preferred_unit: microgram per liter
+    description: 'Total dissolved nitrogen concentration, reported as nitrogen, measured by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen'
+    title: total dissolved nitrogen
+    examples:
+      - value: 40 microgram per liter
+    keywords:
+      - dissolved
+      - nitrogen
+      - total
+    slot_uri: MIXS:0000744
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_inorg_nitro:
+    annotations:
+      Preferred_unit: microgram per liter
+    description: Total inorganic nitrogen content
+    title: total inorganic nitrogen
+    examples:
+      - value: 40 microgram per liter
+    keywords:
+      - inorganic
+      - nitrogen
+      - total
+    slot_uri: MIXS:0000745
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_iron:
+    annotations:
+      Preferred_unit: milligram per liter, milligram per kilogram
+    description: Concentration of total iron in the sample
+    title: total iron
+    keywords:
+      - total
+    slot_uri: MIXS:0000105
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_nitro:
+    annotations:
+      Preferred_unit: microgram per liter, micromole per liter, milligram per liter
+    description: 'Total nitrogen concentration of water samples, calculated by: total nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured without filtering, reported as nitrogen'
+    title: total nitrogen concentration
+    examples:
+      - value: 50 micromole per liter
+    keywords:
+      - concentration
+      - nitrogen
+      - total
+    slot_uri: MIXS:0000102
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_nitro_cont_meth:
+    description: Reference or method used in determining the total nitrogen
+    title: total nitrogen content method
+    examples:
+      - value: https://currentprotocols.onlinelibrary.wiley.com/doi/abs/10.1002/0471142913.fab0102s00
+    keywords:
+      - content
+      - method
+      - nitrogen
+      - total
+    slot_uri: MIXS:0000338
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  tot_nitro_content:
+    description: Total nitrogen content of the sample
+    title: total nitrogen content
+    examples:
+      - value: 35 milligrams Nitrogen per kilogram of soil
+    keywords:
+      - content
+      - nitrogen
+      - total
+    slot_uri: MIXS:0000530
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_org_c_meth:
+    description: Reference or method used in determining total organic carbon
+    title: total organic carbon method
+    examples:
+      - value: https://www.epa.gov/sites/production/files/2015-12/documents/9060a.pdf
+    keywords:
+      - carbon
+      - method
+      - organic
+      - total
+    slot_uri: MIXS:0000337
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  tot_org_carb:
+    annotations:
+      Preferred_unit: gram Carbon per kilogram sample material
+    description: Total organic carbon content
+    title: total organic carbon
+    examples:
+      - value: '0.02'
+    keywords:
+      - carbon
+      - organic
+      - total
+    slot_uri: MIXS:0000533
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_part_carb:
+    annotations:
+      Preferred_unit: microgram per liter, micromole per liter
+    description: Total particulate carbon content
+    title: total particulate carbon
+    examples:
+      - value: 35 micromole per liter
+    keywords:
+      - carbon
+      - particle
+      - particulate
+      - total
+    slot_uri: MIXS:0000747
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_phosp:
+    annotations:
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
+    description: 'Total phosphorus concentration in the sample, calculated by: total phosphorus = total dissolved phosphorus + particulate phosphorus'
+    title: total phosphorus
+    examples:
+      - value: 0.03 milligram per liter
+    keywords:
+      - phosphorus
+      - total
+    slot_uri: MIXS:0000117
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_phosphate:
+    annotations:
+      Preferred_unit: microgram per liter, micromole per liter
+    description: Total amount or concentration of phosphate
+    title: total phosphate
+    keywords:
+      - phosphate
+      - total
+    slot_uri: MIXS:0000689
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tot_sulfur:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of total sulfur in the sample
+    title: total sulfur
+    keywords:
+      - sulfur
+      - total
+    slot_uri: MIXS:0000419
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  train_line:
+    description: The subway line name
+    title: train line
+    examples:
+      - value: red
+    keywords:
+      - train
+    slot_uri: MIXS:0000837
+    range: TrainLineEnum
+  train_stat_loc:
+    description: The train station collection location
+    title: train station collection location
+    examples:
+      - value: forest hills
+    keywords:
+      - location
+      - train
+    slot_uri: MIXS:0000838
+    range: TrainStatLocEnum
+  train_stop_loc:
+    description: The train stop collection location
+    title: train stop collection location
+    examples:
+      - value: end
+    keywords:
+      - location
+      - stop
+      - train
+    slot_uri: MIXS:0000839
+    range: TrainStopLocEnum
+  travel_out_six_month:
+    annotations:
+      Expected_value: country name
+    description: Specification of the countries travelled in the last six months; can include multiple travels
+    title: travel outside the country in last six months
+    keywords:
+      - months
+    slot_uri: MIXS:0000268
+    range: string
+    multivalued: true
+  trna_ext_software:
+    description: Tools used for tRNA identification
+    title: tRNA extraction software
+    examples:
+      - value: infernal;v2;default parameters
+    in_subset:
+      - sequencing
+    keywords:
+      - software
+    slot_uri: MIXS:0000068
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{software};{version};{parameters}$
+      interpolated: true
+      partial_match: true
+  trnas:
+    annotations:
+      Expected_value: value from 0-21
+    description: The total number of tRNAs identified from the SAG or MAG
+    title: number of standard tRNAs extracted
+    examples:
+      - value: '18'
+    in_subset:
+      - sequencing
+    keywords:
+      - number
+    string_serialization: '{integer}'
+    slot_uri: MIXS:0000067
+  trophic_level:
+    description: Trophic levels are the feeding position in a food chain. Microbes can be a range of producers (e.g. chemolithotroph)
+    title: trophic level
+    examples:
+      - value: heterotroph
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - level
+    slot_uri: MIXS:0000032
+    range: TrophicLevelEnum
+  turbidity:
+    description: Measure of the amount of cloudiness or haziness in water caused by individual particles
+    title: turbidity
+    examples:
+      - value: 0.3 nephelometric turbidity units
+    slot_uri: MIXS:0000191
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tvdss_of_hcr_press:
+    annotations:
+      Preferred_unit: meter
+    description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where the original pressure was measured (e.g. 1578 m)
+    title: depth (TVDSS) of hydrocarbon resource pressure
+    keywords:
+      - depth
+      - hydrocarbon
+      - pressure
+      - resource
+    slot_uri: MIXS:0000397
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  tvdss_of_hcr_temp:
+    annotations:
+      Preferred_unit: meter
+    description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where the original temperature was measured (e.g. 1345 m)
+    title: depth (TVDSS) of hydrocarbon resource temperature
+    keywords:
+      - depth
+      - hydrocarbon
+      - resource
+      - temperature
+    slot_uri: MIXS:0000394
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  twin_sibling:
+    description: Specification of twin sibling presence
+    title: twin sibling presence
+    examples:
+      - value: 'yes'
+    keywords:
+      - presence
+    slot_uri: MIXS:0000326
+    range: boolean
+  typ_occup_density:
+    description: Customary or normal density of occupants
+    title: typical occupant density
+    examples:
+      - value: '25'
+    keywords:
+      - density
+    slot_uri: MIXS:0000771
+    range: float
+    required: true
+  type_of_symbiosis:
+    description: Type of biological interaction established between the symbiotic host organism being sampled and its respective host
+    title: type of symbiosis
+    examples:
+      - value: parasitic
+    keywords:
+      - symbiosis
+      - type
+    slot_uri: MIXS:0001307
+    range: TypeOfSymbiosisEnum
+    recommended: true
+  urine_collect_meth:
+    description: Specification of urine collection method
+    title: urine/collection method
+    examples:
+      - value: catheter
+    keywords:
+      - method
+    slot_uri: MIXS:0000899
+    range: UrineCollectMethEnum
+  urobiom_sex:
+    annotations:
+      Expected_value: sex of the symbiotic organism (host of the samples); enumeration
+    description: Physical sex of the host
+    title: host sex
+    keywords:
+      - host
+      - host.
+    slot_uri: MIXS:0000862
+    range: UrobiomSexEnum
+  urogenit_disord:
+    description: History of urogenital disorders, can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, reproductive system disease (https://disease-ontology.org/?id=DOID:15) or urinary system disease (https://disease-ontology.org/?id=DOID:18)
+    title: urogenital disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000289
+    range: string
+    multivalued: true
+  urogenit_tract_disor:
+    description: History of urogenital tract disorders; can include multiple disorders. The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org, urinary system disease (https://disease-ontology.org/?id=DOID:18)
+    title: urine/urogenital tract disorder
+    keywords:
+      - disorder
+    slot_uri: MIXS:0000278
+    range: string
+    multivalued: true
+  ventilation_rate:
+    annotations:
+      Preferred_unit: cubic meter per minute, liters per second
+    description: Ventilation rate of the system in the sampled premises
+    title: ventilation rate
+    examples:
+      - value: 750 cubic meter per minute
+    keywords:
+      - rate
+    slot_uri: MIXS:0000114
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  ventilation_type:
+    annotations:
+      Expected_value: ventilation type name
+    description: Ventilation system used in the sampled premises
+    title: ventilation type
+    examples:
+      - value: Operable windows
+    keywords:
+      - type
+    slot_uri: MIXS:0000756
+    range: string
+    multivalued: true
+  vfa:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of Volatile Fatty Acids in the sample
+    title: volatile fatty acids
+    slot_uri: MIXS:0000152
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  vfa_fw:
+    annotations:
+      Preferred_unit: milligram per liter
+    description: Original volatile fatty acid concentration in the hydrocarbon resource
+    title: vfa in formation water
+    keywords:
+      - water
+    slot_uri: MIXS:0000408
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  vir_ident_software:
+    annotations:
+      Expected_value: software name, version and relevant parameters
+    description: Tool(s) used for the identification of UViG as a viral genome, software or protocol name including version number, parameters, and cutoffs used
+    title: viral identification software
+    examples:
+      - value: VirSorter; 1.0.4; Virome database, category 2
+    in_subset:
+      - sequencing
+    keywords:
+      - identifier
+      - software
+    string_serialization: '{software};{version};{parameters}'
+    slot_uri: MIXS:0000081
+  virus_enrich_appr:
+    description: List of approaches used to enrich the sample for viruses, if any
+    title: virus enrichment approach
+    examples:
+      - value: filtration
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: FeCl Precipitation
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: ultracentrifugation
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+      - value: DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+    in_subset:
+      - nucleic acid sequence source
+    keywords:
+      - enrichment
+    slot_uri: MIXS:0000036
+    range: VirusEnrichApprEnum
+  vis_media:
+    annotations:
+      Expected_value: enumeration
+    description: The building visual media
+    title: visual media
+    examples:
+      - value: 3D scans
+    string_serialization: '[photos|videos|commonly of the building|site context (adjacent buildings, vegetation, terrain, streets)|interiors|equipment|3D scans]'
+    slot_uri: MIXS:0000840
+  viscosity:
+    annotations:
+      Expected_value: measurement value;measurement value
+      Preferred_unit: cP at degree Celsius
+    description: A measure of oil's resistance  to gradual deformation by  shear stress  or  tensile stress (e.g. 3.5 cp; 100   C)
+    title: viscosity
+    string_serialization: '{float} {unit};{float} {unit}'
+    slot_uri: MIXS:0000126
+  volatile_org_comp:
+    annotations:
+      Expected_value: volatile organic compound name;measurement value
+      Preferred_unit: microgram per cubic meter, parts per million, nanogram per liter
+    description: Concentration of carbon-based chemicals that easily evaporate at room temperature; can report multiple volatile organic compounds by entering numeric values preceded by name of compound
+    title: volatile organic compounds
+    examples:
+      - value: formaldehyde;500 nanogram per liter
+    keywords:
+      - organic
+    string_serialization: '{text};{float} {unit}'
+    slot_uri: MIXS:0000115
+    multivalued: true
+  wall_area:
+    annotations:
+      Preferred_unit: square meter
+    description: The total area of the sampled room's walls
+    title: wall area
+    keywords:
+      - area
+      - wall
+    slot_uri: MIXS:0000198
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  wall_const_type:
+    description: The building class of the wall defined by the composition of the building elements and fire-resistance rating
+    title: wall construction type
+    examples:
+      - value: fire resistive
+    keywords:
+      - type
+      - wall
+    slot_uri: MIXS:0000841
+    range: WallConstTypeEnum
+  wall_finish_mat:
+    description: The material utilized to finish the outer most layer of the wall
+    title: wall finish material
+    examples:
+      - value: wood
+    keywords:
+      - material
+      - wall
+    slot_uri: MIXS:0000842
+    range: WallFinishMatEnum
+  wall_height:
+    annotations:
+      Preferred_unit: centimeter
+    description: The average height of the walls in the sampled room
+    title: wall height
+    keywords:
+      - height
+      - wall
+    slot_uri: MIXS:0000221
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  wall_loc:
+    description: The relative location of the wall within the room
+    title: wall location
+    examples:
+      - value: north
+    keywords:
+      - location
+      - wall
+    slot_uri: MIXS:0000843
+    range: CompassDirections8Enum
+  wall_surf_treatment:
+    description: The surface treatment of interior wall
+    title: wall surface treatment
+    examples:
+      - value: paneling
+    keywords:
+      - surface
+      - treatment
+      - wall
+    slot_uri: MIXS:0000845
+    range: WallSurfTreatmentEnum
+  wall_texture:
+    description: The feel, appearance, or consistency of a wall surface
+    title: wall texture
+    examples:
+      - value: popcorn
+    keywords:
+      - texture
+      - wall
+    slot_uri: MIXS:0000846
+    range: CeilingWallTextureEnum
+  wall_thermal_mass:
+    annotations:
+      Preferred_unit: joule per degree Celsius
+    description: The ability of the wall to provide inertia against temperature fluctuations. Generally this means concrete or concrete block that is either exposed or covered only with paint
+    title: wall thermal mass
+    keywords:
+      - mass
+      - wall
+    slot_uri: MIXS:0000222
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  wall_water_mold:
+    description: Signs of the presence of mold or mildew on a wall
+    title: wall signs of water/mold
+    examples:
+      - value: no presence of mold visible
+    keywords:
+      - wall
+    slot_uri: MIXS:0000844
+    range: MoldVisibilityEnum
+  wastewater_type:
+    annotations:
+      Expected_value: wastewater type name
+    description: The origin of wastewater such as human waste, rainfall, storm drains, etc
+    title: wastewater type
+    keywords:
+      - type
+    slot_uri: MIXS:0000353
+    range: string
+  water_cont_soil_meth:
+    description: Reference or method used in determining the water content of soil
+    title: water content method
+    keywords:
+      - content
+      - method
+      - water
+    slot_uri: MIXS:0000323
+    range: string
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$$
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
+  water_content:
+    annotations:
+      Preferred_unit: gram per gram or cubic centimeter per cubic centimeter
+    description: Water content measurement
+    title: water content
+    keywords:
+      - content
+      - water
+    slot_uri: MIXS:0000185
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  water_current:
+    annotations:
+      Preferred_unit: cubic meter per second, knots
+    description: Measurement of magnitude and direction of flow within a fluid
+    title: water current
+    examples:
+      - value: 10 cubic meter per second
+    keywords:
+      - water
+    slot_uri: MIXS:0000203
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  water_cut:
+    annotations:
+      Preferred_unit: percent
+    description: Current amount of water (%) in a produced fluid stream; or the average of the combined streams
+    title: water cut
+    comments:
+      - percent or float?
+    examples:
+      - value: 45%
+    keywords:
+      - water
+    slot_uri: MIXS:0000454
+    range: string
+    required: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  water_feat_size:
+    annotations:
+      Preferred_unit: square meter
+    description: The size of the water feature
+    title: water feature size
+    keywords:
+      - feature
+      - size
+      - water
+    slot_uri: MIXS:0000223
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  water_feat_type:
+    description: The type of water feature present within the building being sampled
+    title: water feature type
+    examples:
+      - value: stream
+    keywords:
+      - feature
+      - type
+      - water
+    slot_uri: MIXS:0000847
+    range: WaterFeatTypeEnum
+  water_frequency:
+    annotations:
+      Expected_value: rate
+      Preferred_unit: per day, per week, per month
+    description: Number of water delivery events within a given period of time
+    title: water delivery frequency
+    examples:
+      - value: 2 per day
+    keywords:
+      - delivery
+      - frequency
+      - water
+    string_serialization: '{float}{unit}'
+    slot_uri: MIXS:0001174
+  water_pH:
+    title: water pH
+    examples:
+      - value: '7.2'
+    keywords:
+      - ph
+      - water
+    slot_uri: MIXS:0001175
+    range: float
+  water_prod_rate:
+    annotations:
+      Preferred_unit: cubic meter per day
+    description: Water production rates per well (e.g. 987 m3 / day)
+    title: water production rate
+    keywords:
+      - production
+      - rate
+      - water
+    slot_uri: MIXS:0000453
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  water_source_adjac:
+    annotations:
+      Expected_value: ENVO_01001110 or ENVO_00000070
+    description: Description of the environmental features that are adjacent to the farm water source. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110) and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple terms can be separated by pipes
+    title: environmental feature adjacent water source
+    examples:
+      - value: feedlot [ENVO:01000627]
+    keywords:
+      - adjacent
+      - environmental
+      - feature
+      - source
+      - water
+    slot_uri: MIXS:0001122
+    range: string
+    multivalued: true
+  water_source_shared:
+    annotations:
+      Expected_value: enumeration
+    description: Other users sharing access to the same water source. Multiple terms can be separated by one or more pipes
+    title: water source shared
+    examples:
+      - value: no sharing
+    keywords:
+      - source
+      - water
+    string_serialization: '[multiple users, agricutural|multiple users, other|no sharing]'
+    slot_uri: MIXS:0001176
+    multivalued: true
+  water_temp_regm:
+    annotations:
+      Preferred_unit: degree Celsius
+    description: Information about treatment involving an exposure to water with varying degree of temperature, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
+    title: water temperature regimen
+    examples:
+      - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+      - temperature
+      - water
+    slot_uri: MIXS:0000590
+    range: string
+    multivalued: true
+  watering_regm:
+    annotations:
+      Preferred_unit: milliliter, liter
+    description: Information about treatment involving an exposure to watering frequencies, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
+    title: watering regimen
+    examples:
+      - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+    keywords:
+      - regimen
+      - water
+    slot_uri: MIXS:0000591
+    range: string
+    multivalued: true
+  weekday:
+    description: The day of the week when sampling occurred
+    title: weekday
+    examples:
+      - value: Sunday
+    slot_uri: MIXS:0000848
+    range: WeekdayEnum
+  weight_loss_3_month:
+    annotations:
+      Expected_value: weight loss specification;measurement value
+      Preferred_unit: kilogram, gram
+    description: Specification of weight loss in the last three months, if yes should be further specified to include amount of weight loss
+    title: weight loss in last three months
+    examples:
+      - value: yes;5 kilogram
+    keywords:
+      - months
+      - weight
+    string_serialization: '{boolean};{float} {unit}'
+    slot_uri: MIXS:0000295
+  wga_amp_appr:
+    description: Method used to amplify genomic DNA in preparation for sequencing
+    title: WGA amplification approach
+    examples:
+      - value: mda based
+    in_subset:
+      - sequencing
+    slot_uri: MIXS:0000055
+    range: WgaAmpApprEnum
+  wga_amp_kit:
+    annotations:
+      Expected_value: kit name
+    description: Kit used to amplify genomic DNA in preparation for sequencing
+    title: WGA amplification kit
+    examples:
+      - value: qiagen repli-g
+    in_subset:
+      - sequencing
+    keywords:
+      - kit
+    slot_uri: MIXS:0000006
+    range: string
+  win:
+    description: 'A unique identifier of a well or wellbore. This is part of the Global Framework for Well Identification initiative which is compiled by the Professional Petroleum Data Management Association (PPDM) in an effort to improve well identification systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)'
+    title: well identification number
+    keywords:
+      - identifier
+      - number
+    slot_uri: MIXS:0000297
+    range: string
+    recommended: true
+  wind_direction:
+    annotations:
+      Preferred_unit: degrees or cardinal direction
+    description: Wind direction is the direction from which a wind originates
+    title: wind direction
+    keywords:
+      - direction
+      - wind
+    slot_uri: MIXS:0000757
+    range: string
+  wind_speed:
+    description: speed of wind measured at the time of sampling
+    title: wind speed
+    keywords:
+      - speed
+      - wind
+    slot_uri: MIXS:0000118
+    range: string
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+  window_cond:
+    description: The physical condition of the window at the time of sampling
+    title: window condition
+    examples:
+      - value: rupture
+    keywords:
+      - condition
+      - window
+    slot_uri: MIXS:0000849
+    range: DamagedRupturedEnum
+  window_cover:
+    description: The type of window covering
+    title: window covering
+    examples:
+      - value: curtains
+    keywords:
+      - window
+    slot_uri: MIXS:0000850
+    range: WindowCoverEnum
+  window_horiz_pos:
+    description: The horizontal position of the window on the wall
+    title: window horizontal position
+    examples:
+      - value: middle
+    keywords:
+      - window
+    slot_uri: MIXS:0000851
+    range: WindowHorizPosEnum
+  window_loc:
+    description: The relative location of the window within the room
+    title: window location
+    examples:
+      - value: west
+    keywords:
+      - location
+      - window
+    slot_uri: MIXS:0000852
+    range: CompassDirections8Enum
+  window_mat:
+    description: The type of material used to finish a window
+    title: window material
+    examples:
+      - value: wood
+    keywords:
+      - material
+      - window
+    slot_uri: MIXS:0000853
+    range: WindowMatEnum
+  window_open_freq:
+    description: The number of times windows are opened per week
+    title: window open frequency
+    keywords:
+      - frequency
+      - window
+    slot_uri: MIXS:0000246
+    range: integer
+  window_size:
+    annotations:
+      Expected_value: measurement value
+      Preferred_unit: inch, meter
+    description: The window's length and width
+    title: window area/size
+    keywords:
+      - window
+    string_serialization: '{float} {unit} x {float} {unit}'
+    slot_uri: MIXS:0000224
+  window_status:
+    description: Defines whether the windows were open or closed during environmental testing
+    title: window status
+    examples:
+      - value: open
+    keywords:
+      - status
+      - window
+    slot_uri: MIXS:0000855
+    range: WindowStatusEnum
+  window_type:
+    description: The type of windows
+    title: window type
+    examples:
+      - value: fixed window
+    keywords:
+      - type
+      - window
+    slot_uri: MIXS:0000856
+    range: WindowTypeEnum
+  window_vert_pos:
+    description: The vertical position of the window on the wall
+    title: window vertical position
+    examples:
+      - value: middle
+    keywords:
+      - window
+    slot_uri: MIXS:0000857
+    range: WindowVertPosEnum
+  window_water_mold:
+    description: Signs of the presence of mold or mildew on the window
+    title: window signs of water/mold
+    examples:
+      - value: no presence of mold visible
+    keywords:
+      - window
+    slot_uri: MIXS:0000854
+    range: MoldVisibilityEnum
+  x16s_recover:
+    description: Can a 16S gene be recovered from the submitted SAG or MAG?
+    title: 16S recovered
+    examples:
+      - value: 'yes'
+    in_subset:
+      - sequencing
+    keywords:
+      - recover
+    slot_uri: MIXS:0000065
+    range: boolean
+  x16s_recover_software:
+    description: Tools used for 16S rRNA gene extraction
+    title: 16S recovery software
+    examples:
+      - value: rambl;v2;default parameters
+    in_subset:
+      - sequencing
+    keywords:
+      - recover
+      - software
+    slot_uri: MIXS:0000066
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+);([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    structured_pattern:
+      syntax: ^{software};{version};{parameters}$
+      interpolated: true
+      partial_match: true
+  xylene:
+    annotations:
+      Preferred_unit: milligram per liter, parts per million
+    description: Concentration of xylene in the sample
+    title: xylene
+    slot_uri: MIXS:0000156
+    range: string
+    recommended: true
+    pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$
+    structured_pattern:
+      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
+      interpolated: true
+      partial_match: true
+classes:
+  MigsBa:
+    description: 'Minimal Information about a Genome Sequence: cultured bacteria/archaea'
+    title: MIGS bacteria
+    aliases:
+      - migs_ba
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - extrachrom_elements
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - pathogenicity
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - encoded_traits
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - num_replicons
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - trophic_level
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      annot:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_qual:
+        required: true
+      assembly_software:
+        required: true
+      biotic_relationship:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      extrachrom_elements:
+        recommended: true
+      host_disease_stat:
+        examples:
+          - value: rabies [DOID:11260]
+        recommended: true
+      isol_growth_condt:
+        required: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      num_replicons:
+        required: true
+      number_contig:
+        required: true
+      pathogenicity:
+        recommended: true
+      ref_biomaterial:
+        required: true
+      rel_to_oxygen:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: swabbing
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      specific_host:
+        recommended: true
+      subspecf_gen_lin:
+        recommended: true
+      tax_ident:
+        recommended: true
+      temp:
+        recommended: true
+      trophic_level:
+        recommended: true
+    class_uri: MIXS:0010003
+  MigsEu:
+    description: 'Minimal Information about a Genome Sequence: eukaryote'
+    title: MIGS eukaryote
+    aliases:
+      - migs_eu
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - estimated_size
+      - extrachrom_elements
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - ploidy
+      - pathogenicity
+      - lib_reads_seqd
+      - propagation
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - num_replicons
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - trophic_level
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      annot:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_qual:
+        required: true
+      assembly_software:
+        required: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      host_disease_stat:
+        examples:
+          - value: rabies [DOID:11260]
+      isol_growth_condt:
+        required: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      number_contig:
+        required: true
+      pathogenicity:
+        recommended: true
+      propagation:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: swabbing
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      subspecf_gen_lin:
+        recommended: true
+      tax_ident:
+        recommended: true
+      temp:
+        recommended: true
+      trophic_level:
+        recommended: true
+    class_uri: MIXS:0010002
+  MigsOrg:
+    description: 'Minimal Information about a Genome Sequence: organelle'
+    title: MIGS org
+    aliases:
+      - migs_org
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - extrachrom_elements
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - samp_collect_device
+      - number_contig
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      annot:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_software:
+        required: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      extrachrom_elements:
+        recommended: true
+      isol_growth_condt:
+        required: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: swabbing
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      subspecf_gen_lin:
+        recommended: true
+      tax_ident:
+        recommended: true
+      temp:
+        recommended: true
+    class_uri: MIXS:0010006
+  MigsPl:
+    description: 'Minimal Information about a Genome Sequence: plasmid'
+    title: MIGS pl
+    aliases:
+      - migs_pl
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - encoded_traits
+      - propagation
+      - samp_collect_device
+      - number_contig
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      annot:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_software:
+        required: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      encoded_traits:
+        recommended: true
+      isol_growth_condt:
+        required: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      propagation:
+        required: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: swabbing
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      specific_host:
+        recommended: true
+      subspecf_gen_lin:
+        recommended: true
+      tax_ident:
+        recommended: true
+      temp:
+        recommended: true
+    class_uri: MIXS:0010004
+  MigsVi:
+    description: 'Minimal Information about a Genome Sequence: virus'
+    title: MIGS virus
+    aliases:
+      - migs_vi
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - assembly_name
+      - temp
+      - compl_score
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - estimated_size
+      - samp_vol_we_dna_ext
+      - pathogenicity
+      - lib_reads_seqd
+      - encoded_traits
+      - propagation
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - num_replicons
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - virus_enrich_appr
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - subspecf_gen_lin
+      - feat_pred
+      - env_local_scale
+      - compl_software
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      annot:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_software:
+        required: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      encoded_traits:
+        recommended: true
+      host_disease_stat:
+        examples:
+          - value: rabies [DOID:11260]
+        recommended: true
+      host_spec_range:
+        recommended: true
+      isol_growth_condt:
+        required: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      num_replicons:
+        recommended: true
+      pathogenicity:
+        recommended: true
+      propagation:
+        required: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: swabbing
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      specific_host:
+        recommended: true
+      subspecf_gen_lin:
+        recommended: true
+      tax_ident:
+        recommended: true
+      temp:
+        recommended: true
+      virus_enrich_appr:
+        recommended: true
+    class_uri: MIXS:0010005
+  Mimag:
+    description: Minimum Information About a Metagenome-Assembled Genome
+    title: MIMAG
+    aliases:
+      - mimag
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - size_frac
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - contam_screen_input
+      - mid
+      - assembly_name
+      - temp
+      - compl_score
+      - trnas
+      - mag_cov_software
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - bin_param
+      - bin_software
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - reassembly_bin
+      - decontam_software
+      - samp_collect_device
+      - number_contig
+      - trna_ext_software
+      - lib_layout
+      - contam_screen_param
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - tax_ident
+      - contam_score
+      - annot
+      - x16s_recover_software
+      - x16s_recover
+      - pos_cont_type
+      - feat_pred
+      - compl_software
+      - env_local_scale
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - compl_appr
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_qual:
+        required: true
+      assembly_software:
+        required: true
+      bin_param:
+        required: true
+      bin_software:
+        required: true
+      compl_score:
+        required: true
+      compl_software:
+        required: true
+      contam_score:
+        required: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      experimental_factor:
+        recommended: true
+      lib_layout:
+        recommended: true
+      lib_reads_seqd:
+        recommended: true
+      lib_screen:
+        recommended: true
+      lib_size:
+        recommended: true
+      lib_vector:
+        recommended: true
+      mid:
+        recommended: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        recommended: true
+      samp_collect_method:
+        examples:
+          - value: swabbing
+        recommended: true
+      samp_mat_process:
+        recommended: true
+      samp_size:
+        recommended: true
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      tax_ident:
+        required: true
+      temp:
+        recommended: true
+    class_uri: MIXS:0010011
+  MimarksC:
+    description: 'Minimal Information about a Marker Sequence: specimen'
+    title: MIMARKS specimen
+    comments:
+      - for marker gene sequences from cultured or voucher-identifiable specimens
+    aliases:
+      - mimarks_c
+      - MIMARKS-SU
+      - MIMARKS-specimen
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - pcr_primers
+      - nucl_acid_amp
+      - target_subfragment
+      - temp
+      - pcr_cond
+      - nucl_acid_ext
+      - samp_size
+      - isol_growth_condt
+      - alt
+      - source_mat_id
+      - extrachrom_elements
+      - samp_vol_we_dna_ext
+      - rel_to_oxygen
+      - samp_collect_device
+      - biotic_relationship
+      - seq_quality_check
+      - project_name
+      - neg_cont_type
+      - chimera_check
+      - trophic_level
+      - pos_cont_type
+      - subspecf_gen_lin
+      - env_local_scale
+      - samp_mat_process
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - experimental_factor
+      - target_gene
+      - associated_resource
+      - sop
+    slot_usage:
+      alt:
+        recommended: true
+      biotic_relationship:
+        recommended: true
+      chimera_check:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      isol_growth_condt:
+        required: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      pcr_cond:
+        recommended: true
+      pcr_primers:
+        recommended: true
+      rel_to_oxygen:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: swabbing
+      samp_mat_process:
+        recommended: true
+      seq_quality_check:
+        recommended: true
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      subspecf_gen_lin:
+        recommended: true
+      target_gene:
+        required: true
+      target_subfragment:
+        recommended: true
+      temp:
+        recommended: true
+      trophic_level:
+        recommended: true
+    class_uri: MIXS:0010009
+  MimarksS:
+    description: 'Minimal Information about a Marker Sequence: survey'
+    title: MIMARKS survey
+    comments:
+      - for marker gene sequences obtained directly from the environment
+    aliases:
+      - mimarks_s
+      - MIMARKS-SP
+      - MIMARKS-survey
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - pcr_primers
+      - size_frac
+      - lib_screen
+      - nucl_acid_amp
+      - lib_size
+      - target_subfragment
+      - mid
+      - temp
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - samp_collect_device
+      - seq_quality_check
+      - lib_layout
+      - env_broad_scale
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - chimera_check
+      - pos_cont_type
+      - env_local_scale
+      - samp_mat_process
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - pcr_cond
+      - experimental_factor
+      - target_gene
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      assembly_software:
+        recommended: true
+      chimera_check:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      experimental_factor:
+        recommended: true
+      lib_layout:
+        recommended: true
+      lib_reads_seqd:
+        recommended: true
+      lib_screen:
+        recommended: true
+      lib_size:
+        recommended: true
+      lib_vector:
+        recommended: true
+      mid:
+        recommended: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      pcr_cond:
+        recommended: true
+      pcr_primers:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        recommended: true
+      samp_collect_method:
+        examples:
+          - value: swabbing
+        recommended: true
+      samp_mat_process:
+        recommended: true
+      samp_size:
+        recommended: true
+      seq_quality_check:
+        recommended: true
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      target_gene:
+        required: true
+      target_subfragment:
+        recommended: true
+      temp:
+        recommended: true
+    class_uri: MIXS:0010008
+  Mims:
+    description: Metagenome or Environmental
+    title: MIMS
+    aliases:
+      - mims
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - size_frac
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - mid
+      - assembly_name
+      - temp
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - samp_collect_device
+      - number_contig
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - annot
+      - pos_cont_type
+      - feat_pred
+      - env_local_scale
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      annot:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_qual:
+        recommended: true
+      assembly_software:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      experimental_factor:
+        recommended: true
+      lib_layout:
+        recommended: true
+      lib_reads_seqd:
+        recommended: true
+      lib_screen:
+        recommended: true
+      lib_size:
+        recommended: true
+      lib_vector:
+        recommended: true
+      mid:
+        recommended: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      number_contig:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        recommended: true
+      samp_collect_method:
+        examples:
+          - value: swabbing
+        recommended: true
+      samp_mat_process:
+        recommended: true
+      samp_size:
+        recommended: true
+      sop:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      temp:
+        recommended: true
+    class_uri: MIXS:0010007
+  Misag:
+    description: Minimum Information About a Single Amplified Genome
+    title: Minimum Information About a Single Amplified Genome
+    aliases:
+      - misag
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - size_frac
+      - lib_screen
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - contam_screen_input
+      - mid
+      - assembly_name
+      - temp
+      - compl_score
+      - trnas
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - lib_reads_seqd
+      - rel_to_oxygen
+      - wga_amp_kit
+      - decontam_software
+      - samp_collect_device
+      - number_contig
+      - trna_ext_software
+      - sc_lysis_method
+      - lib_layout
+      - contam_screen_param
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - adapters
+      - neg_cont_type
+      - assembly_software
+      - tax_ident
+      - contam_score
+      - annot
+      - x16s_recover_software
+      - x16s_recover
+      - pos_cont_type
+      - feat_pred
+      - compl_software
+      - env_local_scale
+      - sort_tech
+      - samp_mat_process
+      - sim_search_meth
+      - depth
+      - samp_collect_method
+      - wga_amp_appr
+      - compl_appr
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - sc_lysis_approach
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_qual:
+        required: true
+      assembly_software:
+        required: true
+      compl_score:
+        required: true
+      compl_software:
+        required: true
+      contam_score:
+        required: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      experimental_factor:
+        recommended: true
+      lib_layout:
+        recommended: true
+      lib_reads_seqd:
+        recommended: true
+      lib_screen:
+        recommended: true
+      lib_size:
+        recommended: true
+      lib_vector:
+        recommended: true
+      mid:
+        recommended: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        recommended: true
+      samp_collect_method:
+        examples:
+          - value: swabbing
+        recommended: true
+      samp_mat_process:
+        recommended: true
+      samp_size:
+        recommended: true
+      sc_lysis_approach:
+        required: true
+      sop:
+        recommended: true
+      sort_tech:
+        required: true
+      source_mat_id:
+        recommended: true
+      tax_ident:
+        required: true
+      temp:
+        recommended: true
+      wga_amp_appr:
+        required: true
+    class_uri: MIXS:0010010
+  Miuvig:
+    description: Minimum Information About an Uncultivated Virus Genome
+    title: Minimum Information About an Uncultivated Virus Genome
+    aliases:
+      - miuvig
+    is_a: Checklist
+    mixin: true
+    slots:
+      - samp_name
+      - size_frac
+      - lib_screen
+      - source_uvig
+      - ref_db
+      - nucl_acid_amp
+      - lib_size
+      - mid
+      - assembly_name
+      - temp
+      - compl_score
+      - trnas
+      - nucl_acid_ext
+      - samp_size
+      - alt
+      - estimated_size
+      - source_mat_id
+      - samp_vol_we_dna_ext
+      - pathogenicity
+      - lib_reads_seqd
+      - samp_collect_device
+      - number_contig
+      - biotic_relationship
+      - trna_ext_software
+      - lib_layout
+      - assembly_qual
+      - ref_biomaterial
+      - project_name
+      - lib_vector
+      - host_spec_range
+      - neg_cont_type
+      - virus_enrich_appr
+      - adapters
+      - assembly_software
+      - tax_ident
+      - annot
+      - pos_cont_type
+      - feat_pred
+      - compl_software
+      - env_local_scale
+      - samp_mat_process
+      - sim_search_meth
+      - host_disease_stat
+      - depth
+      - samp_collect_method
+      - compl_appr
+      - specific_host
+      - env_medium
+      - samp_taxon_id
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - lat_lon
+      - elev
+      - env_broad_scale
+      - tax_class
+      - experimental_factor
+      - sort_tech
+      - sc_lysis_approach
+      - sc_lysis_method
+      - wga_amp_appr
+      - wga_amp_kit
+      - bin_param
+      - bin_software
+      - reassembly_bin
+      - mag_cov_software
+      - vir_ident_software
+      - pred_genome_type
+      - pred_genome_struc
+      - detec_type
+      - otu_class_appr
+      - otu_seq_comp_appr
+      - otu_db
+      - host_pred_appr
+      - host_pred_est_acc
+      - associated_resource
+      - sop
+    slot_usage:
+      adapters:
+        recommended: true
+      alt:
+        recommended: true
+      assembly_name:
+        recommended: true
+      assembly_qual:
+        required: true
+      assembly_software:
+        required: true
+      bin_param:
+        recommended: true
+      bin_software:
+        recommended: true
+      compl_appr:
+        recommended: true
+      compl_score:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      detec_type:
+        required: true
+      elev:
+        recommended: true
+      experimental_factor:
+        recommended: true
+      feat_pred:
+        recommended: true
+      host_disease_stat:
+        examples:
+          - value: rabies [DOID:11260]
+        recommended: true
+      host_pred_appr:
+        recommended: true
+      host_pred_est_acc:
+        recommended: true
+      lib_layout:
+        recommended: true
+      lib_reads_seqd:
+        recommended: true
+      lib_screen:
+        recommended: true
+      lib_size:
+        recommended: true
+      lib_vector:
+        recommended: true
+      mid:
+        recommended: true
+      nucl_acid_amp:
+        recommended: true
+      nucl_acid_ext:
+        recommended: true
+      number_contig:
+        required: true
+      otu_class_appr:
+        recommended: true
+      otu_db:
+        recommended: true
+      otu_seq_comp_appr:
+        recommended: true
+      pred_genome_struc:
+        required: true
+      pred_genome_type:
+        required: true
+      reassembly_bin:
+        recommended: true
+      ref_db:
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+        recommended: true
+      samp_collect_method:
+        examples:
+          - value: swabbing
+        recommended: true
+      samp_mat_process:
+        recommended: true
+      samp_size:
+        recommended: true
+      sc_lysis_approach:
+        recommended: true
+      sc_lysis_method:
+        recommended: true
+      sim_search_meth:
+        recommended: true
+      size_frac:
+        recommended: true
+      sop:
+        recommended: true
+      sort_tech:
+        recommended: true
+      source_mat_id:
+        recommended: true
+      source_uvig:
+        required: true
+      tax_class:
+        recommended: true
+      temp:
+        recommended: true
+      vir_ident_software:
+        required: true
+      virus_enrich_appr:
+        required: true
+      wga_amp_appr:
+        recommended: true
+      wga_amp_kit:
+        recommended: true
+    class_uri: MIXS:0010012
+  Agriculture:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Agricultural Microbiomes Research Coordination Network, model cropping and plant systems focused on agricultural plant and soil microbe; microbiome studies in agricultural sites; long-term ecological research in croplands; eDNA in manure samples; describing agricultural microbiome studies
+    description: A collection of terms appropriate when sequencing samples obtained in an agricultural environment.  Suitable to capture metadata appropriate to enhance crop productivity and agroecosystem health  with the aim to facilitate research of agricultural microbiomes and their relationships to plant productivity  and sustainable crop production from diverse crop management contexts.
+    title: agriculture
+    aliases:
+      - MIxS-Ag (agriculture)
+    is_a: Extension
+    slots:
+      - plant_growth_med
+      - photosynt_activ
+      - photosynt_activ_meth
+      - samp_collect_method
+      - enrichment_protocol
+      - library_prep_kit
+      - sequencing_location
+      - soil_temp
+      - soil_pH
+      - soil_conductivity
+      - rel_location
+      - soil_cover
+      - porosity
+      - soil_texture
+      - soil_texture_meth
+      - host_symbiont
+      - host_disease_stat
+      - pres_animal_insect
+      - plant_water_method
+      - anim_water_method
+      - farm_water_source
+      - water_source_shared
+      - water_pH
+      - elev
+      - season
+      - solar_irradiance
+      - crop_yield
+      - season_humidity
+      - humidity
+      - adjacent_environment
+      - chem_administration
+      - food_prod
+      - lot_number
+      - fertilizer_admin
+      - samp_store_temp
+      - food_trav_mode
+      - food_trav_vehic
+      - farm_equip_san
+      - farm_equip
+      - farm_equip_shared
+      - food_harvest_proc
+      - plant_struc
+      - host_dry_mass
+      - ances_data
+      - genetic_mod
+      - food_product_type
+      - food_source
+      - spikein_strain
+      - organism_count
+      - size_frac_low
+      - size_frac_up
+      - cult_isol_date
+      - samp_pooling
+      - root_med_macronutr
+      - root_med_carbon
+      - root_med_ph
+      - depth
+      - specific_host
+      - pathogenicity
+      - biotic_relationship
+      - water_temp_regm
+      - watering_regm
+      - standing_water_regm
+      - gaseous_environment
+      - fungicide_regm
+      - climate_environment
+      - herbicide_regm
+      - non_min_nutr_regm
+      - pesticide_regm
+      - ph_regm
+      - salt_regm
+      - season_environment
+      - temp
+      - perturbation
+      - isol_growth_condt
+      - samp_store_dur
+      - samp_store_loc
+      - samp_collect_device
+      - samp_mat_process
+      - host_age
+      - host_common_name
+      - host_genotype
+      - host_height
+      - host_subspecf_genlin
+      - host_length
+      - host_life_stage
+      - host_phenotype
+      - host_taxid
+      - host_tot_mass
+      - host_spec_range
+      - trophic_level
+      - plant_product
+      - samp_size
+      - oxy_stat_samp
+      - seq_meth
+      - samp_vol_we_dna_ext
+      - pcr_primers
+      - nucl_acid_ext
+      - nucl_acid_amp
+      - lib_size
+      - lib_reads_seqd
+      - lib_layout
+      - lib_vector
+      - lib_screen
+      - target_gene
+      - target_subfragment
+      - mid
+      - adapters
+      - pcr_cond
+      - seq_quality_check
+      - chimera_check
+      - assembly_name
+      - assembly_qual
+      - assembly_software
+      - annot
+      - associated_resource
+      - sop
+      - source_mat_id
+      - fao_class
+      - local_class
+      - local_class_meth
+      - soil_type
+      - soil_type_meth
+      - soil_horizon
+      - horizon_meth
+      - link_class_info
+      - previous_land_use
+      - prev_land_use_meth
+      - crop_rotation
+      - agrochem_addition
+      - tillage
+      - fire
+      - flooding
+      - extreme_event
+      - link_climate_info
+      - annual_temp
+      - season_temp
+      - annual_precpt
+      - season_precpt
+      - cur_land_use
+      - slope_gradient
+      - slope_aspect
+      - profile_position
+      - drainage_class
+      - store_cond
+      - ph_meth
+      - cur_vegetation
+      - cur_vegetation_meth
+      - tot_org_carb
+      - tot_org_c_meth
+      - tot_nitro_content
+      - tot_nitro_cont_meth
+      - microbial_biomass
+      - micro_biomass_meth
+      - heavy_metals_meth
+      - tot_carb
+      - tot_phosphate
+      - sieving
+      - pool_dna_extracts
+      - misc_param
+    slot_usage:
+      adapters:
+        required: true
+      annot:
+        recommended: true
+      assembly_name:
+        required: true
+      biotic_relationship:
+        recommended: true
+      chem_administration:
+        required: true
+      chimera_check:
+        required: true
+      climate_environment:
+        string_serialization: '{text};{period};{interval};{period}'
+        recommended: true
+      crop_rotation:
+        string_serialization: '{boolean};Rn/{timestamp}/{period}'
+        recommended: true
+      cur_vegetation:
+        recommended: true
+      cur_vegetation_meth:
+        recommended: true
+      depth:
+        examples:
+          - value: 5 cm
+        recommended: true
+      drainage_class:
+        recommended: true
+      enrichment_protocol:
+        recommended: true
+      extreme_event:
+        recommended: true
+      fao_class:
+        recommended: true
+      fire:
+        recommended: true
+      flooding:
+        recommended: true
+      food_product_type:
+        examples:
+          - value: delicatessen salad; FOODON:03316276
+      food_source:
+        examples:
+          - value: red swamp crayfish; FOODON:03412231
+        required: true
+      fungicide_regm:
+        string_serialization: '{text};{float} {unit};{period};{interval};{period}'
+        recommended: true
+      gaseous_environment:
+        string_serialization: '{text};{float} {unit};{period};{interval};{period}'
+        recommended: true
+      heavy_metals_meth:
+        string_serialization: '{PMID|DOI|URL}'
+        recommended: true
+      herbicide_regm:
+        string_serialization: '{text};{float} {unit};{period};{interval};{period}'
+        recommended: true
+      horizon_meth:
+        recommended: true
+      host_age:
+        required: true
+      host_common_name:
+        required: true
+      host_disease_stat:
+        examples:
+          - value: downy mildew
+        recommended: true
+      host_genotype:
+        required: true
+      host_height:
+        required: true
+      host_length:
+        required: true
+      host_life_stage:
+        required: true
+      host_phenotype:
+        required: true
+      host_spec_range:
+        required: true
+      host_symbiont:
+        examples:
+          - value: Paragordius varius
+      host_taxid:
+        examples:
+          - value: '9606'
+        string_serialization: '{integer}'
+        required: true
+      host_tot_mass:
+        required: true
+      humidity:
+        examples:
+          - value: 30% relative humidity
+        recommended: true
+      lib_layout:
+        recommended: true
+      lib_reads_seqd:
+        required: true
+      lib_screen:
+        required: true
+      lib_vector:
+        required: true
+      library_prep_kit:
+        examples:
+          - value: llumina DNA Prep, (M) Tagmentation
+      local_class:
+        recommended: true
+      local_class_meth:
+        recommended: true
+      micro_biomass_meth:
+        required: true
+      microbial_biomass:
+        required: true
+      mid:
+        required: true
+      non_min_nutr_regm:
+        string_serialization: '{text};{float} {unit};{period};{interval};{period}'
+        recommended: true
+      nucl_acid_amp:
+        required: true
+      nucl_acid_ext:
+        required: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        recommended: true
+      oxy_stat_samp:
+        recommended: true
+      pathogenicity:
+        required: true
+      pcr_cond:
+        required: true
+      pcr_primers:
+        required: true
+      perturbation:
+        recommended: true
+      pesticide_regm:
+        string_serialization: '{text};{float} {unit};{period};{interval};{period}'
+        recommended: true
+      ph_meth:
+        recommended: true
+      ph_regm:
+        string_serialization: '{float};{period};{interval};{period}'
+        recommended: true
+      plant_growth_med:
+        examples:
+          - value: hydroponic plant culture media [EO:0007067]
+      plant_product:
+        recommended: true
+      plant_struc:
+        recommended: true
+      pool_dna_extracts:
+        string_serialization: '{boolean};{float} {unit}'
+        required: true
+      prev_land_use_meth:
+        recommended: true
+      previous_land_use:
+        recommended: true
+      profile_position:
+        recommended: true
+      rel_location:
+        recommended: true
+      salt_regm:
+        string_serialization: '{text};{float} {unit};{period};{interval};{period}'
+        recommended: true
+      samp_collect_device:
+        examples:
+          - value: biopsy, niskin bottle, push core
+        required: true
+      samp_collect_method:
+        examples:
+          - value: environmental swab sampling
+      samp_mat_process:
+        required: true
+      samp_pooling:
+        recommended: true
+      samp_size:
+        required: true
+      samp_store_dur:
+        required: true
+      samp_store_loc:
+        required: true
+      samp_vol_we_dna_ext:
+        required: true
+      season_environment:
+        string_serialization: '{text};{period};{interval};{period}'
+        recommended: true
+      sieving:
+        required: true
+      slope_aspect:
+        recommended: true
+      slope_gradient:
+        recommended: true
+      soil_conductivity:
+        description: Conductivity of some soil.
+      soil_cover:
+        recommended: true
+      soil_horizon:
+        recommended: true
+      soil_pH:
+        description: pH of some soil.
+      soil_type:
+        required: true
+      soil_type_meth:
+        required: true
+      specific_host:
+        required: true
+      standing_water_regm:
+        string_serialization: '{text};{period};{interval};{period}'
+        recommended: true
+      store_cond:
+        required: true
+      target_gene:
+        required: true
+      target_subfragment:
+        required: true
+      temp:
+        required: true
+      tillage:
+        recommended: true
+      tot_carb:
+        recommended: true
+      tot_nitro_cont_meth:
+        recommended: true
+      tot_nitro_content:
+        recommended: true
+      tot_org_c_meth:
+        recommended: true
+      tot_org_carb:
+        recommended: true
+      tot_phosphate:
+        recommended: true
+      trophic_level:
+        recommended: true
+      water_pH:
+        description: The pH measurement of the sample, or liquid portion of sample, or aqueous phase of the fluid.
+      water_temp_regm:
+        string_serialization: '{float} {unit};{period};{interval};{period}'
+        recommended: true
+      watering_regm:
+        string_serialization: '{float} {unit};{period};{interval};{period}'
+        recommended: true
+    class_uri: MIXS:0016018
+  Air:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: bioaerosol samples, pathogen load in urban air, aerosols
+    description: A collection of terms appropriate when collecting and sequencing samples obtained from a gaseous environment.
+    title: air
+    aliases:
+      - MIxS-air
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - alt
+      - elev
+      - barometric_press
+      - carb_dioxide
+      - carb_monoxide
+      - chem_administration
+      - humidity
+      - methane
+      - organism_count
+      - oxygen
+      - oxy_stat_samp
+      - perturbation
+      - pollutants
+      - air_PM_concen
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - solar_irradiance
+      - temp
+      - ventilation_rate
+      - ventilation_type
+      - volatile_org_comp
+      - wind_direction
+      - wind_speed
+      - misc_param
+    slot_usage:
+      alt:
+        required: true
+      elev:
+        recommended: true
+      humidity:
+        examples:
+          - value: 25 gram per cubic meter
+      methane:
+        examples:
+          - value: 1800 parts per billion
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+      wind_direction:
+        examples:
+          - value: Northwest
+      wind_speed:
+        examples:
+          - value: 21 kilometer per hour
+    class_uri: MIXS:0016000
+  BuiltEnvironment:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: microbiology studies of the built environment, NASA space station sampling, MetaSUB transit system sampling, home, hospitals, office buildings
+    description: A collection of terms appropriate when collecting samples and sequencing samples obtained in the  built-up environment, which includes terms for surface material, humidity, temperature, moisture and  occupancy type along with specific metadata terms describing the indoor air, building and sample properties.
+    title: built environment
+    aliases:
+      - MIxS-BE (built environment)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - surf_material
+      - surf_air_cont
+      - rel_air_humidity
+      - abs_air_humidity
+      - surf_humidity
+      - air_temp
+      - surf_temp
+      - surf_moisture_ph
+      - build_occup_type
+      - surf_moisture
+      - dew_point
+      - carb_dioxide
+      - ventilation_type
+      - organism_count
+      - indoor_space
+      - indoor_surf
+      - filter_type
+      - heat_cool_type
+      - substructure_type
+      - building_setting
+      - light_type
+      - samp_sort_meth
+      - space_typ_state
+      - typ_occup_density
+      - occup_samp
+      - occup_density_samp
+      - address
+      - adj_room
+      - aero_struc
+      - amount_light
+      - arch_struc
+      - avg_occup
+      - avg_dew_point
+      - avg_temp
+      - bathroom_count
+      - bedroom_count
+      - built_struc_age
+      - built_struc_set
+      - built_struc_type
+      - ceil_area
+      - ceil_cond
+      - ceil_finish_mat
+      - ceil_water_mold
+      - ceil_struc
+      - ceil_texture
+      - ceil_thermal_mass
+      - ceil_type
+      - cool_syst_id
+      - date_last_rain
+      - build_docs
+      - door_size
+      - door_cond
+      - door_direct
+      - door_loc
+      - door_mat
+      - door_move
+      - door_water_mold
+      - door_type
+      - door_comp_type
+      - door_type_metal
+      - door_type_wood
+      - drawings
+      - elevator
+      - escalator
+      - exp_duct
+      - exp_pipe
+      - ext_door
+      - fireplace_type
+      - floor_age
+      - floor_area
+      - floor_cond
+      - floor_count
+      - floor_finish_mat
+      - floor_water_mold
+      - floor_struc
+      - floor_thermal_mass
+      - freq_clean
+      - freq_cook
+      - furniture
+      - gender_restroom
+      - hall_count
+      - handidness
+      - heat_deliv_loc
+      - heat_sys_deliv_meth
+      - heat_system_id
+      - height_carper_fiber
+      - inside_lux
+      - int_wall_cond
+      - last_clean
+      - max_occup
+      - mech_struc
+      - number_plants
+      - number_pets
+      - number_resident
+      - occup_document
+      - ext_wall_orient
+      - ext_window_orient
+      - rel_humidity_out
+      - pres_animal_insect
+      - quad_pos
+      - rel_samp_loc
+      - room_air_exch_rate
+      - room_architec_elem
+      - room_condt
+      - room_count
+      - room_dim
+      - room_door_dist
+      - room_loc
+      - room_moist_dam_hist
+      - room_net_area
+      - room_occup
+      - room_samp_pos
+      - room_type
+      - room_vol
+      - room_window_count
+      - room_connected
+      - room_hallway
+      - room_door_share
+      - room_wall_share
+      - samp_weather
+      - samp_floor
+      - samp_room_id
+      - samp_time_out
+      - season
+      - season_use
+      - shading_device_cond
+      - shading_device_loc
+      - shading_device_mat
+      - shad_dev_water_mold
+      - shading_device_type
+      - specific_humidity
+      - specific
+      - temp_out
+      - train_line
+      - train_stat_loc
+      - train_stop_loc
+      - vis_media
+      - wall_area
+      - wall_const_type
+      - wall_finish_mat
+      - wall_height
+      - wall_loc
+      - wall_water_mold
+      - wall_surf_treatment
+      - wall_texture
+      - wall_thermal_mass
+      - water_feat_size
+      - water_feat_type
+      - weekday
+      - window_size
+      - window_cond
+      - window_cover
+      - window_horiz_pos
+      - window_loc
+      - window_mat
+      - window_open_freq
+      - window_water_mold
+      - window_status
+      - window_type
+      - window_vert_pos
+    slot_usage:
+      air_temp:
+        examples:
+          - value: 20 degree Celsius
+        required: true
+      avg_occup:
+        examples:
+          - value: '2'
+      carb_dioxide:
+        required: true
+      freq_clean:
+        string_serialization: '[ Daily| Weekly| Monthly| Quarterly | Annually| other]'
+      indoor_surf:
+        required: true
+        recommended: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        required: true
+      surf_material:
+        required: true
+        recommended: true
+      ventilation_type:
+        required: true
+    class_uri: MIXS:0016001
+  FoodAnimalAndAnimalFeed:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of farm animals, their feed, and pet food.
+    description: A collection of terms appropriate when collecting samples and performing sequencing of samples  obtained from farm animals and their feed.
+    title: food-animal and animal feed
+    comments:
+      - This extension is intended to work alongside the other food extensions (farm environment, food production facility, and human foods) for capturing contextual data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food (animal and animal feed)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - experimental_factor
+      - nucl_acid_ext
+      - organism_count
+      - spikein_count
+      - samp_store_temp
+      - samp_store_dur
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - temp
+      - samp_store_loc
+      - samp_transport_cont
+      - perturbation
+      - coll_site_geo_feat
+      - food_origin
+      - food_prod
+      - food_product_type
+      - food_source
+      - IFSAC_category
+      - intended_consumer
+      - samp_purpose
+      - animal_am
+      - animal_am_dur
+      - animal_am_freq
+      - animal_am_route
+      - animal_am_use
+      - animal_body_cond
+      - animal_diet
+      - animal_feed_equip
+      - animal_group_size
+      - animal_housing
+      - animal_sex
+      - bacterial_density
+      - cons_food_stor_dur
+      - cons_food_stor_temp
+      - cons_purch_date
+      - cons_qty_purchased
+      - cult_isol_date
+      - cult_result
+      - cult_result_org
+      - cult_target
+      - enrichment_protocol
+      - food_additive
+      - food_contact_surf
+      - food_contain_wrap
+      - food_cooking_proc
+      - food_dis_point
+      - food_dis_point_city
+      - food_ingredient
+      - food_pack_capacity
+      - food_pack_integrity
+      - food_pack_medium
+      - food_preserv_proc
+      - food_prior_contact
+      - food_prod_synonym
+      - food_product_qual
+      - food_quality_date
+      - food_source_age
+      - food_trace_list
+      - food_trav_mode
+      - food_trav_vehic
+      - food_treat_proc
+      - HACCP_term
+      - library_prep_kit
+      - lot_number
+      - microb_cult_med
+      - part_plant_animal
+      - repository_name
+      - samp_collect_method
+      - samp_pooling
+      - samp_rep_biol
+      - samp_rep_tech
+      - samp_source_mat_cat
+      - samp_stor_device
+      - samp_stor_media
+      - samp_transport_dur
+      - samp_transport_temp
+      - sequencing_kit
+      - sequencing_location
+      - serovar_or_serotype
+      - spikein_AMR
+      - spikein_antibiotic
+      - spikein_growth_med
+      - spikein_metal
+      - spikein_org
+      - spikein_serovar
+      - spikein_strain
+      - study_design
+      - study_inc_dur
+      - study_inc_temp
+      - study_timecourse
+      - study_tmnt
+      - timepoint
+      - misc_param
+    slot_usage:
+      food_origin:
+        required: true
+      food_pack_medium:
+        examples:
+          - value: packed in fruit juice [FOODON:03480039]
+      food_prod:
+        required: true
+      food_product_type:
+        examples:
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        required: true
+      food_source:
+        examples:
+          - value: giant tiger prawn [FOODON:03412612]
+      intended_consumer:
+        required: true
+      library_prep_kit:
+        examples:
+          - value: Illumina DNA Prep
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+      pool_dna_extracts:
+        string_serialization: '{boolean},{integer}'
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: environmental swab sampling
+      samp_purpose:
+        required: true
+    class_uri: MIXS:0016019
+  FoodFarmEnvironment:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of farm and field crops as well as environmental samples including irrigation, soil amendments, and farm equipment.
+    description: A collection of terms appropriate when collecting samples and performing sequencing of samples  obtained from the farm environment, including soil, manure, and food harvesting equipment.
+    title: food-farm environment
+    comments:
+      - This extension is intended to work alongside the other food extensions (animals and animal feed, food production facility, and human foods) for capturing contextual data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food (farm environment)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - nucl_acid_ext
+      - humidity
+      - organism_count
+      - spikein_count
+      - samp_store_temp
+      - solar_irradiance
+      - ventilation_rate
+      - samp_store_dur
+      - wind_speed
+      - salinity
+      - samp_vol_we_dna_ext
+      - previous_land_use
+      - crop_rotation
+      - soil_type_meth
+      - tot_org_c_meth
+      - tot_nitro_cont_meth
+      - host_age
+      - host_dry_mass
+      - host_height
+      - host_length
+      - host_tot_mass
+      - root_med_carbon
+      - root_med_macronutr
+      - root_med_micronutr
+      - depth
+      - season_temp
+      - season_precpt
+      - tot_org_carb
+      - tot_nitro_content
+      - conduc
+      - turbidity
+      - size_frac_low
+      - size_frac_up
+      - temp
+      - ventilation_type
+      - wind_direction
+      - genetic_mod
+      - host_phenotype
+      - ph
+      - ances_data
+      - biotic_regm
+      - chem_administration
+      - growth_habit
+      - host_disease_stat
+      - host_genotype
+      - host_taxid
+      - mechanical_damage
+      - perturbation
+      - root_cond
+      - root_med_ph
+      - tillage
+      - ph_meth
+      - growth_medium
+      - season
+      - food_product_type
+      - samp_type
+      - farm_water_source
+      - plant_water_method
+      - air_PM_concen
+      - animal_feed_equip
+      - animal_intrusion
+      - anim_water_method
+      - crop_yield
+      - cult_result
+      - cult_result_org
+      - cult_target
+      - plant_part_maturity
+      - adjacent_environment
+      - water_source_adjac
+      - farm_equip_shared
+      - farm_equip_san
+      - farm_equip_san_freq
+      - farm_equip
+      - fertilizer_admin
+      - fertilizer_date
+      - animal_group_size
+      - animal_diet
+      - food_contact_surf
+      - food_contain_wrap
+      - food_harvest_proc
+      - food_pack_medium
+      - food_preserv_proc
+      - food_prod_char
+      - prod_label_claims
+      - food_trav_mode
+      - food_trav_vehic
+      - food_source
+      - food_treat_proc
+      - extr_weather_event
+      - date_extr_weath
+      - host_subspecf_genlin
+      - intended_consumer
+      - library_prep_kit
+      - air_flow_impede
+      - lot_number
+      - season_humidity
+      - part_plant_animal
+      - plant_growth_med
+      - plant_reprod_crop
+      - samp_purpose
+      - repository_name
+      - samp_pooling
+      - samp_source_mat_cat
+      - sequencing_kit
+      - sequencing_location
+      - serovar_or_serotype
+      - soil_conductivity
+      - soil_cover
+      - soil_pH
+      - rel_location
+      - soil_porosity
+      - soil_temp
+      - soil_texture_class
+      - soil_texture_meth
+      - soil_type
+      - spikein_org
+      - spikein_serovar
+      - spikein_growth_med
+      - spikein_strain
+      - spikein_antibiotic
+      - spikein_metal
+      - timepoint
+      - water_frequency
+      - water_pH
+      - water_source_shared
+      - enrichment_protocol
+      - food_quality_date
+      - IFSAC_category
+      - animal_housing
+      - cult_isol_date
+      - food_clean_proc
+      - misc_param
+    slot_usage:
+      biotic_regm:
+        required: true
+      chem_administration:
+        required: true
+      crop_rotation:
+        string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
+      depth:
+        examples:
+          - value: 10 meter
+        required: true
+      food_pack_medium:
+        examples:
+          - value: vacuum-packed [FOODON:03480027]
+      food_product_type:
+        examples:
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        required: true
+      food_source:
+        examples:
+          - value: giant tiger prawn [FOODON:03412612]
+      host_age:
+        examples:
+          - value: 10 days
+      host_disease_stat:
+        examples:
+          - value: downy mildew
+        recommended: true
+      host_genotype:
+        examples:
+          - value: Ts
+      host_height:
+        examples:
+          - value: 1 meter
+      host_phenotype:
+        examples:
+          - value: seed pod; green [PATO:0000320]
+      host_taxid:
+        examples:
+          - value: '4530'
+        string_serialization: '{NCBI taxid}'
+      host_tot_mass:
+        examples:
+          - value: 2500 gram
+      humidity:
+        examples:
+          - value: 30% relative humidity
+      library_prep_kit:
+        examples:
+          - value: Illumina DNA Prep
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+      plant_growth_med:
+        examples:
+          - value: soil
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      soil_conductivity:
+        description: Conductivity of soil at time of sampling.
+      soil_pH:
+        description: The pH of soil at time of sampling.
+      soil_type:
+        string_serialization: '{termLabel} [{termID}]'
+      water_pH:
+        description: pH measurement of the sample, or liquid portion of sample, or aqueous phase of the fluid.
+      wind_direction:
+        examples:
+          - value: 0 degrees; Northwest
+      wind_speed:
+        examples:
+          - value: 1.6 kilometers per hour
+    class_uri: MIXS:0016020
+  FoodFoodProductionFacility:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of food production facilities/factories
+    description: A collection of terms appropriate when collecting samples and performing sequencing of samples  obtained from food production facilities.
+    title: food-food production facility
+    comments:
+      - This extension is intended to work alongside the other food extensions (animals and animal feed, farm environment, and human foods) for capturing contextual data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food(food production facility)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - experimental_factor
+      - nucl_acid_ext
+      - organism_count
+      - samp_store_temp
+      - samp_store_dur
+      - air_temp
+      - room_dim
+      - freq_clean
+      - samp_room_id
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - samp_store_loc
+      - surf_material
+      - indoor_surf
+      - avg_occup
+      - samp_floor
+      - genetic_mod
+      - coll_site_geo_feat
+      - samp_source_mat_cat
+      - samp_type
+      - samp_stor_media
+      - samp_stor_device
+      - food_product_type
+      - IFSAC_category
+      - food_product_qual
+      - food_contact_surf
+      - facility_type
+      - food_trav_mode
+      - food_trav_vehic
+      - samp_transport_dur
+      - samp_transport_temp
+      - samp_collect_method
+      - num_samp_collect
+      - lot_number
+      - hygienic_area
+      - env_monitoring_zone
+      - area_samp_size
+      - samp_surf_moisture
+      - samp_loc_condition
+      - biocide_used
+      - ster_meth_samp_room
+      - enrichment_protocol
+      - cult_target
+      - microb_cult_med
+      - timepoint
+      - bacterial_density
+      - cult_isol_date
+      - cult_result
+      - cult_result_org
+      - subspecf_gen_lin
+      - samp_pooling
+      - samp_purpose
+      - samp_rep_tech
+      - samp_rep_biol
+      - samp_transport_cont
+      - study_design
+      - nucl_acid_ext_kit
+      - library_prep_kit
+      - sequencing_kit
+      - sequencing_location
+      - study_inc_temp
+      - study_inc_dur
+      - study_timecourse
+      - study_tmnt
+      - food_source
+      - food_dis_point
+      - food_dis_point_city
+      - food_origin
+      - food_prod_synonym
+      - food_additive
+      - food_trace_list
+      - part_plant_animal
+      - food_ingredient
+      - spec_intended_cons
+      - HACCP_term
+      - dietary_claim_use
+      - food_allergen_label
+      - food_prod_char
+      - prod_label_claims
+      - food_name_status
+      - food_preserv_proc
+      - food_cooking_proc
+      - food_treat_proc
+      - food_contain_wrap
+      - food_pack_capacity
+      - food_pack_medium
+      - food_prior_contact
+      - food_prod
+      - food_quality_date
+      - repository_name
+      - intended_consumer
+      - food_pack_integrity
+      - misc_param
+    slot_usage:
+      air_temp:
+        examples:
+          - value: 4 degree Celsius
+      avg_occup:
+        examples:
+          - value: '6'
+      food_contact_surf:
+        required: true
+      food_pack_medium:
+        examples:
+          - value: vacuum-packed [FOODON:03480027]
+      food_product_qual:
+        required: true
+      food_product_type:
+        examples:
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        required: true
+      food_source:
+        examples:
+          - value: giant tiger prawn [FOODON:03412612]
+      library_prep_kit:
+        examples:
+          - value: Illumina DNA Prep
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+      pool_dna_extracts:
+        string_serialization: '{boolean},{integer}'
+      samp_collect_device:
+        examples:
+          - value: biopsy, niskin bottle, push core
+      samp_collect_method:
+        examples:
+          - value: environmental swab sampling
+      samp_source_mat_cat:
+        required: true
+      samp_stor_device:
+        required: true
+      samp_stor_media:
+        required: true
+    class_uri: MIXS:0016021
+  FoodHumanFoods:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of foods intended for human consumption.
+    description: A collection of terms appropriate when collecting samples and performing sequencing of samples  obtained from human food products.
+    title: food-human foods
+    comments:
+      - This extension is intended to work alongside the other food extensions (animals and animal feed, farm environment, and food production facilities) for capturing contextual data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food (human foods)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - seq_meth
+      - samp_size
+      - samp_collect_device
+      - experimental_factor
+      - nucl_acid_ext
+      - organism_count
+      - spikein_count
+      - samp_store_temp
+      - samp_store_dur
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - temp
+      - samp_store_loc
+      - genetic_mod
+      - perturbation
+      - coll_site_geo_feat
+      - food_product_type
+      - IFSAC_category
+      - ferm_chem_add
+      - ferm_chem_add_perc
+      - ferm_headspace_oxy
+      - ferm_medium
+      - ferm_pH
+      - ferm_rel_humidity
+      - ferm_temp
+      - ferm_time
+      - ferm_vessel
+      - bacterial_density
+      - cons_food_stor_dur
+      - cons_food_stor_temp
+      - cons_purch_date
+      - cons_qty_purchased
+      - cult_isol_date
+      - cult_result
+      - cult_result_org
+      - cult_target
+      - dietary_claim_use
+      - enrichment_protocol
+      - food_additive
+      - food_allergen_label
+      - food_contact_surf
+      - food_contain_wrap
+      - food_cooking_proc
+      - food_dis_point
+      - food_ingredient
+      - food_name_status
+      - food_origin
+      - food_pack_capacity
+      - food_pack_integrity
+      - food_pack_medium
+      - food_preserv_proc
+      - food_prior_contact
+      - food_prod
+      - food_prod_synonym
+      - food_product_qual
+      - food_quality_date
+      - food_source
+      - food_trace_list
+      - food_trav_mode
+      - food_trav_vehic
+      - food_treat_proc
+      - HACCP_term
+      - intended_consumer
+      - library_prep_kit
+      - lot_number
+      - microb_cult_med
+      - microb_start
+      - microb_start_count
+      - microb_start_inoc
+      - microb_start_prep
+      - microb_start_source
+      - microb_start_taxID
+      - nucl_acid_ext_kit
+      - num_samp_collect
+      - part_plant_animal
+      - repository_name
+      - samp_collect_method
+      - samp_pooling
+      - samp_rep_biol
+      - samp_rep_tech
+      - samp_source_mat_cat
+      - samp_stor_device
+      - samp_stor_media
+      - samp_transport_cont
+      - samp_transport_dur
+      - samp_transport_temp
+      - samp_purpose
+      - sequencing_kit
+      - sequencing_location
+      - serovar_or_serotype
+      - spikein_AMR
+      - spikein_antibiotic
+      - spikein_growth_med
+      - spikein_metal
+      - spikein_org
+      - spikein_serovar
+      - spikein_strain
+      - study_design
+      - study_inc_dur
+      - study_inc_temp
+      - study_timecourse
+      - study_tmnt
+      - timepoint
+      - misc_param
+    slot_usage:
+      food_pack_medium:
+        examples:
+          - value: vacuum-packed[FOODON:03480027]
+      food_product_type:
+        examples:
+          - value: shrimp (peeled, deep-frozen) [FOODON:03317171]
+        required: true
+      food_source:
+        examples:
+          - value: giant tiger prawn [FOODON:03412612]
+      library_prep_kit:
+        examples:
+          - value: Illumina DNA Prep
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 colony forming units per milliliter;qPCR
+      pool_dna_extracts:
+        string_serialization: '{boolean},{integer}'
+      samp_collect_device:
+        examples:
+          - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+      samp_collect_method:
+        examples:
+          - value: environmental swab sampling
+    class_uri: MIXS:0016022
+  HostAssociated:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: elephant fecal matter or cat oral cavity
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a non-human host, to examine the host-associated microbiome or genome.
+    title: host-associated
+    comments:
+      - This is a very broad package, intended to capture many kinds of sequences derived from the bodies of or derived from an organism. Where possible, please use a more specific package. For example, consider using food-animal and animal feed extension for sampling of farm animals reared for consumption. For human stool microbiomes, consider MIxS-human-gut. Incidental associations of environmental material with an organism may also be better served by other packages. For example, nucleic acids derived from soil that was sampled from the hoof of a cow may be better described by terms from the soil extension; however, soil embedded in a wound on a cow’s leg would be best described by terms in this extension
+    aliases:
+      - MIxS-host-associated
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - alt
+      - depth
+      - elev
+      - ances_data
+      - biol_stat
+      - genetic_mod
+      - host_common_name
+      - samp_capt_status
+      - samp_dis_stage
+      - host_taxid
+      - host_subject_id
+      - host_age
+      - host_life_stage
+      - host_sex
+      - host_disease_stat
+      - chem_administration
+      - host_body_habitat
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_length
+      - host_diet
+      - host_last_meal
+      - host_growth_cond
+      - host_substrate
+      - host_fam_rel
+      - host_subspecf_genlin
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_dry_mass
+      - blood_press_diast
+      - blood_press_syst
+      - host_color
+      - host_shape
+      - gravidity
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - host_symbiont
+      - misc_param
+    slot_usage:
+      alt:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      host_age:
+        examples:
+          - value: 10 days
+      host_body_habitat:
+        examples:
+          - value: nasopharynx
+      host_body_site:
+        examples:
+          - value: gill [UBERON:0002535]
+      host_body_temp:
+        examples:
+          - value: 15 degree Celsius
+      host_common_name:
+        examples:
+          - value: human
+      host_diet:
+        examples:
+          - value: herbivore
+      host_disease_stat:
+        examples:
+          - value: rabies [DOID:11260]
+      host_fam_rel:
+        examples:
+          - value: offspring;Mussel25
+      host_genotype:
+        examples:
+          - value: C57BL/6
+      host_height:
+        examples:
+          - value: 0.1 meter
+      host_last_meal:
+        examples:
+          - value: corn feed;P2H
+      host_life_stage:
+        examples:
+          - value: adult
+      host_phenotype:
+        examples:
+          - value: elongated [PATO:0001154]
+      host_subject_id:
+        examples:
+          - value: MPI123
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_taxid:
+        examples:
+          - value: '7955'
+        string_serialization: '{NCBI taxid}'
+      host_tot_mass:
+        examples:
+          - value: 2500 gram
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016002
+  HumanAssociated:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: blood samples or biopsy samples.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a person to examine their human-associated microbiome or genome,  that does not have a specific extension (e.g., skin, gut, vaginal).
+    title: human-associated
+    comments:
+      - For stool samples use MIxS-human-gut extension.
+    aliases:
+      - MIxS-human-associated
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - smoker
+      - host_hiv_stat
+      - drug_usage
+      - host_body_mass_index
+      - diet_last_six_month
+      - weight_loss_3_month
+      - ethnicity
+      - host_occupation
+      - pet_farm_animal
+      - travel_out_six_month
+      - twin_sibling
+      - medic_hist_perform
+      - study_complt_stat
+      - pulmonary_disord
+      - nose_throat_disord
+      - blood_blood_disord
+      - host_pulse
+      - gestation_state
+      - maternal_health_stat
+      - foetal_health_stat
+      - amniotic_fluid_color
+      - kidney_disord
+      - urogenit_tract_disor
+      - urine_collect_meth
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - host_symbiont
+      - samp_store_loc
+      - misc_param
+    slot_usage:
+      host_age:
+        examples:
+          - value: 30 years
+      host_body_site:
+        examples:
+          - value: Lung parenchyma [fma27360]
+      host_body_temp:
+        examples:
+          - value: 36.5 degree Celsius
+      host_diet:
+        examples:
+          - value: high-fat
+      host_disease_stat:
+        examples:
+          - value: measles [DOID:8622]
+      host_fam_rel:
+        examples:
+          - value: mother;ID298
+      host_genotype:
+        examples:
+          - value: ST1
+      host_height:
+        examples:
+          - value: 1.75 meter
+      host_last_meal:
+        examples:
+          - value: french fries;P5H30M
+      host_phenotype:
+        examples:
+          - value: Tinnitus [HP:0000360]
+      host_subject_id:
+        examples:
+          - value: MPI123
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_tot_mass:
+        examples:
+          - value: 65 kilogram
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016003
+  HumanGut:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: human stool or fecal samples, or samples collected directly from the gut.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a person to examine their gut-associated microbiome.
+    title: human-gut
+    aliases:
+      - MIxS-human-gut
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - gastrointest_disord
+      - liver_disord
+      - special_diet
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - samp_store_dur
+      - host_symbiont
+      - samp_store_loc
+      - misc_param
+    slot_usage:
+      host_age:
+        examples:
+          - value: 30 years
+      host_body_site:
+        examples:
+          - value: Wall of gut [fma45653]
+      host_body_temp:
+        examples:
+          - value: 36.5 degree Celsius
+      host_diet:
+        examples:
+          - value: high-fat
+      host_disease_stat:
+        examples:
+          - value: measles [DOID:8622]
+      host_fam_rel:
+        examples:
+          - value: mother;ID298
+      host_genotype:
+        examples:
+          - value: ST1
+      host_height:
+        examples:
+          - value: 1.75 meter
+      host_last_meal:
+        examples:
+          - value: french fries;P5H30M
+      host_phenotype:
+        examples:
+          - value: Tinnitus [HP:0000360]
+      host_subject_id:
+        examples:
+          - value: MPI123
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_tot_mass:
+        examples:
+          - value: 65 kilogram
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016004
+  HumanOral:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: mouth swab sampling, dental microbiome samples, microbiome of oral swabs, nasal, mouth, throat, teeth, tongue microbiome studies
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a person to examine their oral-associated microbiome.
+    title: human-oral
+    aliases:
+      - MIxS-human-oral
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - nose_mouth_teeth_throat_disord
+      - time_last_toothbrush
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - host_symbiont
+      - samp_store_loc
+      - misc_param
+    slot_usage:
+      host_age:
+        examples:
+          - value: 30 years
+      host_body_site:
+        examples:
+          - value: Epithelium of tongue [fma284658]
+      host_body_temp:
+        examples:
+          - value: 36.5 degree Celsius
+      host_diet:
+        examples:
+          - value: high-fat
+      host_disease_stat:
+        examples:
+          - value: measles [DOID:8622]
+      host_fam_rel:
+        examples:
+          - value: mother;ID298
+      host_genotype:
+        examples:
+          - value: ST1
+      host_height:
+        examples:
+          - value: 1.75 meter
+      host_last_meal:
+        examples:
+          - value: french fries;P5H30M
+      host_phenotype:
+        examples:
+          - value: Tinnitus [HP:0000360]
+      host_subject_id:
+        examples:
+          - value: MPI123
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_tot_mass:
+        examples:
+          - value: 65 kilogram
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016005
+  HumanSkin:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: swab samples taken on a person’s skin surface.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a person to examine their skin-associated microbiome.
+    title: human-skin
+    aliases:
+      - MIxS-human-skin
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - dermatology_disord
+      - time_since_last_wash
+      - dominant_hand
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - host_symbiont
+      - misc_param
+    slot_usage:
+      host_age:
+        examples:
+          - value: 30 years
+      host_body_site:
+        examples:
+          - value: Skin of palm of left hand [fma38303]
+      host_body_temp:
+        examples:
+          - value: 36.5 degree Celsius
+      host_diet:
+        examples:
+          - value: high-fat
+      host_disease_stat:
+        examples:
+          - value: measles [DOID:8622]
+      host_fam_rel:
+        examples:
+          - value: mother;ID298
+      host_genotype:
+        examples:
+          - value: ST1
+      host_height:
+        examples:
+          - value: 1.75 meter
+      host_last_meal:
+        examples:
+          - value: french fries;P5H30M
+      host_phenotype:
+        examples:
+          - value: Tinnitus [HP:0000360]
+      host_subject_id:
+        examples:
+          - value: MPI123
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_tot_mass:
+        examples:
+          - value: 65 kilogram
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016006
+  HumanVaginal:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: vaginal swabbing
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a person to examine their vaginal-associated microbiome.
+    title: human-vaginal
+    aliases:
+      - MIxS-human-vaginal
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - menarche
+      - sexual_act
+      - pregnancy
+      - douche
+      - birth_control
+      - menopause
+      - hrt
+      - hysterectomy
+      - gynecologic_disord
+      - urogenit_disord
+      - host_subject_id
+      - host_age
+      - host_sex
+      - host_disease_stat
+      - ihmc_medication_code
+      - chem_administration
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_diet
+      - host_last_meal
+      - host_fam_rel
+      - host_genotype
+      - host_phenotype
+      - host_body_temp
+      - host_body_mass_index
+      - ethnicity
+      - host_occupation
+      - medic_hist_perform
+      - host_pulse
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_loc
+      - samp_store_dur
+      - host_symbiont
+      - misc_param
+    slot_usage:
+      host_age:
+        examples:
+          - value: 30 years
+      host_body_site:
+        examples:
+          - value: Ectocervix [fma86484]
+      host_body_temp:
+        examples:
+          - value: 36.5 degree Celsius
+      host_diet:
+        examples:
+          - value: high-fat
+      host_disease_stat:
+        examples:
+          - value: measles [DOID:8622]
+      host_fam_rel:
+        examples:
+          - value: mother;ID298
+      host_genotype:
+        examples:
+          - value: ST1
+      host_height:
+        examples:
+          - value: 1.75 meter
+      host_last_meal:
+        examples:
+          - value: french fries;P5H30M
+      host_phenotype:
+        examples:
+          - value: Tinnitus [HP:0000360]
+      host_subject_id:
+        examples:
+          - value: MPI123
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_tot_mass:
+        examples:
+          - value: 65 kilogram
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016007
+  HydrocarbonResourcesCores:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: The microbial characterization of hydrocarbon occurrences, defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon rich formations, such as reservoir cores.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from environments pertaining to hydrocarbon resources, specifically core samples.
+    title: hydrocarbon resources-cores
+    aliases:
+      - MIxS-HCR (hydrocarbon resources-cores)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - hcr
+      - hc_produced
+      - basin
+      - field
+      - reservoir
+      - hcr_temp
+      - tvdss_of_hcr_temp
+      - hcr_pressure
+      - tvdss_of_hcr_press
+      - permeability
+      - porosity
+      - lithology
+      - depos_env
+      - hcr_geol_age
+      - owc_tvdss
+      - hcr_fw_salinity
+      - sulfate_fw
+      - vfa_fw
+      - sr_kerog_type
+      - sr_lithology
+      - sr_dep_env
+      - sr_geol_age
+      - samp_well_name
+      - win
+      - samp_type
+      - samp_subtype
+      - temp
+      - pressure
+      - samp_tvdss
+      - samp_md
+      - elev
+      - oxy_stat_samp
+      - samp_transport_cond
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - samp_vol_we_dna_ext
+      - organism_count
+      - org_count_qpcr_info
+      - ph
+      - salinity
+      - alkalinity
+      - alkalinity_method
+      - sulfate
+      - sulfide
+      - tot_sulfur
+      - nitrate
+      - nitrite
+      - ammonium
+      - tot_nitro
+      - diss_iron
+      - sodium
+      - chloride
+      - potassium
+      - magnesium
+      - calcium
+      - tot_iron
+      - diss_org_carb
+      - diss_inorg_carb
+      - diss_inorg_phosp
+      - tot_phosp
+      - suspend_solids
+      - density
+      - diss_carb_dioxide
+      - diss_oxygen_fluid
+      - vfa
+      - benzene
+      - toluene
+      - ethylbenzene
+      - xylene
+      - api
+      - tan
+      - viscosity
+      - pour_point
+      - saturates_pc
+      - aromatics_pc
+      - resins_pc
+      - asphaltenes_pc
+      - misc_param
+      - additional_info
+    slot_usage:
+      ammonium:
+        recommended: true
+      depos_env:
+        examples:
+          - value: Continental - Alluvial
+      diss_inorg_phosp:
+        recommended: true
+      hcr_temp:
+        required: true
+      nitrate:
+        recommended: true
+      nitrite:
+        recommended: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        recommended: true
+      ph:
+        recommended: true
+      samp_vol_we_dna_ext:
+        recommended: true
+      sulfate:
+        recommended: true
+      sulfate_fw:
+        required: true
+      sulfide:
+        recommended: true
+      temp:
+        required: true
+      vfa_fw:
+        required: true
+    class_uri: MIXS:0016015
+  HydrocarbonResourcesFluidsSwabs:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: The microbial characterization of hydrocarbon occurrences,  defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon resource fluids.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from environments pertaining to hydrocarbon resources, specifically run-off liquids samples and swabs.
+    title: hydrocarbon resources-fluids/swabs
+    aliases:
+      - MIxS-HCR (hydrocarbon resources-fluids/swabs)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - hcr
+      - hc_produced
+      - basin
+      - field
+      - reservoir
+      - hcr_temp
+      - tvdss_of_hcr_temp
+      - hcr_pressure
+      - tvdss_of_hcr_press
+      - lithology
+      - depos_env
+      - hcr_geol_age
+      - hcr_fw_salinity
+      - sulfate_fw
+      - vfa_fw
+      - prod_start_date
+      - prod_rate
+      - water_prod_rate
+      - water_cut
+      - iwf
+      - add_recov_method
+      - iw_bt_date_well
+      - biocide
+      - biocide_admin_method
+      - chem_treatment
+      - chem_treat_method
+      - samp_loc_corr_rate
+      - samp_well_name
+      - win
+      - samp_type
+      - samp_subtype
+      - samp_collect_point
+      - temp
+      - pressure
+      - oxy_stat_samp
+      - samp_preserv
+      - samp_transport_cond
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - samp_vol_we_dna_ext
+      - organism_count
+      - org_count_qpcr_info
+      - ph
+      - salinity
+      - alkalinity
+      - alkalinity_method
+      - sulfate
+      - sulfide
+      - tot_sulfur
+      - nitrate
+      - nitrite
+      - ammonium
+      - tot_nitro
+      - diss_iron
+      - sodium
+      - chloride
+      - potassium
+      - magnesium
+      - calcium
+      - tot_iron
+      - diss_org_carb
+      - diss_inorg_carb
+      - diss_inorg_phosp
+      - tot_phosp
+      - suspend_solids
+      - density
+      - diss_carb_dioxide
+      - diss_oxygen_fluid
+      - vfa
+      - benzene
+      - toluene
+      - ethylbenzene
+      - xylene
+      - api
+      - tan
+      - viscosity
+      - pour_point
+      - saturates_pc
+      - aromatics_pc
+      - resins_pc
+      - asphaltenes_pc
+      - misc_param
+      - additional_info
+    slot_usage:
+      ammonium:
+        recommended: true
+      depos_env:
+        examples:
+          - value: Marine - Reef
+      diss_inorg_phosp:
+        recommended: true
+      hcr_temp:
+        recommended: true
+      nitrate:
+        required: true
+      nitrite:
+        recommended: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+        recommended: true
+      ph:
+        recommended: true
+      samp_vol_we_dna_ext:
+        recommended: true
+      sulfate:
+        required: true
+      sulfate_fw:
+        recommended: true
+      sulfide:
+        required: true
+      temp:
+        required: true
+      vfa_fw:
+        recommended: true
+    class_uri: MIXS:0016016
+  MicrobialMatBiofilm:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: samples from microbial mats at cold seeps
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from biofilm environments including microbial mats.
+    title: microbial mat/biofilm
+    aliases:
+      - MIxS-microbial mat/biofilm
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - alkalinity
+      - alkyl_diethers
+      - aminopept_act
+      - ammonium
+      - bacteria_carb_prod
+      - biomass
+      - bishomohopanol
+      - bromide
+      - calcium
+      - carb_nitro_ratio
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_org_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - glucosidase_act
+      - magnesium
+      - mean_frict_vel
+      - mean_peak_frict_vel
+      - methane
+      - misc_param
+      - n_alkanes
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - part_org_carb
+      - perturbation
+      - petroleum_hydrocarb
+      - phaeopigments
+      - phosphate
+      - phosplipid_fatt_acid
+      - potassium
+      - pressure
+      - redox_potential
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - silicate
+      - sodium
+      - sulfate
+      - sulfide
+      - temp
+      - tot_carb
+      - tot_nitro_content
+      - tot_org_carb
+      - turbidity
+      - water_content
+    slot_usage:
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      methane:
+        examples:
+          - value: 0.15 micromole per liter
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+      water_content:
+        string_serialization: '{float} {unit}'
+    class_uri: MIXS:0016008
+  MiscellaneousNaturalOrArtificialEnvironment:
+    description: A collection of generic terms appropriate when collecting and sequencing samples  obtained from environments, where there is no specific extension already available.
+    title: miscellaneous natural or artificial environment
+    aliases:
+      - MIxS-miscellaneous natural or artificial environment
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - alt
+      - depth
+      - elev
+      - alkalinity
+      - ammonium
+      - biomass
+      - bromide
+      - calcium
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - density
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - misc_param
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - perturbation
+      - phosphate
+      - phosplipid_fatt_acid
+      - potassium
+      - pressure
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - silicate
+      - sodium
+      - sulfate
+      - sulfide
+      - temp
+      - water_current
+    slot_usage:
+      alt:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016009
+  PlantAssociated:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: plant surface swabs, root soil or rhizosphere, cultivated plants, plant phenotyping
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from a plant to examine it’s plant-associated microbiome.
+    title: plant-associated
+    aliases:
+      - MIxS-plant-associated
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - air_temp_regm
+      - ances_data
+      - antibiotic_regm
+      - biol_stat
+      - biotic_regm
+      - chem_administration
+      - chem_mutagen
+      - climate_environment
+      - cult_root_med
+      - fertilizer_regm
+      - fungicide_regm
+      - gaseous_environment
+      - genetic_mod
+      - gravity
+      - growth_facil
+      - growth_habit
+      - growth_hormone_regm
+      - herbicide_regm
+      - host_age
+      - host_common_name
+      - host_disease_stat
+      - host_dry_mass
+      - host_genotype
+      - host_height
+      - host_subspecf_genlin
+      - host_length
+      - host_life_stage
+      - host_phenotype
+      - host_taxid
+      - host_tot_mass
+      - host_wet_mass
+      - humidity_regm
+      - light_regm
+      - mechanical_damage
+      - mineral_nutr_regm
+      - misc_param
+      - non_min_nutr_regm
+      - organism_count
+      - oxy_stat_samp
+      - ph_regm
+      - perturbation
+      - pesticide_regm
+      - plant_growth_med
+      - plant_product
+      - plant_sex
+      - plant_struc
+      - radiation_regm
+      - rainfall_regm
+      - root_cond
+      - root_med_carbon
+      - root_med_macronutr
+      - root_med_micronutr
+      - root_med_suppl
+      - root_med_ph
+      - root_med_regl
+      - root_med_solid
+      - salt_regm
+      - samp_capt_status
+      - samp_dis_stage
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - season_environment
+      - standing_water_regm
+      - temp
+      - tiss_cult_growth_med
+      - water_temp_regm
+      - watering_regm
+      - host_symbiont
+    slot_usage:
+      climate_environment:
+        string_serialization: '{text};{Rn/start_time/end_time/duration}'
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      fungicide_regm:
+        string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+      gaseous_environment:
+        string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+      herbicide_regm:
+        string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+      host_age:
+        examples:
+          - value: 10 days
+      host_common_name:
+        examples:
+          - value: rice
+      host_disease_stat:
+        examples:
+          - value: downy mildew
+      host_genotype:
+        examples:
+          - value: Ts
+      host_height:
+        examples:
+          - value: 1 meter
+      host_life_stage:
+        examples:
+          - value: adult
+      host_phenotype:
+        examples:
+          - value: seed pod; green [PATO:0000320]
+      host_symbiont:
+        examples:
+          - value: flukeworms
+      host_taxid:
+        examples:
+          - value: '4530'
+        string_serialization: '{NCBI taxid}'
+      host_tot_mass:
+        examples:
+          - value: 2500 gram
+      non_min_nutr_regm:
+        string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+      pesticide_regm:
+        string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+      ph_regm:
+        string_serialization: '{float};{Rn/start_time/end_time/duration}'
+      plant_growth_med:
+        examples:
+          - value: hydroponic plant culture media [EO:0007067]
+      salt_regm:
+        string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
+      season_environment:
+        string_serialization: '{text};{Rn/start_time/end_time/duration}'
+      standing_water_regm:
+        string_serialization: '{text};{Rn/start_time/end_time/duration}'
+      water_temp_regm:
+        string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
+      watering_regm:
+        string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
+    class_uri: MIXS:0016010
+  Sediment:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: river bed or sea floor.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from the sedimentary area of aquatic environments.
+    title: sediment
+    comments:
+      - Sedimentary layers in terrestrial environments will probably be better served by the soil extension.
+    aliases:
+      - MIxS-sediment
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - alkalinity
+      - alkyl_diethers
+      - aminopept_act
+      - ammonium
+      - bacteria_carb_prod
+      - biomass
+      - bishomohopanol
+      - bromide
+      - calcium
+      - carb_nitro_ratio
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - density
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_org_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - glucosidase_act
+      - magnesium
+      - mean_frict_vel
+      - mean_peak_frict_vel
+      - methane
+      - misc_param
+      - n_alkanes
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - particle_class
+      - part_org_carb
+      - perturbation
+      - petroleum_hydrocarb
+      - phaeopigments
+      - phosphate
+      - phosplipid_fatt_acid
+      - porosity
+      - potassium
+      - pressure
+      - redox_potential
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - sediment_type
+      - silicate
+      - sodium
+      - sulfate
+      - sulfide
+      - temp
+      - tidal_stage
+      - tot_carb
+      - tot_depth_water_col
+      - tot_nitro_content
+      - tot_org_carb
+      - turbidity
+      - water_content
+    slot_usage:
+      depth:
+        examples:
+          - value: 10 meter
+        required: true
+      elev:
+        recommended: true
+      methane:
+        examples:
+          - value: 0.15 micromole per liter
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+      water_content:
+        string_serialization: '{float} {unit}'
+    class_uri: MIXS:0016011
+  Soil:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: soil collection, island microbiome sampling, farm land or forest floor.
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from the uppermost layer of Earth's crust, contributed by the Terragenome Consortium.
+    title: soil
+    see_also:
+      - https://www.fao.org/agriculture/crops/thematic-sitemap/theme/spi/soil-biodiversity/research-into-soil-biodiversity/the-terragenome-project/en/
+    aliases:
+      - MIxS-soil
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - cur_land_use
+      - cur_vegetation
+      - cur_vegetation_meth
+      - previous_land_use
+      - prev_land_use_meth
+      - crop_rotation
+      - agrochem_addition
+      - tillage
+      - fire
+      - flooding
+      - extreme_event
+      - soil_horizon
+      - horizon_meth
+      - sieving
+      - water_content
+      - water_cont_soil_meth
+      - samp_vol_we_dna_ext
+      - pool_dna_extracts
+      - store_cond
+      - link_climate_info
+      - annual_temp
+      - season_temp
+      - annual_precpt
+      - season_precpt
+      - link_class_info
+      - fao_class
+      - local_class
+      - local_class_meth
+      - org_nitro
+      - temp
+      - soil_type
+      - soil_type_meth
+      - slope_gradient
+      - slope_aspect
+      - profile_position
+      - drainage_class
+      - soil_texture
+      - soil_texture_meth
+      - ph
+      - ph_meth
+      - org_matter
+      - tot_org_carb
+      - tot_org_c_meth
+      - tot_nitro_content
+      - tot_nitro_cont_meth
+      - microbial_biomass
+      - micro_biomass_meth
+      - link_addit_analys
+      - heavy_metals
+      - heavy_metals_meth
+      - al_sat
+      - al_sat_meth
+      - misc_param
+    slot_usage:
+      crop_rotation:
+        string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
+      depth:
+        examples:
+          - value: 10 meter
+        required: true
+      elev:
+        required: true
+      heavy_metals_meth:
+        string_serialization: '{PMID}|{DOI}|{URL}'
+      pool_dna_extracts:
+        string_serialization: '{boolean};{integer}'
+      soil_type:
+        string_serialization: '{termLabel} [{termID}]'
+      water_content:
+        string_serialization: '{float}'
+    class_uri: MIXS:0016012
+  SymbiontAssociated:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: the microbiome sequence of a flea sampled from a farm animal
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from an organism that lives in close association with any other organism(s).
+    title: symbiont-associated
+    aliases:
+      - MIxS-SA (symbiont-associated)
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - lat_lon
+      - geo_loc_name
+      - collection_date
+      - alt
+      - depth
+      - elev
+      - host_subject_id
+      - host_common_name
+      - host_taxid
+      - source_mat_id
+      - host_dependence
+      - type_of_symbiosis
+      - sym_life_cycle_type
+      - host_life_stage
+      - host_age
+      - urobiom_sex
+      - mode_transmission
+      - route_transmission
+      - host_body_habitat
+      - host_body_site
+      - host_body_product
+      - host_tot_mass
+      - host_height
+      - host_length
+      - host_growth_cond
+      - host_substrate
+      - host_fam_rel
+      - host_infra_spec_name
+      - host_infra_spec_rank
+      - host_genotype
+      - host_phenotype
+      - host_dry_mass
+      - host_color
+      - host_shape
+      - gravidity
+      - host_number
+      - host_symbiont
+      - host_specificity
+      - symbiont_host_role
+      - host_cellular_loc
+      - association_duration
+      - host_of_host_coinf
+      - host_of_host_name
+      - host_of_host_env_loc
+      - host_of_host_env_med
+      - host_of_host_taxid
+      - host_of_host_sub_id
+      - host_of_host_disease
+      - host_of_host_fam_rel
+      - host_of_host_infname
+      - host_of_host_infrank
+      - host_of_host_geno
+      - host_of_host_pheno
+      - host_of_host_gravid
+      - host_of_host_totmass
+      - chem_administration
+      - perturbation
+      - salinity
+      - oxy_stat_samp
+      - temp
+      - organism_count
+      - samp_vol_we_dna_ext
+      - samp_store_temp
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_sol
+      - misc_param
+    slot_usage:
+      alt:
+        recommended: true
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      elev:
+        recommended: true
+      host_body_habitat:
+        examples:
+          - value: anterior end of a tapeworm
+      host_body_site:
+        examples:
+          - value: scolex [UBERON:0015119]
+      host_common_name:
+        examples:
+          - value: trematode
+      host_fam_rel:
+        examples:
+          - value: clone;P15
+      host_life_stage:
+        examples:
+          - value: redia
+        required: true
+      host_phenotype:
+        examples:
+          - value: soldier
+      host_subject_id:
+        examples:
+          - value: P14
+      host_symbiont:
+        examples:
+          - value: Paragordius varius
+      host_taxid:
+        examples:
+          - value: '395013'
+        string_serialization: '{integer}'
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016023
+  WastewaterSludge:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: sewerage or industrial wastewater
+    description: A collection of terms appropriate when collecting samples and sequencing samples  obtained from any solid, semisolid or liquid waste.
+    title: wastewater/sludge
+    aliases:
+      - MIxS-wastewater/sludge
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - depth
+      - alkalinity
+      - biochem_oxygen_dem
+      - chem_administration
+      - chem_oxygen_dem
+      - efficiency_percent
+      - emulsions
+      - gaseous_substances
+      - indust_eff_percent
+      - inorg_particles
+      - misc_param
+      - nitrate
+      - org_particles
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - perturbation
+      - phosphate
+      - pre_treatment
+      - primary_treatment
+      - reactor_type
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - secondary_treatment
+      - sewage_type
+      - sludge_retent_time
+      - sodium
+      - soluble_inorg_mat
+      - soluble_org_mat
+      - suspend_solids
+      - temp
+      - tertiary_treatment
+      - tot_nitro
+      - tot_phosphate
+      - wastewater_type
+    slot_usage:
+      depth:
+        examples:
+          - value: 10 meter
+        recommended: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016013
+  Water:
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: sea or river water, global ocean sampling day
+    description: A collection of terms appropriate when collecting samples and sequencing water samples  obtained from any aquatic environment.
+    title: water
+    see_also:
+      - https://www.vliz.be/projects/assembleplus/research/ocean-sampling-day-2018.html
+    aliases:
+      - MIxS-water
+    is_a: Extension
+    slots:
+      - samp_name
+      - project_name
+      - depth
+      - elev
+      - alkalinity
+      - alkalinity_method
+      - alkyl_diethers
+      - aminopept_act
+      - ammonium
+      - atmospheric_data
+      - bacteria_carb_prod
+      - bac_prod
+      - bac_resp
+      - biomass
+      - bishomohopanol
+      - bromide
+      - calcium
+      - carb_nitro_ratio
+      - chem_administration
+      - chloride
+      - chlorophyll
+      - conduc
+      - density
+      - diether_lipids
+      - diss_carb_dioxide
+      - diss_hydrogen
+      - diss_inorg_carb
+      - diss_inorg_nitro
+      - diss_inorg_phosp
+      - diss_org_carb
+      - diss_org_nitro
+      - diss_oxygen
+      - down_par
+      - fluor
+      - glucosidase_act
+      - light_intensity
+      - magnesium
+      - mean_frict_vel
+      - mean_peak_frict_vel
+      - misc_param
+      - n_alkanes
+      - nitrate
+      - nitrite
+      - nitro
+      - org_carb
+      - org_matter
+      - org_nitro
+      - organism_count
+      - oxy_stat_samp
+      - ph
+      - part_org_carb
+      - part_org_nitro
+      - perturbation
+      - petroleum_hydrocarb
+      - phaeopigments
+      - phosphate
+      - phosplipid_fatt_acid
+      - photon_flux
+      - potassium
+      - pressure
+      - primary_prod
+      - redox_potential
+      - salinity
+      - samp_store_dur
+      - samp_store_loc
+      - samp_store_temp
+      - samp_vol_we_dna_ext
+      - silicate
+      - size_frac_low
+      - size_frac_up
+      - sodium
+      - soluble_react_phosp
+      - sulfate
+      - sulfide
+      - suspend_part_matter
+      - temp
+      - tidal_stage
+      - tot_depth_water_col
+      - tot_diss_nitro
+      - tot_inorg_nitro
+      - tot_nitro
+      - tot_part_carb
+      - tot_phosp
+      - turbidity
+      - water_current
+    slot_usage:
+      depth:
+        examples:
+          - value: 10 meter
+        required: true
+      elev:
+        recommended: true
+      organism_count:
+        examples:
+          - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+    class_uri: MIXS:0016014
+  Checklist:
+    description: A collection of metadata terms (slots) to minimally describe the sampling and sequencing method of a specimen used to generate a nucleotide sequence.
+  Extension:
+    description: A collection of recommended metadata terms (slots) developed by community experts, describing the specific context under which a sample was collected.
+    aliases:
+      - EnvironmentalPackage
+  MixsCompliantData:
+    description: A collection of Data that comply with some combination of a MIxS checklist and environmental extension
+    title: MIxS compliant data
+    slots:
+      - migs_ba_data
+      - agriculture_data
+      - migs_ba_agriculture_data
+      - air_data
+      - migs_ba_air_data
+      - built_environment_data
+      - migs_ba_built_environment_data
+      - food_animal_and_animal_feed_data
+      - migs_ba_food_animal_and_animal_feed_data
+      - food_farm_environment_data
+      - migs_ba_food_farm_environment_data
+      - food_food_production_facility_data
+      - migs_ba_food_food_production_facility_data
+      - food_human_foods_data
+      - migs_ba_food_human_foods_data
+      - host_associated_data
+      - migs_ba_host_associated_data
+      - human_associated_data
+      - migs_ba_human_associated_data
+      - human_gut_data
+      - migs_ba_human_gut_data
+      - human_oral_data
+      - migs_ba_human_oral_data
+      - human_skin_data
+      - migs_ba_human_skin_data
+      - human_vaginal_data
+      - migs_ba_human_vaginal_data
+      - hydrocarbon_resources_cores_data
+      - migs_ba_hydrocarbon_resources_cores_data
+      - hydrocarbon_resources_fluids_swabs_data
+      - migs_ba_hydrocarbon_resources_fluids_swabs_data
+      - microbial_mat_biofilm_data
+      - migs_ba_microbial_mat_biofilm_data
+      - miscellaneous_natural_or_artificial_environment_data
+      - migs_ba_miscellaneous_natural_or_artificial_environment_data
+      - plant_associated_data
+      - migs_ba_plant_associated_data
+      - sediment_data
+      - migs_ba_sediment_data
+      - soil_data
+      - migs_ba_soil_data
+      - symbiont_associated_data
+      - migs_ba_symbiont_associated_data
+      - wastewater_sludge_data
+      - migs_ba_wastewater_sludge_data
+      - water_data
+      - migs_ba_water_data
+      - migs_eu_data
+      - migs_eu_agriculture_data
+      - migs_eu_air_data
+      - migs_eu_built_environment_data
+      - migs_eu_food_animal_and_animal_feed_data
+      - migs_eu_food_farm_environment_data
+      - migs_eu_food_food_production_facility_data
+      - migs_eu_food_human_foods_data
+      - migs_eu_host_associated_data
+      - migs_eu_human_associated_data
+      - migs_eu_human_gut_data
+      - migs_eu_human_oral_data
+      - migs_eu_human_skin_data
+      - migs_eu_human_vaginal_data
+      - migs_eu_hydrocarbon_resources_cores_data
+      - migs_eu_hydrocarbon_resources_fluids_swabs_data
+      - migs_eu_microbial_mat_biofilm_data
+      - migs_eu_miscellaneous_natural_or_artificial_environment_data
+      - migs_eu_plant_associated_data
+      - migs_eu_sediment_data
+      - migs_eu_soil_data
+      - migs_eu_symbiont_associated_data
+      - migs_eu_wastewater_sludge_data
+      - migs_eu_water_data
+      - migs_org_data
+      - migs_org_agriculture_data
+      - migs_org_air_data
+      - migs_org_built_environment_data
+      - migs_org_food_animal_and_animal_feed_data
+      - migs_org_food_farm_environment_data
+      - migs_org_food_food_production_facility_data
+      - migs_org_food_human_foods_data
+      - migs_org_host_associated_data
+      - migs_org_human_associated_data
+      - migs_org_human_gut_data
+      - migs_org_human_oral_data
+      - migs_org_human_skin_data
+      - migs_org_human_vaginal_data
+      - migs_org_hydrocarbon_resources_cores_data
+      - migs_org_hydrocarbon_resources_fluids_swabs_data
+      - migs_org_microbial_mat_biofilm_data
+      - migs_org_miscellaneous_natural_or_artificial_environment_data
+      - migs_org_plant_associated_data
+      - migs_org_sediment_data
+      - migs_org_soil_data
+      - migs_org_symbiont_associated_data
+      - migs_org_wastewater_sludge_data
+      - migs_org_water_data
+      - migs_pl_data
+      - migs_pl_agriculture_data
+      - migs_pl_air_data
+      - migs_pl_built_environment_data
+      - migs_pl_food_animal_and_animal_feed_data
+      - migs_pl_food_farm_environment_data
+      - migs_pl_food_food_production_facility_data
+      - migs_pl_food_human_foods_data
+      - migs_pl_host_associated_data
+      - migs_pl_human_associated_data
+      - migs_pl_human_gut_data
+      - migs_pl_human_oral_data
+      - migs_pl_human_skin_data
+      - migs_pl_human_vaginal_data
+      - migs_pl_hydrocarbon_resources_cores_data
+      - migs_pl_hydrocarbon_resources_fluids_swabs_data
+      - migs_pl_microbial_mat_biofilm_data
+      - migs_pl_miscellaneous_natural_or_artificial_environment_data
+      - migs_pl_plant_associated_data
+      - migs_pl_sediment_data
+      - migs_pl_soil_data
+      - migs_pl_symbiont_associated_data
+      - migs_pl_wastewater_sludge_data
+      - migs_pl_water_data
+      - migs_vi_data
+      - migs_vi_agriculture_data
+      - migs_vi_air_data
+      - migs_vi_built_environment_data
+      - migs_vi_food_animal_and_animal_feed_data
+      - migs_vi_food_farm_environment_data
+      - migs_vi_food_food_production_facility_data
+      - migs_vi_food_human_foods_data
+      - migs_vi_host_associated_data
+      - migs_vi_human_associated_data
+      - migs_vi_human_gut_data
+      - migs_vi_human_oral_data
+      - migs_vi_human_skin_data
+      - migs_vi_human_vaginal_data
+      - migs_vi_hydrocarbon_resources_cores_data
+      - migs_vi_hydrocarbon_resources_fluids_swabs_data
+      - migs_vi_microbial_mat_biofilm_data
+      - migs_vi_miscellaneous_natural_or_artificial_environment_data
+      - migs_vi_plant_associated_data
+      - migs_vi_sediment_data
+      - migs_vi_soil_data
+      - migs_vi_symbiont_associated_data
+      - migs_vi_wastewater_sludge_data
+      - migs_vi_water_data
+      - mimag_data
+      - mimag_agriculture_data
+      - mimag_air_data
+      - mimag_built_environment_data
+      - mimag_food_animal_and_animal_feed_data
+      - mimag_food_farm_environment_data
+      - mimag_food_food_production_facility_data
+      - mimag_food_human_foods_data
+      - mimag_host_associated_data
+      - mimag_human_associated_data
+      - mimag_human_gut_data
+      - mimag_human_oral_data
+      - mimag_human_skin_data
+      - mimag_human_vaginal_data
+      - mimag_hydrocarbon_resources_cores_data
+      - mimag_hydrocarbon_resources_fluids_swabs_data
+      - mimag_microbial_mat_biofilm_data
+      - mimag_miscellaneous_natural_or_artificial_environment_data
+      - mimag_plant_associated_data
+      - mimag_sediment_data
+      - mimag_soil_data
+      - mimag_symbiont_associated_data
+      - mimag_wastewater_sludge_data
+      - mimag_water_data
+      - mimarks_c_data
+      - mimarks_c_agriculture_data
+      - mimarks_c_air_data
+      - mimarks_c_built_environment_data
+      - mimarks_c_food_animal_and_animal_feed_data
+      - mimarks_c_food_farm_environment_data
+      - mimarks_c_food_food_production_facility_data
+      - mimarks_c_food_human_foods_data
+      - mimarks_c_host_associated_data
+      - mimarks_c_human_associated_data
+      - mimarks_c_human_gut_data
+      - mimarks_c_human_oral_data
+      - mimarks_c_human_skin_data
+      - mimarks_c_human_vaginal_data
+      - mimarks_c_hydrocarbon_resources_cores_data
+      - mimarks_c_hydrocarbon_resources_fluids_swabs_data
+      - mimarks_c_microbial_mat_biofilm_data
+      - mimarks_c_miscellaneous_natural_or_artificial_environment_data
+      - mimarks_c_plant_associated_data
+      - mimarks_c_sediment_data
+      - mimarks_c_soil_data
+      - mimarks_c_symbiont_associated_data
+      - mimarks_c_wastewater_sludge_data
+      - mimarks_c_water_data
+      - mimarks_s_data
+      - mimarks_s_agriculture_data
+      - mimarks_s_air_data
+      - mimarks_s_built_environment_data
+      - mimarks_s_food_animal_and_animal_feed_data
+      - mimarks_s_food_farm_environment_data
+      - mimarks_s_food_food_production_facility_data
+      - mimarks_s_food_human_foods_data
+      - mimarks_s_host_associated_data
+      - mimarks_s_human_associated_data
+      - mimarks_s_human_gut_data
+      - mimarks_s_human_oral_data
+      - mimarks_s_human_skin_data
+      - mimarks_s_human_vaginal_data
+      - mimarks_s_hydrocarbon_resources_cores_data
+      - mimarks_s_hydrocarbon_resources_fluids_swabs_data
+      - mimarks_s_microbial_mat_biofilm_data
+      - mimarks_s_miscellaneous_natural_or_artificial_environment_data
+      - mimarks_s_plant_associated_data
+      - mimarks_s_sediment_data
+      - mimarks_s_soil_data
+      - mimarks_s_symbiont_associated_data
+      - mimarks_s_wastewater_sludge_data
+      - mimarks_s_water_data
+      - mims_data
+      - mims_agriculture_data
+      - mims_air_data
+      - mims_built_environment_data
+      - mims_food_animal_and_animal_feed_data
+      - mims_food_farm_environment_data
+      - mims_food_food_production_facility_data
+      - mims_food_human_foods_data
+      - mims_host_associated_data
+      - mims_human_associated_data
+      - mims_human_gut_data
+      - mims_human_oral_data
+      - mims_human_skin_data
+      - mims_human_vaginal_data
+      - mims_hydrocarbon_resources_cores_data
+      - mims_hydrocarbon_resources_fluids_swabs_data
+      - mims_microbial_mat_biofilm_data
+      - mims_miscellaneous_natural_or_artificial_environment_data
+      - mims_plant_associated_data
+      - mims_sediment_data
+      - mims_soil_data
+      - mims_symbiont_associated_data
+      - mims_wastewater_sludge_data
+      - mims_water_data
+      - misag_data
+      - misag_agriculture_data
+      - misag_air_data
+      - misag_built_environment_data
+      - misag_food_animal_and_animal_feed_data
+      - misag_food_farm_environment_data
+      - misag_food_food_production_facility_data
+      - misag_food_human_foods_data
+      - misag_host_associated_data
+      - misag_human_associated_data
+      - misag_human_gut_data
+      - misag_human_oral_data
+      - misag_human_skin_data
+      - misag_human_vaginal_data
+      - misag_hydrocarbon_resources_cores_data
+      - misag_hydrocarbon_resources_fluids_swabs_data
+      - misag_microbial_mat_biofilm_data
+      - misag_miscellaneous_natural_or_artificial_environment_data
+      - misag_plant_associated_data
+      - misag_sediment_data
+      - misag_soil_data
+      - misag_symbiont_associated_data
+      - misag_wastewater_sludge_data
+      - misag_water_data
+      - miuvig_data
+      - miuvig_agriculture_data
+      - miuvig_air_data
+      - miuvig_built_environment_data
+      - miuvig_food_animal_and_animal_feed_data
+      - miuvig_food_farm_environment_data
+      - miuvig_food_food_production_facility_data
+      - miuvig_food_human_foods_data
+      - miuvig_host_associated_data
+      - miuvig_human_associated_data
+      - miuvig_human_gut_data
+      - miuvig_human_oral_data
+      - miuvig_human_skin_data
+      - miuvig_human_vaginal_data
+      - miuvig_hydrocarbon_resources_cores_data
+      - miuvig_hydrocarbon_resources_fluids_swabs_data
+      - miuvig_microbial_mat_biofilm_data
+      - miuvig_miscellaneous_natural_or_artificial_environment_data
+      - miuvig_plant_associated_data
+      - miuvig_sediment_data
+      - miuvig_soil_data
+      - miuvig_symbiont_associated_data
+      - miuvig_wastewater_sludge_data
+      - miuvig_water_data
+    tree_root: true
+  MigsBaAgriculture:
+    description: MIxS Data that comply with the MigsBa checklist and the Agriculture Extension
+    title: MigsBa combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016018
+  MigsBaAir:
+    description: MIxS Data that comply with the MigsBa checklist and the Air Extension
+    title: MigsBa combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016000
+  MigsBaBuiltEnvironment:
+    description: MIxS Data that comply with the MigsBa checklist and the BuiltEnvironment Extension
+    title: MigsBa combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016001
+  MigsBaFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MigsBa checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MigsBa combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016019
+  MigsBaFoodFarmEnvironment:
+    description: MIxS Data that comply with the MigsBa checklist and the FoodFarmEnvironment Extension
+    title: MigsBa combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016020
+  MigsBaFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MigsBa checklist and the FoodFoodProductionFacility Extension
+    title: MigsBa combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016021
+  MigsBaFoodHumanFoods:
+    description: MIxS Data that comply with the MigsBa checklist and the FoodHumanFoods Extension
+    title: MigsBa combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016022
+  MigsBaHostAssociated:
+    description: MIxS Data that comply with the MigsBa checklist and the HostAssociated Extension
+    title: MigsBa combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016002
+  MigsBaHumanAssociated:
+    description: MIxS Data that comply with the MigsBa checklist and the HumanAssociated Extension
+    title: MigsBa combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016003
+  MigsBaHumanGut:
+    description: MIxS Data that comply with the MigsBa checklist and the HumanGut Extension
+    title: MigsBa combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016004
+  MigsBaHumanOral:
+    description: MIxS Data that comply with the MigsBa checklist and the HumanOral Extension
+    title: MigsBa combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016005
+  MigsBaHumanSkin:
+    description: MIxS Data that comply with the MigsBa checklist and the HumanSkin Extension
+    title: MigsBa combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016006
+  MigsBaHumanVaginal:
+    description: MIxS Data that comply with the MigsBa checklist and the HumanVaginal Extension
+    title: MigsBa combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016007
+  MigsBaHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MigsBa checklist and the HydrocarbonResourcesCores Extension
+    title: MigsBa combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016015
+  MigsBaHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MigsBa checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MigsBa combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016016
+  MigsBaMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MigsBa checklist and the MicrobialMatBiofilm Extension
+    title: MigsBa combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016008
+  MigsBaMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MigsBa checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MigsBa combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016009
+  MigsBaPlantAssociated:
+    description: MIxS Data that comply with the MigsBa checklist and the PlantAssociated Extension
+    title: MigsBa combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016010
+  MigsBaSediment:
+    description: MIxS Data that comply with the MigsBa checklist and the Sediment Extension
+    title: MigsBa combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016011
+  MigsBaSoil:
+    description: MIxS Data that comply with the MigsBa checklist and the Soil Extension
+    title: MigsBa combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016012
+  MigsBaSymbiontAssociated:
+    description: MIxS Data that comply with the MigsBa checklist and the SymbiontAssociated Extension
+    title: MigsBa combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016023
+  MigsBaWastewaterSludge:
+    description: MIxS Data that comply with the MigsBa checklist and the WastewaterSludge Extension
+    title: MigsBa combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016013
+  MigsBaWater:
+    description: MIxS Data that comply with the MigsBa checklist and the Water Extension
+    title: MigsBa combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MigsBa
+    class_uri: MIXS:0010003_0016014
+  MigsEuAgriculture:
+    description: MIxS Data that comply with the MigsEu checklist and the Agriculture Extension
+    title: MigsEu combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016018
+  MigsEuAir:
+    description: MIxS Data that comply with the MigsEu checklist and the Air Extension
+    title: MigsEu combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016000
+  MigsEuBuiltEnvironment:
+    description: MIxS Data that comply with the MigsEu checklist and the BuiltEnvironment Extension
+    title: MigsEu combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016001
+  MigsEuFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MigsEu checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MigsEu combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016019
+  MigsEuFoodFarmEnvironment:
+    description: MIxS Data that comply with the MigsEu checklist and the FoodFarmEnvironment Extension
+    title: MigsEu combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016020
+  MigsEuFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MigsEu checklist and the FoodFoodProductionFacility Extension
+    title: MigsEu combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016021
+  MigsEuFoodHumanFoods:
+    description: MIxS Data that comply with the MigsEu checklist and the FoodHumanFoods Extension
+    title: MigsEu combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016022
+  MigsEuHostAssociated:
+    description: MIxS Data that comply with the MigsEu checklist and the HostAssociated Extension
+    title: MigsEu combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016002
+  MigsEuHumanAssociated:
+    description: MIxS Data that comply with the MigsEu checklist and the HumanAssociated Extension
+    title: MigsEu combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016003
+  MigsEuHumanGut:
+    description: MIxS Data that comply with the MigsEu checklist and the HumanGut Extension
+    title: MigsEu combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016004
+  MigsEuHumanOral:
+    description: MIxS Data that comply with the MigsEu checklist and the HumanOral Extension
+    title: MigsEu combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016005
+  MigsEuHumanSkin:
+    description: MIxS Data that comply with the MigsEu checklist and the HumanSkin Extension
+    title: MigsEu combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016006
+  MigsEuHumanVaginal:
+    description: MIxS Data that comply with the MigsEu checklist and the HumanVaginal Extension
+    title: MigsEu combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016007
+  MigsEuHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MigsEu checklist and the HydrocarbonResourcesCores Extension
+    title: MigsEu combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016015
+  MigsEuHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MigsEu checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MigsEu combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016016
+  MigsEuMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MigsEu checklist and the MicrobialMatBiofilm Extension
+    title: MigsEu combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016008
+  MigsEuMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MigsEu checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MigsEu combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016009
+  MigsEuPlantAssociated:
+    description: MIxS Data that comply with the MigsEu checklist and the PlantAssociated Extension
+    title: MigsEu combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016010
+  MigsEuSediment:
+    description: MIxS Data that comply with the MigsEu checklist and the Sediment Extension
+    title: MigsEu combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016011
+  MigsEuSoil:
+    description: MIxS Data that comply with the MigsEu checklist and the Soil Extension
+    title: MigsEu combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016012
+  MigsEuSymbiontAssociated:
+    description: MIxS Data that comply with the MigsEu checklist and the SymbiontAssociated Extension
+    title: MigsEu combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016023
+  MigsEuWastewaterSludge:
+    description: MIxS Data that comply with the MigsEu checklist and the WastewaterSludge Extension
+    title: MigsEu combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016013
+  MigsEuWater:
+    description: MIxS Data that comply with the MigsEu checklist and the Water Extension
+    title: MigsEu combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MigsEu
+    class_uri: MIXS:0010002_0016014
+  MigsOrgAgriculture:
+    description: MIxS Data that comply with the MigsOrg checklist and the Agriculture Extension
+    title: MigsOrg combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016018
+  MigsOrgAir:
+    description: MIxS Data that comply with the MigsOrg checklist and the Air Extension
+    title: MigsOrg combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016000
+  MigsOrgBuiltEnvironment:
+    description: MIxS Data that comply with the MigsOrg checklist and the BuiltEnvironment Extension
+    title: MigsOrg combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016001
+  MigsOrgFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MigsOrg checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MigsOrg combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016019
+  MigsOrgFoodFarmEnvironment:
+    description: MIxS Data that comply with the MigsOrg checklist and the FoodFarmEnvironment Extension
+    title: MigsOrg combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016020
+  MigsOrgFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MigsOrg checklist and the FoodFoodProductionFacility Extension
+    title: MigsOrg combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016021
+  MigsOrgFoodHumanFoods:
+    description: MIxS Data that comply with the MigsOrg checklist and the FoodHumanFoods Extension
+    title: MigsOrg combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016022
+  MigsOrgHostAssociated:
+    description: MIxS Data that comply with the MigsOrg checklist and the HostAssociated Extension
+    title: MigsOrg combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016002
+  MigsOrgHumanAssociated:
+    description: MIxS Data that comply with the MigsOrg checklist and the HumanAssociated Extension
+    title: MigsOrg combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016003
+  MigsOrgHumanGut:
+    description: MIxS Data that comply with the MigsOrg checklist and the HumanGut Extension
+    title: MigsOrg combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016004
+  MigsOrgHumanOral:
+    description: MIxS Data that comply with the MigsOrg checklist and the HumanOral Extension
+    title: MigsOrg combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016005
+  MigsOrgHumanSkin:
+    description: MIxS Data that comply with the MigsOrg checklist and the HumanSkin Extension
+    title: MigsOrg combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016006
+  MigsOrgHumanVaginal:
+    description: MIxS Data that comply with the MigsOrg checklist and the HumanVaginal Extension
+    title: MigsOrg combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016007
+  MigsOrgHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MigsOrg checklist and the HydrocarbonResourcesCores Extension
+    title: MigsOrg combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016015
+  MigsOrgHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MigsOrg checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MigsOrg combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016016
+  MigsOrgMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MigsOrg checklist and the MicrobialMatBiofilm Extension
+    title: MigsOrg combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016008
+  MigsOrgMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MigsOrg checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MigsOrg combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016009
+  MigsOrgPlantAssociated:
+    description: MIxS Data that comply with the MigsOrg checklist and the PlantAssociated Extension
+    title: MigsOrg combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016010
+  MigsOrgSediment:
+    description: MIxS Data that comply with the MigsOrg checklist and the Sediment Extension
+    title: MigsOrg combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016011
+  MigsOrgSoil:
+    description: MIxS Data that comply with the MigsOrg checklist and the Soil Extension
+    title: MigsOrg combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016012
+  MigsOrgSymbiontAssociated:
+    description: MIxS Data that comply with the MigsOrg checklist and the SymbiontAssociated Extension
+    title: MigsOrg combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016023
+  MigsOrgWastewaterSludge:
+    description: MIxS Data that comply with the MigsOrg checklist and the WastewaterSludge Extension
+    title: MigsOrg combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016013
+  MigsOrgWater:
+    description: MIxS Data that comply with the MigsOrg checklist and the Water Extension
+    title: MigsOrg combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MigsOrg
+    class_uri: MIXS:0010006_0016014
+  MigsPlAgriculture:
+    description: MIxS Data that comply with the MigsPl checklist and the Agriculture Extension
+    title: MigsPl combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016018
+  MigsPlAir:
+    description: MIxS Data that comply with the MigsPl checklist and the Air Extension
+    title: MigsPl combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016000
+  MigsPlBuiltEnvironment:
+    description: MIxS Data that comply with the MigsPl checklist and the BuiltEnvironment Extension
+    title: MigsPl combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016001
+  MigsPlFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MigsPl checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MigsPl combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016019
+  MigsPlFoodFarmEnvironment:
+    description: MIxS Data that comply with the MigsPl checklist and the FoodFarmEnvironment Extension
+    title: MigsPl combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016020
+  MigsPlFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MigsPl checklist and the FoodFoodProductionFacility Extension
+    title: MigsPl combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016021
+  MigsPlFoodHumanFoods:
+    description: MIxS Data that comply with the MigsPl checklist and the FoodHumanFoods Extension
+    title: MigsPl combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016022
+  MigsPlHostAssociated:
+    description: MIxS Data that comply with the MigsPl checklist and the HostAssociated Extension
+    title: MigsPl combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016002
+  MigsPlHumanAssociated:
+    description: MIxS Data that comply with the MigsPl checklist and the HumanAssociated Extension
+    title: MigsPl combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016003
+  MigsPlHumanGut:
+    description: MIxS Data that comply with the MigsPl checklist and the HumanGut Extension
+    title: MigsPl combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016004
+  MigsPlHumanOral:
+    description: MIxS Data that comply with the MigsPl checklist and the HumanOral Extension
+    title: MigsPl combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016005
+  MigsPlHumanSkin:
+    description: MIxS Data that comply with the MigsPl checklist and the HumanSkin Extension
+    title: MigsPl combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016006
+  MigsPlHumanVaginal:
+    description: MIxS Data that comply with the MigsPl checklist and the HumanVaginal Extension
+    title: MigsPl combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016007
+  MigsPlHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MigsPl checklist and the HydrocarbonResourcesCores Extension
+    title: MigsPl combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016015
+  MigsPlHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MigsPl checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MigsPl combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016016
+  MigsPlMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MigsPl checklist and the MicrobialMatBiofilm Extension
+    title: MigsPl combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016008
+  MigsPlMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MigsPl checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MigsPl combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016009
+  MigsPlPlantAssociated:
+    description: MIxS Data that comply with the MigsPl checklist and the PlantAssociated Extension
+    title: MigsPl combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016010
+  MigsPlSediment:
+    description: MIxS Data that comply with the MigsPl checklist and the Sediment Extension
+    title: MigsPl combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016011
+  MigsPlSoil:
+    description: MIxS Data that comply with the MigsPl checklist and the Soil Extension
+    title: MigsPl combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016012
+  MigsPlSymbiontAssociated:
+    description: MIxS Data that comply with the MigsPl checklist and the SymbiontAssociated Extension
+    title: MigsPl combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016023
+  MigsPlWastewaterSludge:
+    description: MIxS Data that comply with the MigsPl checklist and the WastewaterSludge Extension
+    title: MigsPl combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016013
+  MigsPlWater:
+    description: MIxS Data that comply with the MigsPl checklist and the Water Extension
+    title: MigsPl combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MigsPl
+    class_uri: MIXS:0010004_0016014
+  MigsViAgriculture:
+    description: MIxS Data that comply with the MigsVi checklist and the Agriculture Extension
+    title: MigsVi combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016018
+  MigsViAir:
+    description: MIxS Data that comply with the MigsVi checklist and the Air Extension
+    title: MigsVi combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016000
+  MigsViBuiltEnvironment:
+    description: MIxS Data that comply with the MigsVi checklist and the BuiltEnvironment Extension
+    title: MigsVi combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016001
+  MigsViFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MigsVi checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MigsVi combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016019
+  MigsViFoodFarmEnvironment:
+    description: MIxS Data that comply with the MigsVi checklist and the FoodFarmEnvironment Extension
+    title: MigsVi combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016020
+  MigsViFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MigsVi checklist and the FoodFoodProductionFacility Extension
+    title: MigsVi combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016021
+  MigsViFoodHumanFoods:
+    description: MIxS Data that comply with the MigsVi checklist and the FoodHumanFoods Extension
+    title: MigsVi combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016022
+  MigsViHostAssociated:
+    description: MIxS Data that comply with the MigsVi checklist and the HostAssociated Extension
+    title: MigsVi combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016002
+  MigsViHumanAssociated:
+    description: MIxS Data that comply with the MigsVi checklist and the HumanAssociated Extension
+    title: MigsVi combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016003
+  MigsViHumanGut:
+    description: MIxS Data that comply with the MigsVi checklist and the HumanGut Extension
+    title: MigsVi combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016004
+  MigsViHumanOral:
+    description: MIxS Data that comply with the MigsVi checklist and the HumanOral Extension
+    title: MigsVi combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016005
+  MigsViHumanSkin:
+    description: MIxS Data that comply with the MigsVi checklist and the HumanSkin Extension
+    title: MigsVi combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016006
+  MigsViHumanVaginal:
+    description: MIxS Data that comply with the MigsVi checklist and the HumanVaginal Extension
+    title: MigsVi combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016007
+  MigsViHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MigsVi checklist and the HydrocarbonResourcesCores Extension
+    title: MigsVi combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016015
+  MigsViHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MigsVi checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MigsVi combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016016
+  MigsViMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MigsVi checklist and the MicrobialMatBiofilm Extension
+    title: MigsVi combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016008
+  MigsViMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MigsVi checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MigsVi combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016009
+  MigsViPlantAssociated:
+    description: MIxS Data that comply with the MigsVi checklist and the PlantAssociated Extension
+    title: MigsVi combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016010
+  MigsViSediment:
+    description: MIxS Data that comply with the MigsVi checklist and the Sediment Extension
+    title: MigsVi combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016011
+  MigsViSoil:
+    description: MIxS Data that comply with the MigsVi checklist and the Soil Extension
+    title: MigsVi combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016012
+  MigsViSymbiontAssociated:
+    description: MIxS Data that comply with the MigsVi checklist and the SymbiontAssociated Extension
+    title: MigsVi combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016023
+  MigsViWastewaterSludge:
+    description: MIxS Data that comply with the MigsVi checklist and the WastewaterSludge Extension
+    title: MigsVi combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016013
+  MigsViWater:
+    description: MIxS Data that comply with the MigsVi checklist and the Water Extension
+    title: MigsVi combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MigsVi
+    class_uri: MIXS:0010005_0016014
+  MimagAgriculture:
+    description: MIxS Data that comply with the Mimag checklist and the Agriculture Extension
+    title: Mimag combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016018
+  MimagAir:
+    description: MIxS Data that comply with the Mimag checklist and the Air Extension
+    title: Mimag combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016000
+  MimagBuiltEnvironment:
+    description: MIxS Data that comply with the Mimag checklist and the BuiltEnvironment Extension
+    title: Mimag combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016001
+  MimagFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the Mimag checklist and the FoodAnimalAndAnimalFeed Extension
+    title: Mimag combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016019
+  MimagFoodFarmEnvironment:
+    description: MIxS Data that comply with the Mimag checklist and the FoodFarmEnvironment Extension
+    title: Mimag combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016020
+  MimagFoodFoodProductionFacility:
+    description: MIxS Data that comply with the Mimag checklist and the FoodFoodProductionFacility Extension
+    title: Mimag combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016021
+  MimagFoodHumanFoods:
+    description: MIxS Data that comply with the Mimag checklist and the FoodHumanFoods Extension
+    title: Mimag combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016022
+  MimagHostAssociated:
+    description: MIxS Data that comply with the Mimag checklist and the HostAssociated Extension
+    title: Mimag combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016002
+  MimagHumanAssociated:
+    description: MIxS Data that comply with the Mimag checklist and the HumanAssociated Extension
+    title: Mimag combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016003
+  MimagHumanGut:
+    description: MIxS Data that comply with the Mimag checklist and the HumanGut Extension
+    title: Mimag combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016004
+  MimagHumanOral:
+    description: MIxS Data that comply with the Mimag checklist and the HumanOral Extension
+    title: Mimag combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016005
+  MimagHumanSkin:
+    description: MIxS Data that comply with the Mimag checklist and the HumanSkin Extension
+    title: Mimag combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016006
+  MimagHumanVaginal:
+    description: MIxS Data that comply with the Mimag checklist and the HumanVaginal Extension
+    title: Mimag combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016007
+  MimagHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the Mimag checklist and the HydrocarbonResourcesCores Extension
+    title: Mimag combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016015
+  MimagHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the Mimag checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: Mimag combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016016
+  MimagMicrobialMatBiofilm:
+    description: MIxS Data that comply with the Mimag checklist and the MicrobialMatBiofilm Extension
+    title: Mimag combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016008
+  MimagMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the Mimag checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: Mimag combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016009
+  MimagPlantAssociated:
+    description: MIxS Data that comply with the Mimag checklist and the PlantAssociated Extension
+    title: Mimag combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016010
+  MimagSediment:
+    description: MIxS Data that comply with the Mimag checklist and the Sediment Extension
+    title: Mimag combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016011
+  MimagSoil:
+    description: MIxS Data that comply with the Mimag checklist and the Soil Extension
+    title: Mimag combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016012
+  MimagSymbiontAssociated:
+    description: MIxS Data that comply with the Mimag checklist and the SymbiontAssociated Extension
+    title: Mimag combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016023
+  MimagWastewaterSludge:
+    description: MIxS Data that comply with the Mimag checklist and the WastewaterSludge Extension
+    title: Mimag combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016013
+  MimagWater:
+    description: MIxS Data that comply with the Mimag checklist and the Water Extension
+    title: Mimag combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - Mimag
+    class_uri: MIXS:0010011_0016014
+  MimarksCAgriculture:
+    description: MIxS Data that comply with the MimarksC checklist and the Agriculture Extension
+    title: MimarksC combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016018
+  MimarksCAir:
+    description: MIxS Data that comply with the MimarksC checklist and the Air Extension
+    title: MimarksC combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016000
+  MimarksCBuiltEnvironment:
+    description: MIxS Data that comply with the MimarksC checklist and the BuiltEnvironment Extension
+    title: MimarksC combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016001
+  MimarksCFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MimarksC checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MimarksC combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016019
+  MimarksCFoodFarmEnvironment:
+    description: MIxS Data that comply with the MimarksC checklist and the FoodFarmEnvironment Extension
+    title: MimarksC combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016020
+  MimarksCFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MimarksC checklist and the FoodFoodProductionFacility Extension
+    title: MimarksC combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016021
+  MimarksCFoodHumanFoods:
+    description: MIxS Data that comply with the MimarksC checklist and the FoodHumanFoods Extension
+    title: MimarksC combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016022
+  MimarksCHostAssociated:
+    description: MIxS Data that comply with the MimarksC checklist and the HostAssociated Extension
+    title: MimarksC combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016002
+  MimarksCHumanAssociated:
+    description: MIxS Data that comply with the MimarksC checklist and the HumanAssociated Extension
+    title: MimarksC combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016003
+  MimarksCHumanGut:
+    description: MIxS Data that comply with the MimarksC checklist and the HumanGut Extension
+    title: MimarksC combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016004
+  MimarksCHumanOral:
+    description: MIxS Data that comply with the MimarksC checklist and the HumanOral Extension
+    title: MimarksC combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016005
+  MimarksCHumanSkin:
+    description: MIxS Data that comply with the MimarksC checklist and the HumanSkin Extension
+    title: MimarksC combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016006
+  MimarksCHumanVaginal:
+    description: MIxS Data that comply with the MimarksC checklist and the HumanVaginal Extension
+    title: MimarksC combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016007
+  MimarksCHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MimarksC checklist and the HydrocarbonResourcesCores Extension
+    title: MimarksC combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016015
+  MimarksCHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MimarksC checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MimarksC combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016016
+  MimarksCMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MimarksC checklist and the MicrobialMatBiofilm Extension
+    title: MimarksC combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016008
+  MimarksCMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MimarksC checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MimarksC combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016009
+  MimarksCPlantAssociated:
+    description: MIxS Data that comply with the MimarksC checklist and the PlantAssociated Extension
+    title: MimarksC combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016010
+  MimarksCSediment:
+    description: MIxS Data that comply with the MimarksC checklist and the Sediment Extension
+    title: MimarksC combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016011
+  MimarksCSoil:
+    description: MIxS Data that comply with the MimarksC checklist and the Soil Extension
+    title: MimarksC combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016012
+  MimarksCSymbiontAssociated:
+    description: MIxS Data that comply with the MimarksC checklist and the SymbiontAssociated Extension
+    title: MimarksC combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016023
+  MimarksCWastewaterSludge:
+    description: MIxS Data that comply with the MimarksC checklist and the WastewaterSludge Extension
+    title: MimarksC combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016013
+  MimarksCWater:
+    description: MIxS Data that comply with the MimarksC checklist and the Water Extension
+    title: MimarksC combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MimarksC
+    class_uri: MIXS:0010009_0016014
+  MimarksSAgriculture:
+    description: MIxS Data that comply with the MimarksS checklist and the Agriculture Extension
+    title: MimarksS combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016018
+  MimarksSAir:
+    description: MIxS Data that comply with the MimarksS checklist and the Air Extension
+    title: MimarksS combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016000
+  MimarksSBuiltEnvironment:
+    description: MIxS Data that comply with the MimarksS checklist and the BuiltEnvironment Extension
+    title: MimarksS combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016001
+  MimarksSFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the MimarksS checklist and the FoodAnimalAndAnimalFeed Extension
+    title: MimarksS combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016019
+  MimarksSFoodFarmEnvironment:
+    description: MIxS Data that comply with the MimarksS checklist and the FoodFarmEnvironment Extension
+    title: MimarksS combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016020
+  MimarksSFoodFoodProductionFacility:
+    description: MIxS Data that comply with the MimarksS checklist and the FoodFoodProductionFacility Extension
+    title: MimarksS combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016021
+  MimarksSFoodHumanFoods:
+    description: MIxS Data that comply with the MimarksS checklist and the FoodHumanFoods Extension
+    title: MimarksS combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016022
+  MimarksSHostAssociated:
+    description: MIxS Data that comply with the MimarksS checklist and the HostAssociated Extension
+    title: MimarksS combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016002
+  MimarksSHumanAssociated:
+    description: MIxS Data that comply with the MimarksS checklist and the HumanAssociated Extension
+    title: MimarksS combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016003
+  MimarksSHumanGut:
+    description: MIxS Data that comply with the MimarksS checklist and the HumanGut Extension
+    title: MimarksS combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016004
+  MimarksSHumanOral:
+    description: MIxS Data that comply with the MimarksS checklist and the HumanOral Extension
+    title: MimarksS combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016005
+  MimarksSHumanSkin:
+    description: MIxS Data that comply with the MimarksS checklist and the HumanSkin Extension
+    title: MimarksS combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016006
+  MimarksSHumanVaginal:
+    description: MIxS Data that comply with the MimarksS checklist and the HumanVaginal Extension
+    title: MimarksS combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016007
+  MimarksSHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the MimarksS checklist and the HydrocarbonResourcesCores Extension
+    title: MimarksS combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016015
+  MimarksSHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the MimarksS checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: MimarksS combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016016
+  MimarksSMicrobialMatBiofilm:
+    description: MIxS Data that comply with the MimarksS checklist and the MicrobialMatBiofilm Extension
+    title: MimarksS combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016008
+  MimarksSMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the MimarksS checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: MimarksS combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016009
+  MimarksSPlantAssociated:
+    description: MIxS Data that comply with the MimarksS checklist and the PlantAssociated Extension
+    title: MimarksS combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016010
+  MimarksSSediment:
+    description: MIxS Data that comply with the MimarksS checklist and the Sediment Extension
+    title: MimarksS combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016011
+  MimarksSSoil:
+    description: MIxS Data that comply with the MimarksS checklist and the Soil Extension
+    title: MimarksS combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016012
+  MimarksSSymbiontAssociated:
+    description: MIxS Data that comply with the MimarksS checklist and the SymbiontAssociated Extension
+    title: MimarksS combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016023
+  MimarksSWastewaterSludge:
+    description: MIxS Data that comply with the MimarksS checklist and the WastewaterSludge Extension
+    title: MimarksS combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016013
+  MimarksSWater:
+    description: MIxS Data that comply with the MimarksS checklist and the Water Extension
+    title: MimarksS combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - MimarksS
+    class_uri: MIXS:0010008_0016014
+  MimsAgriculture:
+    description: MIxS Data that comply with the Mims checklist and the Agriculture Extension
+    title: Mims combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016018
+  MimsAir:
+    description: MIxS Data that comply with the Mims checklist and the Air Extension
+    title: Mims combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016000
+  MimsBuiltEnvironment:
+    description: MIxS Data that comply with the Mims checklist and the BuiltEnvironment Extension
+    title: Mims combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016001
+  MimsFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the Mims checklist and the FoodAnimalAndAnimalFeed Extension
+    title: Mims combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016019
+  MimsFoodFarmEnvironment:
+    description: MIxS Data that comply with the Mims checklist and the FoodFarmEnvironment Extension
+    title: Mims combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016020
+  MimsFoodFoodProductionFacility:
+    description: MIxS Data that comply with the Mims checklist and the FoodFoodProductionFacility Extension
+    title: Mims combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016021
+  MimsFoodHumanFoods:
+    description: MIxS Data that comply with the Mims checklist and the FoodHumanFoods Extension
+    title: Mims combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016022
+  MimsHostAssociated:
+    description: MIxS Data that comply with the Mims checklist and the HostAssociated Extension
+    title: Mims combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016002
+  MimsHumanAssociated:
+    description: MIxS Data that comply with the Mims checklist and the HumanAssociated Extension
+    title: Mims combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016003
+  MimsHumanGut:
+    description: MIxS Data that comply with the Mims checklist and the HumanGut Extension
+    title: Mims combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016004
+  MimsHumanOral:
+    description: MIxS Data that comply with the Mims checklist and the HumanOral Extension
+    title: Mims combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016005
+  MimsHumanSkin:
+    description: MIxS Data that comply with the Mims checklist and the HumanSkin Extension
+    title: Mims combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016006
+  MimsHumanVaginal:
+    description: MIxS Data that comply with the Mims checklist and the HumanVaginal Extension
+    title: Mims combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016007
+  MimsHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the Mims checklist and the HydrocarbonResourcesCores Extension
+    title: Mims combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016015
+  MimsHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the Mims checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: Mims combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016016
+  MimsMicrobialMatBiofilm:
+    description: MIxS Data that comply with the Mims checklist and the MicrobialMatBiofilm Extension
+    title: Mims combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016008
+  MimsMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the Mims checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: Mims combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016009
+  MimsPlantAssociated:
+    description: MIxS Data that comply with the Mims checklist and the PlantAssociated Extension
+    title: Mims combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016010
+  MimsSediment:
+    description: MIxS Data that comply with the Mims checklist and the Sediment Extension
+    title: Mims combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016011
+  MimsSoil:
+    description: MIxS Data that comply with the Mims checklist and the Soil Extension
+    title: Mims combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016012
+  MimsSymbiontAssociated:
+    description: MIxS Data that comply with the Mims checklist and the SymbiontAssociated Extension
+    title: Mims combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016023
+  MimsWastewaterSludge:
+    description: MIxS Data that comply with the Mims checklist and the WastewaterSludge Extension
+    title: Mims combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016013
+  MimsWater:
+    description: MIxS Data that comply with the Mims checklist and the Water Extension
+    title: Mims combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - Mims
+    class_uri: MIXS:0010007_0016014
+  MisagAgriculture:
+    description: MIxS Data that comply with the Misag checklist and the Agriculture Extension
+    title: Misag combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016018
+  MisagAir:
+    description: MIxS Data that comply with the Misag checklist and the Air Extension
+    title: Misag combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016000
+  MisagBuiltEnvironment:
+    description: MIxS Data that comply with the Misag checklist and the BuiltEnvironment Extension
+    title: Misag combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016001
+  MisagFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the Misag checklist and the FoodAnimalAndAnimalFeed Extension
+    title: Misag combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016019
+  MisagFoodFarmEnvironment:
+    description: MIxS Data that comply with the Misag checklist and the FoodFarmEnvironment Extension
+    title: Misag combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016020
+  MisagFoodFoodProductionFacility:
+    description: MIxS Data that comply with the Misag checklist and the FoodFoodProductionFacility Extension
+    title: Misag combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016021
+  MisagFoodHumanFoods:
+    description: MIxS Data that comply with the Misag checklist and the FoodHumanFoods Extension
+    title: Misag combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016022
+  MisagHostAssociated:
+    description: MIxS Data that comply with the Misag checklist and the HostAssociated Extension
+    title: Misag combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016002
+  MisagHumanAssociated:
+    description: MIxS Data that comply with the Misag checklist and the HumanAssociated Extension
+    title: Misag combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016003
+  MisagHumanGut:
+    description: MIxS Data that comply with the Misag checklist and the HumanGut Extension
+    title: Misag combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016004
+  MisagHumanOral:
+    description: MIxS Data that comply with the Misag checklist and the HumanOral Extension
+    title: Misag combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016005
+  MisagHumanSkin:
+    description: MIxS Data that comply with the Misag checklist and the HumanSkin Extension
+    title: Misag combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016006
+  MisagHumanVaginal:
+    description: MIxS Data that comply with the Misag checklist and the HumanVaginal Extension
+    title: Misag combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016007
+  MisagHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the Misag checklist and the HydrocarbonResourcesCores Extension
+    title: Misag combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016015
+  MisagHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the Misag checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: Misag combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016016
+  MisagMicrobialMatBiofilm:
+    description: MIxS Data that comply with the Misag checklist and the MicrobialMatBiofilm Extension
+    title: Misag combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016008
+  MisagMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the Misag checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: Misag combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016009
+  MisagPlantAssociated:
+    description: MIxS Data that comply with the Misag checklist and the PlantAssociated Extension
+    title: Misag combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016010
+  MisagSediment:
+    description: MIxS Data that comply with the Misag checklist and the Sediment Extension
+    title: Misag combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016011
+  MisagSoil:
+    description: MIxS Data that comply with the Misag checklist and the Soil Extension
+    title: Misag combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016012
+  MisagSymbiontAssociated:
+    description: MIxS Data that comply with the Misag checklist and the SymbiontAssociated Extension
+    title: Misag combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016023
+  MisagWastewaterSludge:
+    description: MIxS Data that comply with the Misag checklist and the WastewaterSludge Extension
+    title: Misag combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016013
+  MisagWater:
+    description: MIxS Data that comply with the Misag checklist and the Water Extension
+    title: Misag combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - Misag
+    class_uri: MIXS:0010010_0016014
+  MiuvigAgriculture:
+    description: MIxS Data that comply with the Miuvig checklist and the Agriculture Extension
+    title: Miuvig combined with Agriculture
+    in_subset:
+      - combination_classes
+    is_a: Agriculture
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016018
+  MiuvigAir:
+    description: MIxS Data that comply with the Miuvig checklist and the Air Extension
+    title: Miuvig combined with Air
+    in_subset:
+      - combination_classes
+    is_a: Air
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016000
+  MiuvigBuiltEnvironment:
+    description: MIxS Data that comply with the Miuvig checklist and the BuiltEnvironment Extension
+    title: Miuvig combined with BuiltEnvironment
+    in_subset:
+      - combination_classes
+    is_a: BuiltEnvironment
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016001
+  MiuvigFoodAnimalAndAnimalFeed:
+    description: MIxS Data that comply with the Miuvig checklist and the FoodAnimalAndAnimalFeed Extension
+    title: Miuvig combined with FoodAnimalAndAnimalFeed
+    in_subset:
+      - combination_classes
+    is_a: FoodAnimalAndAnimalFeed
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016019
+  MiuvigFoodFarmEnvironment:
+    description: MIxS Data that comply with the Miuvig checklist and the FoodFarmEnvironment Extension
+    title: Miuvig combined with FoodFarmEnvironment
+    in_subset:
+      - combination_classes
+    is_a: FoodFarmEnvironment
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016020
+  MiuvigFoodFoodProductionFacility:
+    description: MIxS Data that comply with the Miuvig checklist and the FoodFoodProductionFacility Extension
+    title: Miuvig combined with FoodFoodProductionFacility
+    in_subset:
+      - combination_classes
+    is_a: FoodFoodProductionFacility
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016021
+  MiuvigFoodHumanFoods:
+    description: MIxS Data that comply with the Miuvig checklist and the FoodHumanFoods Extension
+    title: Miuvig combined with FoodHumanFoods
+    in_subset:
+      - combination_classes
+    is_a: FoodHumanFoods
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016022
+  MiuvigHostAssociated:
+    description: MIxS Data that comply with the Miuvig checklist and the HostAssociated Extension
+    title: Miuvig combined with HostAssociated
+    in_subset:
+      - combination_classes
+    is_a: HostAssociated
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016002
+  MiuvigHumanAssociated:
+    description: MIxS Data that comply with the Miuvig checklist and the HumanAssociated Extension
+    title: Miuvig combined with HumanAssociated
+    in_subset:
+      - combination_classes
+    is_a: HumanAssociated
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016003
+  MiuvigHumanGut:
+    description: MIxS Data that comply with the Miuvig checklist and the HumanGut Extension
+    title: Miuvig combined with HumanGut
+    in_subset:
+      - combination_classes
+    is_a: HumanGut
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016004
+  MiuvigHumanOral:
+    description: MIxS Data that comply with the Miuvig checklist and the HumanOral Extension
+    title: Miuvig combined with HumanOral
+    in_subset:
+      - combination_classes
+    is_a: HumanOral
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016005
+  MiuvigHumanSkin:
+    description: MIxS Data that comply with the Miuvig checklist and the HumanSkin Extension
+    title: Miuvig combined with HumanSkin
+    in_subset:
+      - combination_classes
+    is_a: HumanSkin
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016006
+  MiuvigHumanVaginal:
+    description: MIxS Data that comply with the Miuvig checklist and the HumanVaginal Extension
+    title: Miuvig combined with HumanVaginal
+    in_subset:
+      - combination_classes
+    is_a: HumanVaginal
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016007
+  MiuvigHydrocarbonResourcesCores:
+    description: MIxS Data that comply with the Miuvig checklist and the HydrocarbonResourcesCores Extension
+    title: Miuvig combined with HydrocarbonResourcesCores
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesCores
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016015
+  MiuvigHydrocarbonResourcesFluidsSwabs:
+    description: MIxS Data that comply with the Miuvig checklist and the HydrocarbonResourcesFluidsSwabs Extension
+    title: Miuvig combined with HydrocarbonResourcesFluidsSwabs
+    in_subset:
+      - combination_classes
+    is_a: HydrocarbonResourcesFluidsSwabs
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016016
+  MiuvigMicrobialMatBiofilm:
+    description: MIxS Data that comply with the Miuvig checklist and the MicrobialMatBiofilm Extension
+    title: Miuvig combined with MicrobialMatBiofilm
+    in_subset:
+      - combination_classes
+    is_a: MicrobialMatBiofilm
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016008
+  MiuvigMiscellaneousNaturalOrArtificialEnvironment:
+    description: MIxS Data that comply with the Miuvig checklist and the MiscellaneousNaturalOrArtificialEnvironment Extension
+    title: Miuvig combined with MiscellaneousNaturalOrArtificialEnvironment
+    in_subset:
+      - combination_classes
+    is_a: MiscellaneousNaturalOrArtificialEnvironment
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016009
+  MiuvigPlantAssociated:
+    description: MIxS Data that comply with the Miuvig checklist and the PlantAssociated Extension
+    title: Miuvig combined with PlantAssociated
+    in_subset:
+      - combination_classes
+    is_a: PlantAssociated
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016010
+  MiuvigSediment:
+    description: MIxS Data that comply with the Miuvig checklist and the Sediment Extension
+    title: Miuvig combined with Sediment
+    in_subset:
+      - combination_classes
+    is_a: Sediment
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016011
+  MiuvigSoil:
+    description: MIxS Data that comply with the Miuvig checklist and the Soil Extension
+    title: Miuvig combined with Soil
+    in_subset:
+      - combination_classes
+    is_a: Soil
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016012
+  MiuvigSymbiontAssociated:
+    description: MIxS Data that comply with the Miuvig checklist and the SymbiontAssociated Extension
+    title: Miuvig combined with SymbiontAssociated
+    in_subset:
+      - combination_classes
+    is_a: SymbiontAssociated
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016023
+  MiuvigWastewaterSludge:
+    description: MIxS Data that comply with the Miuvig checklist and the WastewaterSludge Extension
+    title: Miuvig combined with WastewaterSludge
+    in_subset:
+      - combination_classes
+    is_a: WastewaterSludge
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016013
+  MiuvigWater:
+    description: MIxS Data that comply with the Miuvig checklist and the Water Extension
+    title: Miuvig combined with Water
+    in_subset:
+      - combination_classes
+    is_a: Water
+    mixins:
+      - Miuvig
+    class_uri: MIXS:0010012_0016014
+settings:
+  agrochemical_name: .*
+  amount: '[-+]?[0-9]*\.?[0-9]+'
+  add_recov_methods: Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer Addition|Surfactant Addition|Not Applicable|other
+  DOI: ^doi:10.\d{2,9}/.*$
+  NCBItaxon_id: NCBITaxon:\d+
+  PMID: ^PMID:\d+$
+  URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$
+  adapter: '[ACGTRKSYMWBHDVN]+'
+  adapter_A_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
+  adapter_B_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
+  ambiguous_nucleotides: '[ACGTRKSYMWBHDVN]+'
+  country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  date_time_stamp: (\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$
+  duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
+  float: '[-+]?[0-9]*\.?[0-9]+'
+  integer: '[1-9][0-9]*'
+  lat: (-?((?:[0-8]?[0-9](?:\.\d{0,8})?)|90))
+  lon: -?[0-9]+(?:\.[0-9]{0,8})?$|^-?(1[0-7]{1,2})
+  name: .*
+  parameters: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  particulate_matter_name: .*
+  region: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  room_name: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  room_number: '[1-9][0-9]*'
+  scientific_float: '[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?'
+  software: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  specific_location: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  storage_condition_type: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  termID: '[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'
+  termLabel: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  text: .*
+  unit: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
+  version: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -1,7 +1,11 @@
 ---
 name: mixs
-description: >-
-  This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project
+description: 'This file contains a YAML-formatted specification of the Minimum Information
+  about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/).
+  This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/)
+  for use by anyone handling data or information about biological sequences. This
+  file is also used as an authoritative ''source of truth'' to generate downstream
+  GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project'
 comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
@@ -18,285 +22,285 @@ prefixes:
 default_prefix: MIXS
 default_range: string
 subsets:
-  combination_classes:
-  sequencing:
-  environment:
-  nucleic acid sequence source:
-  investigation:
+  combination_classes: {}
+  sequencing: {}
+  environment: {}
+  nucleic acid sequence source: {}
+  investigation: {}
 enums:
   BiolStatEnum:
     permissible_values:
-      breeder's line:
-      clonal selection:
-      hybrid:
-      inbred line:
-      mutant:
-      natural:
-      semi-natural:
-      wild:
+      breeder's line: {}
+      clonal selection: {}
+      hybrid: {}
+      inbred line: {}
+      mutant: {}
+      natural: {}
+      semi-natural: {}
+      wild: {}
   AssemblyQualEnum:
     permissible_values:
-      Finished genome:
-      High-quality draft genome:
-      Medium-quality draft genome:
-      Low-quality draft genome:
-      Genome fragment(s):
+      Finished genome: {}
+      High-quality draft genome: {}
+      Medium-quality draft genome: {}
+      Low-quality draft genome: {}
+      Genome fragment(s): {}
   AeroStrucEnum:
     permissible_values:
-      glider:
-      plane:
+      glider: {}
+      plane: {}
   AnimalBodyCondEnum:
     permissible_values:
-      normal:
-      over conditioned:
-      under conditioned:
+      normal: {}
+      over conditioned: {}
+      under conditioned: {}
   AnimalSexEnum:
     permissible_values:
-      castrated female:
-      castrated male:
-      intact female:
-      intact male:
+      castrated female: {}
+      castrated male: {}
+      intact female: {}
+      intact male: {}
   ArchStrucEnum:
     permissible_values:
-      building:
-      home:
-      shed:
+      building: {}
+      home: {}
+      shed: {}
   BinParamEnum:
     permissible_values:
-      codon usage:
-      combination:
-      coverage:
-      homology search:
-      kmer:
+      codon usage: {}
+      combination: {}
+      coverage: {}
+      homology search: {}
+      kmer: {}
   BioticRelationshipEnum:
     permissible_values:
-      commensalism:
-      free living:
-      mutualism:
-      parasitism:
-      symbiotic:
+      commensalism: {}
+      free living: {}
+      mutualism: {}
+      parasitism: {}
+      symbiotic: {}
   BuildingSettingEnum:
     permissible_values:
-      exurban:
-      rural:
-      suburban:
-      urban:
+      exurban: {}
+      rural: {}
+      suburban: {}
+      urban: {}
   BuildDocsEnum:
     permissible_values:
-      building information model:
-      commissioning report:
-      complaint logs:
-      contract administration:
-      cost estimate:
-      janitorial schedules or logs:
-      maintenance plans:
-      schedule:
-      sections:
-      shop drawings:
-      submittals:
-      ventilation system:
-      windows:
+      building information model: {}
+      commissioning report: {}
+      complaint logs: {}
+      contract administration: {}
+      cost estimate: {}
+      janitorial schedules or logs: {}
+      maintenance plans: {}
+      schedule: {}
+      sections: {}
+      shop drawings: {}
+      submittals: {}
+      ventilation system: {}
+      windows: {}
   BuildOccupTypeEnum:
     permissible_values:
-      airport:
-      commercial:
-      health care:
-      high rise:
-      low rise:
-      market:
-      office:
-      residence:
-      residential:
-      restaurant:
-      school:
-      sports complex:
-      wood framed:
+      airport: {}
+      commercial: {}
+      health care: {}
+      high rise: {}
+      low rise: {}
+      market: {}
+      office: {}
+      residence: {}
+      residential: {}
+      restaurant: {}
+      school: {}
+      sports complex: {}
+      wood framed: {}
   BuiltStrucSetEnum:
     permissible_values:
-      rural:
-      urban:
+      rural: {}
+      urban: {}
   CeilFinishMatEnum:
     permissible_values:
-      PVC:
-      drywall:
-      fiberglass:
-      metal:
-      mineral fibre:
-      mineral wool/calcium silicate:
-      plasterboard:
-      stucco:
-      tiles:
-      wood:
+      PVC: {}
+      drywall: {}
+      fiberglass: {}
+      metal: {}
+      mineral fibre: {}
+      mineral wool/calcium silicate: {}
+      plasterboard: {}
+      stucco: {}
+      tiles: {}
+      wood: {}
   CeilStrucEnum:
     permissible_values:
-      concrete:
-      wood frame:
+      concrete: {}
+      wood frame: {}
   CeilTypeEnum:
     permissible_values:
-      barrel-shaped:
-      cathedral:
-      coffered:
-      concave:
-      cove:
-      dropped:
-      stretched:
+      barrel-shaped: {}
+      cathedral: {}
+      coffered: {}
+      concave: {}
+      cove: {}
+      dropped: {}
+      stretched: {}
   ComplApprEnum:
     permissible_values:
-      marker gene:
-      other:
-      reference based:
+      marker gene: {}
+      other: {}
+      reference based: {}
   ContamScreenInputEnum:
     permissible_values:
-      contigs:
-      reads:
+      contigs: {}
+      reads: {}
   CultResultEnum:
     permissible_values:
-      absent:
-      active:
-      inactive:
-      negative:
-      'no':
-      positive:
-      present:
-      'yes':
+      absent: {}
+      active: {}
+      inactive: {}
+      negative: {}
+      'no': {}
+      positive: {}
+      present: {}
+      'yes': {}
   DeposEnvEnum:
     permissible_values:
-      Continental - Aeolian:
-      Continental - Alluvial:
-      Continental - Fluvial:
-      Continental - Lacustrine:
-      Marine - Deep:
-      Marine - Reef:
-      Marine - Shallow:
-      Other - Evaporite:
-      Other - Glacial:
-      Other - Volcanic:
-      Transitional - Beach:
-      Transitional - Deltaic:
-      Transitional - Lagoonal:
-      Transitional - Lake:
-      Transitional - Tidal:
-      other:
+      Continental - Aeolian: {}
+      Continental - Alluvial: {}
+      Continental - Fluvial: {}
+      Continental - Lacustrine: {}
+      Marine - Deep: {}
+      Marine - Reef: {}
+      Marine - Shallow: {}
+      Other - Evaporite: {}
+      Other - Glacial: {}
+      Other - Volcanic: {}
+      Transitional - Beach: {}
+      Transitional - Deltaic: {}
+      Transitional - Lagoonal: {}
+      Transitional - Lake: {}
+      Transitional - Tidal: {}
+      other: {}
   DominantHandEnum:
     permissible_values:
-      ambidextrous:
-      left:
-      right:
+      ambidextrous: {}
+      left: {}
+      right: {}
   DoorCompTypeEnum:
     permissible_values:
-      metal covered:
-      revolving:
-      sliding:
-      telescopic:
+      metal covered: {}
+      revolving: {}
+      sliding: {}
+      telescopic: {}
   DoorDirectEnum:
     permissible_values:
-      inward:
-      outward:
-      sideways:
+      inward: {}
+      outward: {}
+      sideways: {}
   DoorMatEnum:
     permissible_values:
-      aluminum:
-      cellular PVC:
-      engineered plastic:
-      fiberboard:
-      fiberglass:
-      metal:
-      thermoplastic alloy:
-      vinyl:
-      wood:
-      wood/plastic composite:
+      aluminum: {}
+      cellular PVC: {}
+      engineered plastic: {}
+      fiberboard: {}
+      fiberglass: {}
+      metal: {}
+      thermoplastic alloy: {}
+      vinyl: {}
+      wood: {}
+      wood/plastic composite: {}
   DoorMoveEnum:
     permissible_values:
-      collapsible:
-      folding:
-      revolving:
-      rolling shutter:
-      sliding:
-      swinging:
+      collapsible: {}
+      folding: {}
+      revolving: {}
+      rolling shutter: {}
+      sliding: {}
+      swinging: {}
   DoorTypeEnum:
     permissible_values:
-      composite:
-      metal:
-      wooden:
+      composite: {}
+      metal: {}
+      wooden: {}
   DoorTypeMetalEnum:
     permissible_values:
-      collapsible:
-      corrugated steel:
-      hollow:
-      rolling shutters:
-      steel plate:
+      collapsible: {}
+      corrugated steel: {}
+      hollow: {}
+      rolling shutters: {}
+      steel plate: {}
   DrainageClassEnum:
     permissible_values:
-      excessively drained:
-      moderately well:
-      poorly:
-      somewhat poorly:
-      very poorly:
-      well:
+      excessively drained: {}
+      moderately well: {}
+      poorly: {}
+      somewhat poorly: {}
+      very poorly: {}
+      well: {}
   DrawingsEnum:
     permissible_values:
-      as built:
-      bid:
-      building navigation map:
-      construction:
-      design:
-      diagram:
-      operation:
-      sketch:
+      as built: {}
+      bid: {}
+      building navigation map: {}
+      construction: {}
+      design: {}
+      diagram: {}
+      operation: {}
+      sketch: {}
   ExtrWeatherEventEnum:
     permissible_values:
-      drought:
-      dust storm:
-      extreme cold:
-      extreme heat:
-      flood:
-      frost:
-      hail:
-      high precipitation:
-      high winds:
+      drought: {}
+      dust storm: {}
+      extreme cold: {}
+      extreme heat: {}
+      flood: {}
+      frost: {}
+      hail: {}
+      high precipitation: {}
+      high winds: {}
   FacilityTypeEnum:
     permissible_values:
-      ambient storage:
-      caterer-catering point:
-      distribution:
-      frozen storage:
-      importer-broker:
-      interstate conveyance:
-      labeler-relabeler:
-      manufacturing-processing:
-      packaging:
-      refrigerated storage:
-      storage:
+      ambient storage: {}
+      caterer-catering point: {}
+      distribution: {}
+      frozen storage: {}
+      importer-broker: {}
+      interstate conveyance: {}
+      labeler-relabeler: {}
+      manufacturing-processing: {}
+      packaging: {}
+      refrigerated storage: {}
+      storage: {}
   FaoClassEnum:
     permissible_values:
-      Acrisols:
-      Alisols:
-      Andosols:
-      Anthrosols:
-      Arenosols:
-      Calcisols:
-      Cambisols:
-      Chernozems:
-      Cryosols:
-      Durisols:
-      Ferralsols:
-      Fluvisols:
-      Gleysols:
+      Acrisols: {}
+      Alisols: {}
+      Andosols: {}
+      Anthrosols: {}
+      Arenosols: {}
+      Calcisols: {}
+      Cambisols: {}
+      Chernozems: {}
+      Cryosols: {}
+      Durisols: {}
+      Ferralsols: {}
+      Fluvisols: {}
+      Gleysols: {}
       Greyzems:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
-      Gypsisols:
-      Histosols:
-      Kastanozems:
+      Gypsisols: {}
+      Histosols: {}
+      Kastanozems: {}
       Lithosols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
-      Leptosols:
-      Lixisols:
-      Luvisols:
-      Nitosols:
-      Phaeozems:
-      Planosols:
-      Plinthosols:
-      Podzols:
+      Leptosols: {}
+      Lixisols: {}
+      Luvisols: {}
+      Nitosols: {}
+      Phaeozems: {}
+      Planosols: {}
+      Plinthosols: {}
+      Podzols: {}
       Podzoluvisols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
       Rankers:
@@ -305,868 +309,865 @@ enums:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
       Rendzinas:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
-      Solonchaks:
-      Solonetz:
-      Stagnosols:
-      Technosols:
-      Umbrisols:
-      Vertisols:
+      Solonchaks: {}
+      Solonetz: {}
+      Stagnosols: {}
+      Technosols: {}
+      Umbrisols: {}
+      Vertisols: {}
       Yermosols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
   FarmWaterSourceEnum:
     permissible_values:
-      brackish:
-      canal:
-      collected rainwater:
-      ditch:
-      estuary:
-      freshwater:
-      lake:
-      manmade:
-      melt pond:
-      municipal:
-      natural:
-      pond:
-      reservior:
-      river:
-      saline:
-      storage tank:
-      stream:
-      well:
+      brackish: {}
+      canal: {}
+      collected rainwater: {}
+      ditch: {}
+      estuary: {}
+      freshwater: {}
+      lake: {}
+      manmade: {}
+      melt pond: {}
+      municipal: {}
+      natural: {}
+      pond: {}
+      reservior: {}
+      river: {}
+      saline: {}
+      storage tank: {}
+      stream: {}
+      well: {}
   FilterTypeEnum:
     permissible_values:
-      HEPA:
-      chemical air filter:
-      electrostatic:
-      gas-phase or ultraviolet air treatments:
-      low-MERV pleated media:
-      particulate air filter:
+      HEPA: {}
+      chemical air filter: {}
+      electrostatic: {}
+      gas-phase or ultraviolet air treatments: {}
+      low-MERV pleated media: {}
+      particulate air filter: {}
   FireplaceTypeEnum:
     permissible_values:
-      gas burning:
-      wood burning:
+      gas burning: {}
+      wood burning: {}
   FloorStrucEnum:
     permissible_values:
-      balcony:
-      concrete:
-      floating floor:
-      glass floor:
-      raised floor:
-      sprung floor:
-      wood-framed:
+      balcony: {}
+      concrete: {}
+      floating floor: {}
+      glass floor: {}
+      raised floor: {}
+      sprung floor: {}
+      wood-framed: {}
   FloorWaterMoldEnum:
     permissible_values:
-      bulging walls:
-      ceiling discoloration:
-      condensation:
-      floor discoloration:
-      mold odor:
-      peeling paint or wallpaper:
-      wall discoloration:
-      water stains:
-      wet floor:
+      bulging walls: {}
+      ceiling discoloration: {}
+      condensation: {}
+      floor discoloration: {}
+      mold odor: {}
+      peeling paint or wallpaper: {}
+      wall discoloration: {}
+      water stains: {}
+      wet floor: {}
   FoodCleanProcEnum:
     permissible_values:
-      drum and drain:
-      manual spinner:
-      rinsed with sanitizer solution:
-      rinsed with water:
-      scrubbed with brush:
-      scrubbed with hand:
-      soaking:
+      drum and drain: {}
+      manual spinner: {}
+      rinsed with sanitizer solution: {}
+      rinsed with water: {}
+      scrubbed with brush: {}
+      scrubbed with hand: {}
+      soaking: {}
   FoodTraceListEnum:
     permissible_values:
-      cheeses-other than hard cheeses:
-      crustaceans:
-      cucumbers:
-      finfish-including smoked finfish:
-      fruits and vegetables-fresh cut:
-      herbs-fresh:
-      leafy greens-including fresh cut leafy greens:
-      melons:
-      mollusks-bivalves:
-      nut butter:
-      peppers:
-      ready to eat deli salads:
-      shell eggs:
-      sprouts:
-      tomatoes:
-      tropical tree fruits:
+      cheeses-other than hard cheeses: {}
+      crustaceans: {}
+      cucumbers: {}
+      finfish-including smoked finfish: {}
+      fruits and vegetables-fresh cut: {}
+      herbs-fresh: {}
+      leafy greens-including fresh cut leafy greens: {}
+      melons: {}
+      mollusks-bivalves: {}
+      nut butter: {}
+      peppers: {}
+      ready to eat deli salads: {}
+      shell eggs: {}
+      sprouts: {}
+      tomatoes: {}
+      tropical tree fruits: {}
   FreqCleanEnum:
     permissible_values:
-      Annually:
-      Daily:
-      Monthly:
-      Quarterly:
-      Weekly:
-      other:
+      Annually: {}
+      Daily: {}
+      Monthly: {}
+      Quarterly: {}
+      Weekly: {}
+      other: {}
   FurnitureEnum:
     permissible_values:
-      cabinet:
-      chair:
-      desks:
+      cabinet: {}
+      chair: {}
+      desks: {}
   GenderRestroomEnum:
     permissible_values:
-      all gender:
-      female:
-      gender neutral:
-      male:
-      male and female:
-      unisex:
+      all gender: {}
+      female: {}
+      gender neutral: {}
+      male: {}
+      male and female: {}
+      unisex: {}
   GrowthHabitEnum:
     permissible_values:
-      erect:
-      prostrate:
-      semi-erect:
-      spreading:
+      erect: {}
+      prostrate: {}
+      semi-erect: {}
+      spreading: {}
   HandidnessEnum:
     permissible_values:
-      ambidexterity:
-      left handedness:
-      mixed-handedness:
-      right handedness:
+      ambidexterity: {}
+      left handedness: {}
+      mixed-handedness: {}
+      right handedness: {}
   HcrEnum:
     permissible_values:
-      Coalbed:
-      Gas Reservoir:
-      Oil Reservoir:
-      Oil Sand:
-      Shale:
-      Tight Gas Reservoir:
-      Tight Oil Reservoir:
-      other:
+      Coalbed: {}
+      Gas Reservoir: {}
+      Oil Reservoir: {}
+      Oil Sand: {}
+      Shale: {}
+      Tight Gas Reservoir: {}
+      Tight Oil Reservoir: {}
+      other: {}
   HcProducedEnum:
     permissible_values:
-      Bitumen:
-      Coalbed Methane:
-      Gas:
-      Gas-Condensate:
-      Oil:
-      other:
+      Bitumen: {}
+      Coalbed Methane: {}
+      Gas: {}
+      Gas-Condensate: {}
+      Oil: {}
+      other: {}
   HeatCoolTypeEnum:
     permissible_values:
-      forced air system:
-      heat pump:
-      radiant system:
-      steam forced heat:
-      wood stove:
+      forced air system: {}
+      heat pump: {}
+      radiant system: {}
+      steam forced heat: {}
+      wood stove: {}
   HeatSysDelivMethEnum:
     permissible_values:
-      conductive:
-      radiant:
+      conductive: {}
+      radiant: {}
   HostCellularLocEnum:
     permissible_values:
-      extracellular:
-      intracellular:
-      not determined:
+      extracellular: {}
+      intracellular: {}
+      not determined: {}
   HostDependenceEnum:
     permissible_values:
-      facultative:
-      obligate:
+      facultative: {}
+      obligate: {}
   HostPredApprEnum:
     permissible_values:
-      CRISPR spacer match:
-      co-occurrence:
-      combination:
-      host sequence similarity:
-      kmer similarity:
-      other:
-      provirus:
+      CRISPR spacer match: {}
+      co-occurrence: {}
+      combination: {}
+      host sequence similarity: {}
+      kmer similarity: {}
+      other: {}
+      provirus: {}
   HostSpecificityEnum:
     permissible_values:
-      family-specific:
-      generalist:
-      genus-specific:
-      species-specific:
+      family-specific: {}
+      generalist: {}
+      genus-specific: {}
+      species-specific: {}
   IndoorSpaceEnum:
     permissible_values:
-      bathroom:
-      bedroom:
-      elevator:
-      foyer:
-      hallway:
-      kitchen:
-      locker room:
-      office:
+      bathroom: {}
+      bedroom: {}
+      elevator: {}
+      foyer: {}
+      hallway: {}
+      kitchen: {}
+      locker room: {}
+      office: {}
   IndoorSurfEnum:
     permissible_values:
-      cabinet:
-      ceiling:
-      counter top:
-      door:
-      shelving:
-      vent cover:
-      wall:
-      window:
+      cabinet: {}
+      ceiling: {}
+      counter top: {}
+      door: {}
+      shelving: {}
+      vent cover: {}
+      wall: {}
+      window: {}
   LibLayoutEnum:
     permissible_values:
-      other:
-      paired:
-      single:
-      vector:
+      other: {}
+      paired: {}
+      single: {}
+      vector: {}
   LightTypeEnum:
     permissible_values:
-      desk lamp:
-      electric light:
-      fluorescent lights:
-      natural light:
-      none:
+      desk lamp: {}
+      electric light: {}
+      fluorescent lights: {}
+      natural light: {}
+      none: {}
   LithologyEnum:
     permissible_values:
-      Basement:
-      Chalk:
-      Chert:
-      Coal:
-      Conglomerate:
-      Diatomite:
-      Dolomite:
-      Limestone:
-      Sandstone:
-      Shale:
-      Siltstone:
-      Volcanic:
-      other:
+      Basement: {}
+      Chalk: {}
+      Chert: {}
+      Coal: {}
+      Conglomerate: {}
+      Diatomite: {}
+      Dolomite: {}
+      Limestone: {}
+      Sandstone: {}
+      Shale: {}
+      Siltstone: {}
+      Volcanic: {}
+      other: {}
   MagCovSoftwareEnum:
     permissible_values:
-      bbmap:
-      bowtie:
-      bwa:
-      other:
+      bbmap: {}
+      bowtie: {}
+      bwa: {}
+      other: {}
   MechStrucEnum:
     permissible_values:
-      boat:
-      bus:
-      car:
-      carriage:
-      coach:
-      elevator:
-      escalator:
-      subway:
-      train:
+      boat: {}
+      bus: {}
+      car: {}
+      carriage: {}
+      coach: {}
+      elevator: {}
+      escalator: {}
+      subway: {}
+      train: {}
   ModeTransmissionEnum:
     permissible_values:
-      horizontal:castrator:
-      horizontal:directly transmitted:
-      horizontal:micropredator:
-      horizontal:parasitoid:
-      horizontal:trophically transmitted:
-      horizontal:vector transmitted:
-      vertical:
+      horizontal:castrator: {}
+      horizontal:directly transmitted: {}
+      horizontal:micropredator: {}
+      horizontal:parasitoid: {}
+      horizontal:trophically transmitted: {}
+      horizontal:vector transmitted: {}
+      vertical: {}
   NegContTypeEnum:
     permissible_values:
-      DNA-free PCR mix:
-      distilled water:
-      empty collection device:
-      empty collection tube:
-      phosphate buffer:
-      sterile swab:
-      sterile syringe:
+      DNA-free PCR mix: {}
+      distilled water: {}
+      empty collection device: {}
+      empty collection tube: {}
+      phosphate buffer: {}
+      sterile swab: {}
+      sterile syringe: {}
   OccupDocumentEnum:
     permissible_values:
-      automated count:
-      estimate:
-      manual count:
-      videos:
+      automated count: {}
+      estimate: {}
+      manual count: {}
+      videos: {}
   OxyStatSampEnum:
     permissible_values:
-      aerobic:
-      anaerobic:
-      other:
+      aerobic: {}
+      anaerobic: {}
+      other: {}
   PlantReprodCropEnum:
     permissible_values:
-      plant cutting:
-      pregerminated seed:
-      ratoon:
-      seed:
-      seedling:
-      whole mature plant:
+      plant cutting: {}
+      pregerminated seed: {}
+      ratoon: {}
+      seed: {}
+      seedling: {}
+      whole mature plant: {}
   PlantSexEnum:
     permissible_values:
-      Androdioecious:
-      Androecious:
-      Androgynomonoecious:
-      Androgynous:
-      Andromonoecious:
-      Bisexual:
-      Dichogamous:
-      Diclinous:
-      Dioecious:
-      Gynodioecious:
-      Gynoecious:
-      Gynomonoecious:
-      Hermaphroditic:
-      Imperfect:
-      Monoclinous:
-      Monoecious:
-      Perfect:
-      Polygamodioecious:
-      Polygamomonoecious:
-      Polygamous:
-      Protandrous:
-      Protogynous:
-      Subandroecious:
-      Subdioecious:
-      Subgynoecious:
-      Synoecious:
-      Trimonoecious:
-      Trioecious:
-      Unisexual:
+      Androdioecious: {}
+      Androecious: {}
+      Androgynomonoecious: {}
+      Androgynous: {}
+      Andromonoecious: {}
+      Bisexual: {}
+      Dichogamous: {}
+      Diclinous: {}
+      Dioecious: {}
+      Gynodioecious: {}
+      Gynoecious: {}
+      Gynomonoecious: {}
+      Hermaphroditic: {}
+      Imperfect: {}
+      Monoclinous: {}
+      Monoecious: {}
+      Perfect: {}
+      Polygamodioecious: {}
+      Polygamomonoecious: {}
+      Polygamous: {}
+      Protandrous: {}
+      Protogynous: {}
+      Subandroecious: {}
+      Subdioecious: {}
+      Subgynoecious: {}
+      Synoecious: {}
+      Trimonoecious: {}
+      Trioecious: {}
+      Unisexual: {}
   PredGenomeStrucEnum:
     permissible_values:
-      non-segmented:
-      segmented:
-      undetermined:
+      non-segmented: {}
+      segmented: {}
+      undetermined: {}
   ProfilePositionEnum:
     permissible_values:
-      backslope:
-      footslope:
-      shoulder:
-      summit:
-      toeslope:
+      backslope: {}
+      footslope: {}
+      shoulder: {}
+      summit: {}
+      toeslope: {}
   QuadPosEnum:
     permissible_values:
-      East side:
-      North side:
-      South side:
-      West side:
+      East side: {}
+      North side: {}
+      South side: {}
+      West side: {}
   RelSampLocEnum:
     permissible_values:
-      center of car:
-      edge of car:
-      under a seat:
+      center of car: {}
+      edge of car: {}
+      under a seat: {}
   RelToOxygenEnum:
     permissible_values:
-      aerobe:
-      anaerobe:
-      facultative:
-      microaerophilic:
-      microanaerobe:
-      obligate aerobe:
-      obligate anaerobe:
+      aerobe: {}
+      anaerobe: {}
+      facultative: {}
+      microaerophilic: {}
+      microanaerobe: {}
+      obligate aerobe: {}
+      obligate anaerobe: {}
   RoomCondtEnum:
     permissible_values:
-      damaged:
-      needs repair:
-      new:
-      rupture:
-      visible signs of mold/mildew:
-      visible wear:
+      damaged: {}
+      needs repair: {}
+      new: {}
+      rupture: {}
+      visible signs of mold/mildew: {}
+      visible wear: {}
   RoomConnectedEnum:
     permissible_values:
-      attic:
-      bathroom:
-      closet:
-      conference room:
-      elevator:
-      examining room:
-      hallway:
-      kitchen:
-      mail room:
-      office:
-      stairwell:
+      attic: {}
+      bathroom: {}
+      closet: {}
+      conference room: {}
+      elevator: {}
+      examining room: {}
+      hallway: {}
+      kitchen: {}
+      mail room: {}
+      office: {}
+      stairwell: {}
   RoomLocEnum:
     permissible_values:
-      corner room:
-      exterior wall:
-      interior room:
+      corner room: {}
+      exterior wall: {}
+      interior room: {}
   RoomSampPosEnum:
     permissible_values:
-      center:
-      east corner:
-      north corner:
-      northeast corner:
-      northwest corner:
-      south corner:
-      southeast corner:
-      southwest corner:
-      west corner:
+      center: {}
+      east corner: {}
+      north corner: {}
+      northeast corner: {}
+      northwest corner: {}
+      south corner: {}
+      southeast corner: {}
+      southwest corner: {}
+      west corner: {}
   RouteTransmissionEnum:
     permissible_values:
-      environmental:faecal-oral:
-      transplacental:
-      vector-borne:vector penetration:
+      environmental:faecal-oral: {}
+      transplacental: {}
+      vector-borne:vector penetration: {}
   SampCaptStatusEnum:
     permissible_values:
-      active surveillance in response to an outbreak:
-      active surveillance not initiated by an outbreak:
-      farm sample:
-      market sample:
-      other:
+      active surveillance in response to an outbreak: {}
+      active surveillance not initiated by an outbreak: {}
+      farm sample: {}
+      market sample: {}
+      other: {}
   SampCollectPointEnum:
     permissible_values:
-      drilling rig:
-      other:
-      separator:
-      storage tank:
-      test well:
-      well:
-      wellhead:
+      drilling rig: {}
+      other: {}
+      separator: {}
+      storage tank: {}
+      test well: {}
+      well: {}
+      wellhead: {}
   SampDisStageEnum:
     permissible_values:
-      dissemination:
-      growth and reproduction:
-      infection:
-      inoculation:
-      other:
-      penetration:
+      dissemination: {}
+      growth and reproduction: {}
+      infection: {}
+      inoculation: {}
+      other: {}
+      penetration: {}
   SampLocConditionEnum:
     permissible_values:
-      damaged:
-      new:
-      rupture:
-      visible signs of mold-mildew:
-      visible weariness repair:
+      damaged: {}
+      new: {}
+      rupture: {}
+      visible signs of mold-mildew: {}
+      visible weariness repair: {}
   SampSubtypeEnum:
     permissible_values:
-      biofilm:
-      not applicable:
-      oil phase:
-      other:
-      water phase:
+      biofilm: {}
+      not applicable: {}
+      oil phase: {}
+      other: {}
+      water phase: {}
   SampSurfMoistureEnum:
     permissible_values:
-      intermittent moisture:
-      not present:
-      submerged:
+      intermittent moisture: {}
+      not present: {}
+      submerged: {}
   SampTransportContEnum:
     permissible_values:
-      bottle:
-      cooler:
-      glass vial:
-      plastic vial:
-      vendor supplied container:
+      bottle: {}
+      cooler: {}
+      glass vial: {}
+      plastic vial: {}
+      vendor supplied container: {}
   SampWeatherEnum:
     permissible_values:
-      clear sky:
-      cloudy:
-      foggy:
-      hail:
-      rain:
-      sleet:
-      snow:
-      sunny:
-      windy:
+      clear sky: {}
+      cloudy: {}
+      foggy: {}
+      hail: {}
+      rain: {}
+      sleet: {}
+      snow: {}
+      sunny: {}
+      windy: {}
   ScLysisApproachEnum:
     permissible_values:
-      chemical:
-      combination:
-      enzymatic:
-      physical:
+      chemical: {}
+      combination: {}
+      enzymatic: {}
+      physical: {}
   SeasonUseEnum:
     permissible_values:
-      Fall:
-      Spring:
-      Summer:
-      Winter:
+      Fall: {}
+      Spring: {}
+      Summer: {}
+      Winter: {}
   SedimentTypeEnum:
     permissible_values:
-      biogenous:
-      cosmogenous:
-      hydrogenous:
-      lithogenous:
+      biogenous: {}
+      cosmogenous: {}
+      hydrogenous: {}
+      lithogenous: {}
   SeqQualityCheckEnum:
     permissible_values:
-      manually edited:
-      none:
+      manually edited: {}
+      none: {}
   ShadingDeviceLocEnum:
     permissible_values:
-      exterior:
-      interior:
+      exterior: {}
+      interior: {}
   ShadingDeviceTypeEnum:
     permissible_values:
-      bahama shutters:
-      exterior roll blind:
-      gambrel awning:
-      hood awning:
-      porchroller awning:
-      sarasota shutters:
-      slatted aluminum:
-      solid aluminum awning:
-      sun screen:
-      tree:
-      trellis:
-      venetian awning:
+      bahama shutters: {}
+      exterior roll blind: {}
+      gambrel awning: {}
+      hood awning: {}
+      porchroller awning: {}
+      sarasota shutters: {}
+      slatted aluminum: {}
+      solid aluminum awning: {}
+      sun screen: {}
+      tree: {}
+      trellis: {}
+      venetian awning: {}
   CompassDirections8Enum:
     permissible_values:
-      east:
-      north:
-      northeast:
-      northwest:
-      south:
-      southeast:
-      southwest:
-      west:
+      east: {}
+      north: {}
+      northeast: {}
+      northwest: {}
+      south: {}
+      southeast: {}
+      southwest: {}
+      west: {}
   MoldVisibilityEnum:
     permissible_values:
-      no presence of mold visible:
-      presence of mold visible:
+      no presence of mold visible: {}
+      presence of mold visible: {}
   DamagedRupturedEnum:
     permissible_values:
-      damaged:
-      needs repair:
-      new:
-      rupture:
-      visible wear:
+      damaged: {}
+      needs repair: {}
+      new: {}
+      rupture: {}
+      visible wear: {}
   DamagedEnum:
     permissible_values:
-      damaged:
-      needs repair:
-      new:
-      rupture:
-      visible wear:
+      damaged: {}
+      needs repair: {}
+      new: {}
+      rupture: {}
+      visible wear: {}
   CeilingWallTextureEnum:
     permissible_values:
-      Santa-Fe texture:
-      crows feet:
-      crows-foot stomp:
-      double skip:
-      hawk and trowel:
-      knockdown:
-      orange peel:
-      popcorn:
-      rosebud stomp:
-      skip trowel:
-      smooth:
-      stomp knockdown:
-      swirl:
+      Santa-Fe texture: {}
+      crows feet: {}
+      crows-foot stomp: {}
+      double skip: {}
+      hawk and trowel: {}
+      knockdown: {}
+      orange peel: {}
+      popcorn: {}
+      rosebud stomp: {}
+      skip trowel: {}
+      smooth: {}
+      stomp knockdown: {}
+      swirl: {}
   GeolAgeEnum:
     permissible_values:
-      Archean:
-      Cambrian:
-      Carboniferous:
-      Cenozoic:
-      Cretaceous:
-      Devonian:
-      Jurassic:
-      Mesozoic:
-      Neogene:
-      Ordovician:
-      Paleogene:
-      Paleozoic:
-      Permian:
-      Precambrian:
-      Proterozoic:
-      Silurian:
-      Triassic:
-      other:
+      Archean: {}
+      Cambrian: {}
+      Carboniferous: {}
+      Cenozoic: {}
+      Cretaceous: {}
+      Devonian: {}
+      Jurassic: {}
+      Mesozoic: {}
+      Neogene: {}
+      Ordovician: {}
+      Paleogene: {}
+      Paleozoic: {}
+      Permian: {}
+      Precambrian: {}
+      Proterozoic: {}
+      Silurian: {}
+      Triassic: {}
+      other: {}
   SoilHorizonEnum:
     permissible_values:
-      A horizon:
-      B horizon:
-      C horizon:
-      E horizon:
-      O horizon:
-      Permafrost:
-      R layer:
+      A horizon: {}
+      B horizon: {}
+      C horizon: {}
+      E horizon: {}
+      O horizon: {}
+      Permafrost: {}
+      R layer: {}
   SoilTextureClassEnum:
     permissible_values:
-      clay:
-      clay loam:
-      loam:
-      loamy sand:
-      sand:
-      sandy clay:
-      sandy clay loam:
-      sandy loam:
-      silt:
-      silt loam:
-      silty clay:
-      silty clay loam:
+      clay: {}
+      clay loam: {}
+      loam: {}
+      loamy sand: {}
+      sand: {}
+      sandy clay: {}
+      sandy clay loam: {}
+      sandy loam: {}
+      silt: {}
+      silt loam: {}
+      silty clay: {}
+      silty clay loam: {}
   SortTechEnum:
     permissible_values:
-      flow cytometric cell sorting:
-      lazer-tweezing:
-      microfluidics:
-      micromanipulation:
-      optical manipulation:
-      other:
+      flow cytometric cell sorting: {}
+      lazer-tweezing: {}
+      microfluidics: {}
+      micromanipulation: {}
+      optical manipulation: {}
+      other: {}
   SpaceTypStateEnum:
     permissible_values:
-      typically occupied:
-      typically unoccupied:
+      typically occupied: {}
+      typically unoccupied: {}
   SpecificEnum:
     permissible_values:
-      as built:
-      bid:
-      construction:
-      design:
-      operation:
-      photos:
+      as built: {}
+      bid: {}
+      construction: {}
+      design: {}
+      operation: {}
+      photos: {}
   SrDepEnvEnum:
     permissible_values:
-      Fluvioldeltaic:
-      Fluviomarine:
-      Lacustine:
-      Marine:
-      other:
+      Fluvioldeltaic: {}
+      Fluviomarine: {}
+      Lacustine: {}
+      Marine: {}
+      other: {}
   SrKerogTypeEnum:
     permissible_values:
-      Type I:
-      Type II:
-      Type III:
-      Type IV:
-      other:
+      Type I: {}
+      Type II: {}
+      Type III: {}
+      Type IV: {}
+      other: {}
   SrLithologyEnum:
     permissible_values:
-      Biosilicieous:
-      Carbonate:
-      Clastic:
-      Coal:
-      other:
+      Biosilicieous: {}
+      Carbonate: {}
+      Clastic: {}
+      Coal: {}
+      other: {}
   SubstructureTypeEnum:
     permissible_values:
-      basement:
-      crawlspace:
-      slab on grade:
+      basement: {}
+      crawlspace: {}
+      slab on grade: {}
   SurfAirContEnum:
     permissible_values:
-      biocides:
-      biological contaminants:
-      dust:
-      nutrients:
-      organic matter:
-      particulate matter:
-      radon:
-      volatile organic compounds:
+      biocides: {}
+      biological contaminants: {}
+      dust: {}
+      nutrients: {}
+      organic matter: {}
+      particulate matter: {}
+      radon: {}
+      volatile organic compounds: {}
   SurfMaterialEnum:
     permissible_values:
-      adobe:
-      carpet:
-      cinder blocks:
-      concrete:
-      glass:
-      hay bales:
-      metal:
-      paint:
-      plastic:
-      stainless steel:
-      stone:
-      stucco:
-      tile:
-      vinyl:
-      wood:
+      adobe: {}
+      carpet: {}
+      cinder blocks: {}
+      concrete: {}
+      glass: {}
+      hay bales: {}
+      metal: {}
+      paint: {}
+      plastic: {}
+      stainless steel: {}
+      stone: {}
+      stucco: {}
+      tile: {}
+      vinyl: {}
+      wood: {}
   SymbiontHostRoleEnum:
     permissible_values:
-      accidental:
-      dead-end:
-      definitive:
-      intermediate:
-      paratenic:
-      reservoir:
-      single host:
+      accidental: {}
+      dead-end: {}
+      definitive: {}
+      intermediate: {}
+      paratenic: {}
+      reservoir: {}
+      single host: {}
   SymLifeCycleTypeEnum:
     permissible_values:
-      complex life cycle:
-      simple life cycle:
+      complex life cycle: {}
+      simple life cycle: {}
   TaxIdentEnum:
     permissible_values:
-      16S rRNA gene:
-      multi-marker approach:
-      other:
+      16S rRNA gene: {}
+      multi-marker approach: {}
+      other: {}
   TidalStageEnum:
     permissible_values:
-      ebb tide:
-      flood tide:
-      high tide:
-      low tide:
+      ebb tide: {}
+      flood tide: {}
+      high tide: {}
+      low tide: {}
   TillageEnum:
     permissible_values:
-      chisel:
-      cutting disc:
-      disc plough:
-      drill:
-      mouldboard:
-      ridge till:
-      strip tillage:
-      tined:
-      zonal tillage:
+      chisel: {}
+      cutting disc: {}
+      disc plough: {}
+      drill: {}
+      mouldboard: {}
+      ridge till: {}
+      strip tillage: {}
+      tined: {}
+      zonal tillage: {}
   TrainLineEnum:
     permissible_values:
-      green:
-      orange:
-      red:
+      green: {}
+      orange: {}
+      red: {}
   TrainStatLocEnum:
     permissible_values:
-      forest hills:
-      riverside:
-      south station above ground:
-      south station amtrak:
-      south station underground:
+      forest hills: {}
+      riverside: {}
+      south station above ground: {}
+      south station amtrak: {}
+      south station underground: {}
   TrainStopLocEnum:
     permissible_values:
-      downtown:
-      end:
-      mid:
+      downtown: {}
+      end: {}
+      mid: {}
   TrophicLevelEnum:
     permissible_values:
-      autotroph:
-      carboxydotroph:
-      chemoautolithotroph:
-      chemoautotroph:
-      chemoheterotroph:
-      chemolithoautotroph:
-      chemolithotroph:
-      chemoorganoheterotroph:
-      chemoorganotroph:
-      chemosynthetic:
-      chemotroph:
-      copiotroph:
-      diazotroph:
-      facultative:
-      heterotroph:
-      lithoautotroph:
-      lithoheterotroph:
-      lithotroph:
-      methanotroph:
-      methylotroph:
-      mixotroph:
-      obligate:
-      oligotroph:
-      organoheterotroph:
-      organotroph:
-      photoautotroph:
-      photoheterotroph:
-      photolithoautotroph:
-      photolithotroph:
-      photosynthetic:
-      phototroph:
+      autotroph: {}
+      carboxydotroph: {}
+      chemoautolithotroph: {}
+      chemoautotroph: {}
+      chemoheterotroph: {}
+      chemolithoautotroph: {}
+      chemolithotroph: {}
+      chemoorganoheterotroph: {}
+      chemoorganotroph: {}
+      chemosynthetic: {}
+      chemotroph: {}
+      copiotroph: {}
+      diazotroph: {}
+      facultative: {}
+      heterotroph: {}
+      lithoautotroph: {}
+      lithoheterotroph: {}
+      lithotroph: {}
+      methanotroph: {}
+      methylotroph: {}
+      mixotroph: {}
+      obligate: {}
+      oligotroph: {}
+      organoheterotroph: {}
+      organotroph: {}
+      photoautotroph: {}
+      photoheterotroph: {}
+      photolithoautotroph: {}
+      photolithotroph: {}
+      photosynthetic: {}
+      phototroph: {}
   TypeOfSymbiosisEnum:
     permissible_values:
-      commensalistic:
-      mutualistic:
-      parasitic:
+      commensalistic: {}
+      mutualistic: {}
+      parasitic: {}
   UrineCollectMethEnum:
     permissible_values:
-      catheter:
-      clean catch:
+      catheter: {}
+      clean catch: {}
   UrobiomSexEnum:
     permissible_values:
-      female:
-      hermaphrodite:
-      male:
-      neuter:
+      female: {}
+      hermaphrodite: {}
+      male: {}
+      neuter: {}
   VirusEnrichApprEnum:
     permissible_values:
-      CsCl density gradient:
-      DNAse:
-      FeCl Precipitation:
-      PEG Precipitation:
-      RNAse:
-      centrifugation:
-      filtration:
-      none:
-      other:
-      targeted sequence capture:
-      ultracentrifugation:
-      ultrafiltration:
+      CsCl density gradient: {}
+      DNAse: {}
+      FeCl Precipitation: {}
+      PEG Precipitation: {}
+      RNAse: {}
+      centrifugation: {}
+      filtration: {}
+      none: {}
+      other: {}
+      targeted sequence capture: {}
+      ultracentrifugation: {}
+      ultrafiltration: {}
   WallConstTypeEnum:
     permissible_values:
-      fire resistive:
-      frame construction:
-      joisted masonry:
-      light noncombustible:
-      masonry noncombustible:
-      modified fire resistive:
+      fire resistive: {}
+      frame construction: {}
+      joisted masonry: {}
+      light noncombustible: {}
+      masonry noncombustible: {}
+      modified fire resistive: {}
   WallFinishMatEnum:
     permissible_values:
-      acoustical treatment:
-      gypsum board:
-      gypsum plaster:
-      masonry:
-      metal:
-      plaster:
-      stone facing:
-      terrazzo:
-      tile:
-      veneer plaster:
-      wood:
+      acoustical treatment: {}
+      gypsum board: {}
+      gypsum plaster: {}
+      masonry: {}
+      metal: {}
+      plaster: {}
+      stone facing: {}
+      terrazzo: {}
+      tile: {}
+      veneer plaster: {}
+      wood: {}
   WallSurfTreatmentEnum:
     permissible_values:
-      fabric:
-      no treatment:
-      painted:
-      paneling:
-      stucco:
-      wall paper:
+      fabric: {}
+      no treatment: {}
+      painted: {}
+      paneling: {}
+      stucco: {}
+      wall paper: {}
   WaterFeatTypeEnum:
     permissible_values:
-      fountain:
-      pool:
-      standing feature:
-      stream:
-      waterfall:
+      fountain: {}
+      pool: {}
+      standing feature: {}
+      stream: {}
+      waterfall: {}
   WeekdayEnum:
     permissible_values:
-      Friday:
-      Monday:
-      Saturday:
-      Sunday:
-      Thursday:
-      Tuesday:
-      Wednesday:
+      Friday: {}
+      Monday: {}
+      Saturday: {}
+      Sunday: {}
+      Thursday: {}
+      Tuesday: {}
+      Wednesday: {}
   WgaAmpApprEnum:
     permissible_values:
-      mda based:
-      pcr based:
+      mda based: {}
+      pcr based: {}
   WindowCoverEnum:
     permissible_values:
-      blinds:
-      curtains:
-      none:
+      blinds: {}
+      curtains: {}
+      none: {}
   WindowHorizPosEnum:
     permissible_values:
-      left:
-      middle:
-      right:
+      left: {}
+      middle: {}
+      right: {}
   WindowMatEnum:
     permissible_values:
-      clad:
-      fiberglass:
-      metal:
-      vinyl:
-      wood:
+      clad: {}
+      fiberglass: {}
+      metal: {}
+      vinyl: {}
+      wood: {}
   WindowStatusEnum:
     permissible_values:
-      closed:
-      open:
+      closed: {}
+      open: {}
   WindowTypeEnum:
     permissible_values:
-      fixed window:
-      horizontal sash window:
-      single-hung sash window:
+      fixed window: {}
+      horizontal sash window: {}
+      single-hung sash window: {}
   WindowVertPosEnum:
     permissible_values:
-      bottom:
-      high:
-      low:
-      middle:
-      top:
+      bottom: {}
+      high: {}
+      low: {}
+      middle: {}
+      top: {}
 slots:
   migs_ba_data:
     description: Data that comply with checklist MigsBa
     title: MigsBa data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_data
-    multivalued: true
     range: MigsBa
+    multivalued: true
     inlined: true
     inlined_as_list: true
   agriculture_data:
     description: Data that comply with Extension Agriculture
     title: Agriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:agriculture_data
-    multivalued: true
     range: Agriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_agriculture_data:
     description: Data that comply with MigsBa combined with Agriculture
     title: MigsBaAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_agriculture_data
-    multivalued: true
     range: MigsBaAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   air_data:
@@ -1174,307 +1175,273 @@ slots:
     title: Air data
     keywords:
       - air
-    domain: MixsCompliantData
     slot_uri: MIXS:air_data
-    multivalued: true
     range: Air
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_air_data:
     description: Data that comply with MigsBa combined with Air
     title: MigsBaAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_air_data
-    multivalued: true
     range: MigsBaAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   built_environment_data:
     description: Data that comply with Extension BuiltEnvironment
     title: BuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:built_environment_data
-    multivalued: true
     range: BuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_built_environment_data:
     description: Data that comply with MigsBa combined with BuiltEnvironment
     title: MigsBaBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_built_environment_data
-    multivalued: true
     range: MigsBaBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   food_animal_and_animal_feed_data:
     description: Data that comply with Extension FoodAnimalAndAnimalFeed
     title: FoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:food_animal_and_animal_feed_data
-    multivalued: true
     range: FoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_food_animal_and_animal_feed_data:
     description: Data that comply with MigsBa combined with FoodAnimalAndAnimalFeed
     title: MigsBaFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_animal_and_animal_feed_data
-    multivalued: true
     range: MigsBaFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   food_farm_environment_data:
     description: Data that comply with Extension FoodFarmEnvironment
     title: FoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:food_farm_environment_data
-    multivalued: true
     range: FoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_food_farm_environment_data:
     description: Data that comply with MigsBa combined with FoodFarmEnvironment
     title: MigsBaFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_farm_environment_data
-    multivalued: true
     range: MigsBaFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   food_food_production_facility_data:
     description: Data that comply with Extension FoodFoodProductionFacility
     title: FoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:food_food_production_facility_data
-    multivalued: true
     range: FoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_food_food_production_facility_data:
     description: Data that comply with MigsBa combined with FoodFoodProductionFacility
     title: MigsBaFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_food_production_facility_data
-    multivalued: true
     range: MigsBaFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   food_human_foods_data:
     description: Data that comply with Extension FoodHumanFoods
     title: FoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:food_human_foods_data
-    multivalued: true
     range: FoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_food_human_foods_data:
     description: Data that comply with MigsBa combined with FoodHumanFoods
     title: MigsBaFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_human_foods_data
-    multivalued: true
     range: MigsBaFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   host_associated_data:
     description: Data that comply with Extension HostAssociated
     title: HostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:host_associated_data
-    multivalued: true
     range: HostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_host_associated_data:
     description: Data that comply with MigsBa combined with HostAssociated
     title: MigsBaHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_host_associated_data
-    multivalued: true
     range: MigsBaHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   human_associated_data:
     description: Data that comply with Extension HumanAssociated
     title: HumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:human_associated_data
-    multivalued: true
     range: HumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_human_associated_data:
     description: Data that comply with MigsBa combined with HumanAssociated
     title: MigsBaHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_associated_data
-    multivalued: true
     range: MigsBaHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   human_gut_data:
     description: Data that comply with Extension HumanGut
     title: HumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:human_gut_data
-    multivalued: true
     range: HumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_human_gut_data:
     description: Data that comply with MigsBa combined with HumanGut
     title: MigsBaHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_gut_data
-    multivalued: true
     range: MigsBaHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   human_oral_data:
     description: Data that comply with Extension HumanOral
     title: HumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:human_oral_data
-    multivalued: true
     range: HumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_human_oral_data:
     description: Data that comply with MigsBa combined with HumanOral
     title: MigsBaHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_oral_data
-    multivalued: true
     range: MigsBaHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   human_skin_data:
     description: Data that comply with Extension HumanSkin
     title: HumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:human_skin_data
-    multivalued: true
     range: HumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_human_skin_data:
     description: Data that comply with MigsBa combined with HumanSkin
     title: MigsBaHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_skin_data
-    multivalued: true
     range: MigsBaHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   human_vaginal_data:
     description: Data that comply with Extension HumanVaginal
     title: HumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:human_vaginal_data
-    multivalued: true
     range: HumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_human_vaginal_data:
     description: Data that comply with MigsBa combined with HumanVaginal
     title: MigsBaHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_vaginal_data
-    multivalued: true
     range: MigsBaHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   hydrocarbon_resources_cores_data:
     description: Data that comply with Extension HydrocarbonResourcesCores
     title: HydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:hydrocarbon_resources_cores_data
-    multivalued: true
     range: HydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsBa combined with HydrocarbonResourcesCores
     title: MigsBaHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MigsBaHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Extension HydrocarbonResourcesFluidsSwabs
     title: HydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: HydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsBa combined with HydrocarbonResourcesFluidsSwabs
     title: MigsBaHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MigsBaHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   microbial_mat_biofilm_data:
     description: Data that comply with Extension MicrobialMatBiofilm
     title: MicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:microbial_mat_biofilm_data
-    multivalued: true
     range: MicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_microbial_mat_biofilm_data:
     description: Data that comply with MigsBa combined with MicrobialMatBiofilm
     title: MigsBaMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_microbial_mat_biofilm_data
-    multivalued: true
     range: MigsBaMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Extension MiscellaneousNaturalOrArtificialEnvironment
     title: MiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsBa combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsBaMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MigsBaMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   plant_associated_data:
     description: Data that comply with Extension PlantAssociated
     title: PlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:plant_associated_data
-    multivalued: true
     range: PlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_plant_associated_data:
     description: Data that comply with MigsBa combined with PlantAssociated
     title: MigsBaPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_plant_associated_data
-    multivalued: true
     range: MigsBaPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   sediment_data:
@@ -1482,19 +1449,17 @@ slots:
     title: Sediment data
     keywords:
       - sediment
-    domain: MixsCompliantData
     slot_uri: MIXS:sediment_data
-    multivalued: true
     range: Sediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_sediment_data:
     description: Data that comply with MigsBa combined with Sediment
     title: MigsBaSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_sediment_data
-    multivalued: true
     range: MigsBaSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   soil_data:
@@ -1502,55 +1467,49 @@ slots:
     title: Soil data
     keywords:
       - soil
-    domain: MixsCompliantData
     slot_uri: MIXS:soil_data
-    multivalued: true
     range: Soil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_soil_data:
     description: Data that comply with MigsBa combined with Soil
     title: MigsBaSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_soil_data
-    multivalued: true
     range: MigsBaSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   symbiont_associated_data:
     description: Data that comply with Extension SymbiontAssociated
     title: SymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:symbiont_associated_data
-    multivalued: true
     range: SymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_symbiont_associated_data:
     description: Data that comply with MigsBa combined with SymbiontAssociated
     title: MigsBaSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_symbiont_associated_data
-    multivalued: true
     range: MigsBaSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   wastewater_sludge_data:
     description: Data that comply with Extension WastewaterSludge
     title: WastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:wastewater_sludge_data
-    multivalued: true
     range: WastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_wastewater_sludge_data:
     description: Data that comply with MigsBa combined with WastewaterSludge
     title: MigsBaWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_wastewater_sludge_data
-    multivalued: true
     range: MigsBaWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   water_data:
@@ -1558,2179 +1517,1937 @@ slots:
     title: Water data
     keywords:
       - water
-    domain: MixsCompliantData
     slot_uri: MIXS:water_data
-    multivalued: true
     range: Water
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_ba_water_data:
     description: Data that comply with MigsBa combined with Water
     title: MigsBaWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_water_data
-    multivalued: true
     range: MigsBaWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_data:
     description: Data that comply with checklist MigsEu
     title: MigsEu data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_data
-    multivalued: true
     range: MigsEu
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_agriculture_data:
     description: Data that comply with MigsEu combined with Agriculture
     title: MigsEuAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_agriculture_data
-    multivalued: true
     range: MigsEuAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_air_data:
     description: Data that comply with MigsEu combined with Air
     title: MigsEuAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_air_data
-    multivalued: true
     range: MigsEuAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_built_environment_data:
     description: Data that comply with MigsEu combined with BuiltEnvironment
     title: MigsEuBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_built_environment_data
-    multivalued: true
     range: MigsEuBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_food_animal_and_animal_feed_data:
     description: Data that comply with MigsEu combined with FoodAnimalAndAnimalFeed
     title: MigsEuFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_animal_and_animal_feed_data
-    multivalued: true
     range: MigsEuFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_food_farm_environment_data:
     description: Data that comply with MigsEu combined with FoodFarmEnvironment
     title: MigsEuFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_farm_environment_data
-    multivalued: true
     range: MigsEuFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_food_food_production_facility_data:
     description: Data that comply with MigsEu combined with FoodFoodProductionFacility
     title: MigsEuFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_food_production_facility_data
-    multivalued: true
     range: MigsEuFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_food_human_foods_data:
     description: Data that comply with MigsEu combined with FoodHumanFoods
     title: MigsEuFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_human_foods_data
-    multivalued: true
     range: MigsEuFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_host_associated_data:
     description: Data that comply with MigsEu combined with HostAssociated
     title: MigsEuHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_host_associated_data
-    multivalued: true
     range: MigsEuHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_human_associated_data:
     description: Data that comply with MigsEu combined with HumanAssociated
     title: MigsEuHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_associated_data
-    multivalued: true
     range: MigsEuHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_human_gut_data:
     description: Data that comply with MigsEu combined with HumanGut
     title: MigsEuHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_gut_data
-    multivalued: true
     range: MigsEuHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_human_oral_data:
     description: Data that comply with MigsEu combined with HumanOral
     title: MigsEuHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_oral_data
-    multivalued: true
     range: MigsEuHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_human_skin_data:
     description: Data that comply with MigsEu combined with HumanSkin
     title: MigsEuHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_skin_data
-    multivalued: true
     range: MigsEuHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_human_vaginal_data:
     description: Data that comply with MigsEu combined with HumanVaginal
     title: MigsEuHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_vaginal_data
-    multivalued: true
     range: MigsEuHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsEu combined with HydrocarbonResourcesCores
     title: MigsEuHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MigsEuHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsEu combined with HydrocarbonResourcesFluidsSwabs
     title: MigsEuHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MigsEuHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_microbial_mat_biofilm_data:
     description: Data that comply with MigsEu combined with MicrobialMatBiofilm
     title: MigsEuMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_microbial_mat_biofilm_data
-    multivalued: true
     range: MigsEuMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsEu combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsEuMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MigsEuMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_plant_associated_data:
     description: Data that comply with MigsEu combined with PlantAssociated
     title: MigsEuPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_plant_associated_data
-    multivalued: true
     range: MigsEuPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_sediment_data:
     description: Data that comply with MigsEu combined with Sediment
     title: MigsEuSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_sediment_data
-    multivalued: true
     range: MigsEuSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_soil_data:
     description: Data that comply with MigsEu combined with Soil
     title: MigsEuSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_soil_data
-    multivalued: true
     range: MigsEuSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_symbiont_associated_data:
     description: Data that comply with MigsEu combined with SymbiontAssociated
     title: MigsEuSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_symbiont_associated_data
-    multivalued: true
     range: MigsEuSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_wastewater_sludge_data:
     description: Data that comply with MigsEu combined with WastewaterSludge
     title: MigsEuWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_wastewater_sludge_data
-    multivalued: true
     range: MigsEuWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_eu_water_data:
     description: Data that comply with MigsEu combined with Water
     title: MigsEuWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_water_data
-    multivalued: true
     range: MigsEuWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_data:
     description: Data that comply with checklist MigsOrg
     title: MigsOrg data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_data
-    multivalued: true
     range: MigsOrg
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_agriculture_data:
     description: Data that comply with MigsOrg combined with Agriculture
     title: MigsOrgAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_agriculture_data
-    multivalued: true
     range: MigsOrgAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_air_data:
     description: Data that comply with MigsOrg combined with Air
     title: MigsOrgAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_air_data
-    multivalued: true
     range: MigsOrgAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_built_environment_data:
     description: Data that comply with MigsOrg combined with BuiltEnvironment
     title: MigsOrgBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_built_environment_data
-    multivalued: true
     range: MigsOrgBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_food_animal_and_animal_feed_data:
     description: Data that comply with MigsOrg combined with FoodAnimalAndAnimalFeed
     title: MigsOrgFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_animal_and_animal_feed_data
-    multivalued: true
     range: MigsOrgFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_food_farm_environment_data:
     description: Data that comply with MigsOrg combined with FoodFarmEnvironment
     title: MigsOrgFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_farm_environment_data
-    multivalued: true
     range: MigsOrgFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_food_food_production_facility_data:
     description: Data that comply with MigsOrg combined with FoodFoodProductionFacility
     title: MigsOrgFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_food_production_facility_data
-    multivalued: true
     range: MigsOrgFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_food_human_foods_data:
     description: Data that comply with MigsOrg combined with FoodHumanFoods
     title: MigsOrgFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_human_foods_data
-    multivalued: true
     range: MigsOrgFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_host_associated_data:
     description: Data that comply with MigsOrg combined with HostAssociated
     title: MigsOrgHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_host_associated_data
-    multivalued: true
     range: MigsOrgHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_human_associated_data:
     description: Data that comply with MigsOrg combined with HumanAssociated
     title: MigsOrgHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_associated_data
-    multivalued: true
     range: MigsOrgHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_human_gut_data:
     description: Data that comply with MigsOrg combined with HumanGut
     title: MigsOrgHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_gut_data
-    multivalued: true
     range: MigsOrgHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_human_oral_data:
     description: Data that comply with MigsOrg combined with HumanOral
     title: MigsOrgHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_oral_data
-    multivalued: true
     range: MigsOrgHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_human_skin_data:
     description: Data that comply with MigsOrg combined with HumanSkin
     title: MigsOrgHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_skin_data
-    multivalued: true
     range: MigsOrgHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_human_vaginal_data:
     description: Data that comply with MigsOrg combined with HumanVaginal
     title: MigsOrgHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_vaginal_data
-    multivalued: true
     range: MigsOrgHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsOrg combined with HydrocarbonResourcesCores
     title: MigsOrgHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MigsOrgHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsOrg combined with HydrocarbonResourcesFluidsSwabs
     title: MigsOrgHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MigsOrgHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_microbial_mat_biofilm_data:
     description: Data that comply with MigsOrg combined with MicrobialMatBiofilm
     title: MigsOrgMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_microbial_mat_biofilm_data
-    multivalued: true
     range: MigsOrgMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsOrg combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsOrgMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MigsOrgMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_plant_associated_data:
     description: Data that comply with MigsOrg combined with PlantAssociated
     title: MigsOrgPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_plant_associated_data
-    multivalued: true
     range: MigsOrgPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_sediment_data:
     description: Data that comply with MigsOrg combined with Sediment
     title: MigsOrgSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_sediment_data
-    multivalued: true
     range: MigsOrgSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_soil_data:
     description: Data that comply with MigsOrg combined with Soil
     title: MigsOrgSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_soil_data
-    multivalued: true
     range: MigsOrgSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_symbiont_associated_data:
     description: Data that comply with MigsOrg combined with SymbiontAssociated
     title: MigsOrgSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_symbiont_associated_data
-    multivalued: true
     range: MigsOrgSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_wastewater_sludge_data:
     description: Data that comply with MigsOrg combined with WastewaterSludge
     title: MigsOrgWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_wastewater_sludge_data
-    multivalued: true
     range: MigsOrgWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_org_water_data:
     description: Data that comply with MigsOrg combined with Water
     title: MigsOrgWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_water_data
-    multivalued: true
     range: MigsOrgWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_data:
     description: Data that comply with checklist MigsPl
     title: MigsPl data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_data
-    multivalued: true
     range: MigsPl
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_agriculture_data:
     description: Data that comply with MigsPl combined with Agriculture
     title: MigsPlAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_agriculture_data
-    multivalued: true
     range: MigsPlAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_air_data:
     description: Data that comply with MigsPl combined with Air
     title: MigsPlAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_air_data
-    multivalued: true
     range: MigsPlAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_built_environment_data:
     description: Data that comply with MigsPl combined with BuiltEnvironment
     title: MigsPlBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_built_environment_data
-    multivalued: true
     range: MigsPlBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_food_animal_and_animal_feed_data:
     description: Data that comply with MigsPl combined with FoodAnimalAndAnimalFeed
     title: MigsPlFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_animal_and_animal_feed_data
-    multivalued: true
     range: MigsPlFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_food_farm_environment_data:
     description: Data that comply with MigsPl combined with FoodFarmEnvironment
     title: MigsPlFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_farm_environment_data
-    multivalued: true
     range: MigsPlFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_food_food_production_facility_data:
     description: Data that comply with MigsPl combined with FoodFoodProductionFacility
     title: MigsPlFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_food_production_facility_data
-    multivalued: true
     range: MigsPlFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_food_human_foods_data:
     description: Data that comply with MigsPl combined with FoodHumanFoods
     title: MigsPlFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_human_foods_data
-    multivalued: true
     range: MigsPlFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_host_associated_data:
     description: Data that comply with MigsPl combined with HostAssociated
     title: MigsPlHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_host_associated_data
-    multivalued: true
     range: MigsPlHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_human_associated_data:
     description: Data that comply with MigsPl combined with HumanAssociated
     title: MigsPlHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_associated_data
-    multivalued: true
     range: MigsPlHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_human_gut_data:
     description: Data that comply with MigsPl combined with HumanGut
     title: MigsPlHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_gut_data
-    multivalued: true
     range: MigsPlHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_human_oral_data:
     description: Data that comply with MigsPl combined with HumanOral
     title: MigsPlHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_oral_data
-    multivalued: true
     range: MigsPlHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_human_skin_data:
     description: Data that comply with MigsPl combined with HumanSkin
     title: MigsPlHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_skin_data
-    multivalued: true
     range: MigsPlHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_human_vaginal_data:
     description: Data that comply with MigsPl combined with HumanVaginal
     title: MigsPlHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_vaginal_data
-    multivalued: true
     range: MigsPlHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsPl combined with HydrocarbonResourcesCores
     title: MigsPlHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MigsPlHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsPl combined with HydrocarbonResourcesFluidsSwabs
     title: MigsPlHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MigsPlHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_microbial_mat_biofilm_data:
     description: Data that comply with MigsPl combined with MicrobialMatBiofilm
     title: MigsPlMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_microbial_mat_biofilm_data
-    multivalued: true
     range: MigsPlMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsPl combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsPlMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MigsPlMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_plant_associated_data:
     description: Data that comply with MigsPl combined with PlantAssociated
     title: MigsPlPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_plant_associated_data
-    multivalued: true
     range: MigsPlPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_sediment_data:
     description: Data that comply with MigsPl combined with Sediment
     title: MigsPlSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_sediment_data
-    multivalued: true
     range: MigsPlSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_soil_data:
     description: Data that comply with MigsPl combined with Soil
     title: MigsPlSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_soil_data
-    multivalued: true
     range: MigsPlSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_symbiont_associated_data:
     description: Data that comply with MigsPl combined with SymbiontAssociated
     title: MigsPlSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_symbiont_associated_data
-    multivalued: true
     range: MigsPlSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_wastewater_sludge_data:
     description: Data that comply with MigsPl combined with WastewaterSludge
     title: MigsPlWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_wastewater_sludge_data
-    multivalued: true
     range: MigsPlWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_pl_water_data:
     description: Data that comply with MigsPl combined with Water
     title: MigsPlWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_water_data
-    multivalued: true
     range: MigsPlWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_data:
     description: Data that comply with checklist MigsVi
     title: MigsVi data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_data
-    multivalued: true
     range: MigsVi
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_agriculture_data:
     description: Data that comply with MigsVi combined with Agriculture
     title: MigsViAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_agriculture_data
-    multivalued: true
     range: MigsViAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_air_data:
     description: Data that comply with MigsVi combined with Air
     title: MigsViAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_air_data
-    multivalued: true
     range: MigsViAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_built_environment_data:
     description: Data that comply with MigsVi combined with BuiltEnvironment
     title: MigsViBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_built_environment_data
-    multivalued: true
     range: MigsViBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_food_animal_and_animal_feed_data:
     description: Data that comply with MigsVi combined with FoodAnimalAndAnimalFeed
     title: MigsViFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_animal_and_animal_feed_data
-    multivalued: true
     range: MigsViFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_food_farm_environment_data:
     description: Data that comply with MigsVi combined with FoodFarmEnvironment
     title: MigsViFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_farm_environment_data
-    multivalued: true
     range: MigsViFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_food_food_production_facility_data:
     description: Data that comply with MigsVi combined with FoodFoodProductionFacility
     title: MigsViFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_food_production_facility_data
-    multivalued: true
     range: MigsViFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_food_human_foods_data:
     description: Data that comply with MigsVi combined with FoodHumanFoods
     title: MigsViFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_human_foods_data
-    multivalued: true
     range: MigsViFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_host_associated_data:
     description: Data that comply with MigsVi combined with HostAssociated
     title: MigsViHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_host_associated_data
-    multivalued: true
     range: MigsViHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_human_associated_data:
     description: Data that comply with MigsVi combined with HumanAssociated
     title: MigsViHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_associated_data
-    multivalued: true
     range: MigsViHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_human_gut_data:
     description: Data that comply with MigsVi combined with HumanGut
     title: MigsViHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_gut_data
-    multivalued: true
     range: MigsViHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_human_oral_data:
     description: Data that comply with MigsVi combined with HumanOral
     title: MigsViHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_oral_data
-    multivalued: true
     range: MigsViHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_human_skin_data:
     description: Data that comply with MigsVi combined with HumanSkin
     title: MigsViHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_skin_data
-    multivalued: true
     range: MigsViHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_human_vaginal_data:
     description: Data that comply with MigsVi combined with HumanVaginal
     title: MigsViHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_vaginal_data
-    multivalued: true
     range: MigsViHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsVi combined with HydrocarbonResourcesCores
     title: MigsViHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MigsViHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsVi combined with HydrocarbonResourcesFluidsSwabs
     title: MigsViHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MigsViHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_microbial_mat_biofilm_data:
     description: Data that comply with MigsVi combined with MicrobialMatBiofilm
     title: MigsViMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_microbial_mat_biofilm_data
-    multivalued: true
     range: MigsViMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsVi combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsViMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MigsViMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_plant_associated_data:
     description: Data that comply with MigsVi combined with PlantAssociated
     title: MigsViPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_plant_associated_data
-    multivalued: true
     range: MigsViPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_sediment_data:
     description: Data that comply with MigsVi combined with Sediment
     title: MigsViSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_sediment_data
-    multivalued: true
     range: MigsViSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_soil_data:
     description: Data that comply with MigsVi combined with Soil
     title: MigsViSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_soil_data
-    multivalued: true
     range: MigsViSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_symbiont_associated_data:
     description: Data that comply with MigsVi combined with SymbiontAssociated
     title: MigsViSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_symbiont_associated_data
-    multivalued: true
     range: MigsViSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_wastewater_sludge_data:
     description: Data that comply with MigsVi combined with WastewaterSludge
     title: MigsViWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_wastewater_sludge_data
-    multivalued: true
     range: MigsViWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   migs_vi_water_data:
     description: Data that comply with MigsVi combined with Water
     title: MigsViWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_water_data
-    multivalued: true
     range: MigsViWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_data:
     description: Data that comply with checklist Mimag
     title: Mimag data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_data
-    multivalued: true
     range: Mimag
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_agriculture_data:
     description: Data that comply with Mimag combined with Agriculture
     title: MimagAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_agriculture_data
-    multivalued: true
     range: MimagAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_air_data:
     description: Data that comply with Mimag combined with Air
     title: MimagAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_air_data
-    multivalued: true
     range: MimagAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_built_environment_data:
     description: Data that comply with Mimag combined with BuiltEnvironment
     title: MimagBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_built_environment_data
-    multivalued: true
     range: MimagBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_food_animal_and_animal_feed_data:
     description: Data that comply with Mimag combined with FoodAnimalAndAnimalFeed
     title: MimagFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_animal_and_animal_feed_data
-    multivalued: true
     range: MimagFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_food_farm_environment_data:
     description: Data that comply with Mimag combined with FoodFarmEnvironment
     title: MimagFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_farm_environment_data
-    multivalued: true
     range: MimagFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_food_food_production_facility_data:
     description: Data that comply with Mimag combined with FoodFoodProductionFacility
     title: MimagFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_food_production_facility_data
-    multivalued: true
     range: MimagFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_food_human_foods_data:
     description: Data that comply with Mimag combined with FoodHumanFoods
     title: MimagFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_human_foods_data
-    multivalued: true
     range: MimagFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_host_associated_data:
     description: Data that comply with Mimag combined with HostAssociated
     title: MimagHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_host_associated_data
-    multivalued: true
     range: MimagHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_human_associated_data:
     description: Data that comply with Mimag combined with HumanAssociated
     title: MimagHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_associated_data
-    multivalued: true
     range: MimagHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_human_gut_data:
     description: Data that comply with Mimag combined with HumanGut
     title: MimagHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_gut_data
-    multivalued: true
     range: MimagHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_human_oral_data:
     description: Data that comply with Mimag combined with HumanOral
     title: MimagHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_oral_data
-    multivalued: true
     range: MimagHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_human_skin_data:
     description: Data that comply with Mimag combined with HumanSkin
     title: MimagHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_skin_data
-    multivalued: true
     range: MimagHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_human_vaginal_data:
     description: Data that comply with Mimag combined with HumanVaginal
     title: MimagHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_vaginal_data
-    multivalued: true
     range: MimagHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_hydrocarbon_resources_cores_data:
     description: Data that comply with Mimag combined with HydrocarbonResourcesCores
     title: MimagHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MimagHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Mimag combined with HydrocarbonResourcesFluidsSwabs
     title: MimagHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MimagHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_microbial_mat_biofilm_data:
     description: Data that comply with Mimag combined with MicrobialMatBiofilm
     title: MimagMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_microbial_mat_biofilm_data
-    multivalued: true
     range: MimagMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Mimag combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimagMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MimagMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_plant_associated_data:
     description: Data that comply with Mimag combined with PlantAssociated
     title: MimagPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_plant_associated_data
-    multivalued: true
     range: MimagPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_sediment_data:
     description: Data that comply with Mimag combined with Sediment
     title: MimagSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_sediment_data
-    multivalued: true
     range: MimagSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_soil_data:
     description: Data that comply with Mimag combined with Soil
     title: MimagSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_soil_data
-    multivalued: true
     range: MimagSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_symbiont_associated_data:
     description: Data that comply with Mimag combined with SymbiontAssociated
     title: MimagSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_symbiont_associated_data
-    multivalued: true
     range: MimagSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_wastewater_sludge_data:
     description: Data that comply with Mimag combined with WastewaterSludge
     title: MimagWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_wastewater_sludge_data
-    multivalued: true
     range: MimagWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimag_water_data:
     description: Data that comply with Mimag combined with Water
     title: MimagWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimag_water_data
-    multivalued: true
     range: MimagWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_data:
     description: Data that comply with checklist MimarksC
     title: MimarksC data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_data
-    multivalued: true
     range: MimarksC
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_agriculture_data:
     description: Data that comply with MimarksC combined with Agriculture
     title: MimarksCAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_agriculture_data
-    multivalued: true
     range: MimarksCAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_air_data:
     description: Data that comply with MimarksC combined with Air
     title: MimarksCAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_air_data
-    multivalued: true
     range: MimarksCAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_built_environment_data:
     description: Data that comply with MimarksC combined with BuiltEnvironment
     title: MimarksCBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_built_environment_data
-    multivalued: true
     range: MimarksCBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_food_animal_and_animal_feed_data:
     description: Data that comply with MimarksC combined with FoodAnimalAndAnimalFeed
     title: MimarksCFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_animal_and_animal_feed_data
-    multivalued: true
     range: MimarksCFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_food_farm_environment_data:
     description: Data that comply with MimarksC combined with FoodFarmEnvironment
     title: MimarksCFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_farm_environment_data
-    multivalued: true
     range: MimarksCFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_food_food_production_facility_data:
     description: Data that comply with MimarksC combined with FoodFoodProductionFacility
     title: MimarksCFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_food_production_facility_data
-    multivalued: true
     range: MimarksCFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_food_human_foods_data:
     description: Data that comply with MimarksC combined with FoodHumanFoods
     title: MimarksCFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_human_foods_data
-    multivalued: true
     range: MimarksCFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_host_associated_data:
     description: Data that comply with MimarksC combined with HostAssociated
     title: MimarksCHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_host_associated_data
-    multivalued: true
     range: MimarksCHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_human_associated_data:
     description: Data that comply with MimarksC combined with HumanAssociated
     title: MimarksCHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_associated_data
-    multivalued: true
     range: MimarksCHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_human_gut_data:
     description: Data that comply with MimarksC combined with HumanGut
     title: MimarksCHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_gut_data
-    multivalued: true
     range: MimarksCHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_human_oral_data:
     description: Data that comply with MimarksC combined with HumanOral
     title: MimarksCHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_oral_data
-    multivalued: true
     range: MimarksCHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_human_skin_data:
     description: Data that comply with MimarksC combined with HumanSkin
     title: MimarksCHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_skin_data
-    multivalued: true
     range: MimarksCHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_human_vaginal_data:
     description: Data that comply with MimarksC combined with HumanVaginal
     title: MimarksCHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_vaginal_data
-    multivalued: true
     range: MimarksCHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_hydrocarbon_resources_cores_data:
     description: Data that comply with MimarksC combined with HydrocarbonResourcesCores
     title: MimarksCHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MimarksCHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MimarksC combined with HydrocarbonResourcesFluidsSwabs
     title: MimarksCHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MimarksCHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_microbial_mat_biofilm_data:
     description: Data that comply with MimarksC combined with MicrobialMatBiofilm
     title: MimarksCMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_microbial_mat_biofilm_data
-    multivalued: true
     range: MimarksCMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MimarksC combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimarksCMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MimarksCMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_plant_associated_data:
     description: Data that comply with MimarksC combined with PlantAssociated
     title: MimarksCPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_plant_associated_data
-    multivalued: true
     range: MimarksCPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_sediment_data:
     description: Data that comply with MimarksC combined with Sediment
     title: MimarksCSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_sediment_data
-    multivalued: true
     range: MimarksCSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_soil_data:
     description: Data that comply with MimarksC combined with Soil
     title: MimarksCSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_soil_data
-    multivalued: true
     range: MimarksCSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_symbiont_associated_data:
     description: Data that comply with MimarksC combined with SymbiontAssociated
     title: MimarksCSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_symbiont_associated_data
-    multivalued: true
     range: MimarksCSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_wastewater_sludge_data:
     description: Data that comply with MimarksC combined with WastewaterSludge
     title: MimarksCWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_wastewater_sludge_data
-    multivalued: true
     range: MimarksCWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_c_water_data:
     description: Data that comply with MimarksC combined with Water
     title: MimarksCWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_water_data
-    multivalued: true
     range: MimarksCWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_data:
     description: Data that comply with checklist MimarksS
     title: MimarksS data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_data
-    multivalued: true
     range: MimarksS
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_agriculture_data:
     description: Data that comply with MimarksS combined with Agriculture
     title: MimarksSAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_agriculture_data
-    multivalued: true
     range: MimarksSAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_air_data:
     description: Data that comply with MimarksS combined with Air
     title: MimarksSAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_air_data
-    multivalued: true
     range: MimarksSAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_built_environment_data:
     description: Data that comply with MimarksS combined with BuiltEnvironment
     title: MimarksSBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_built_environment_data
-    multivalued: true
     range: MimarksSBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_food_animal_and_animal_feed_data:
     description: Data that comply with MimarksS combined with FoodAnimalAndAnimalFeed
     title: MimarksSFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_animal_and_animal_feed_data
-    multivalued: true
     range: MimarksSFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_food_farm_environment_data:
     description: Data that comply with MimarksS combined with FoodFarmEnvironment
     title: MimarksSFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_farm_environment_data
-    multivalued: true
     range: MimarksSFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_food_food_production_facility_data:
     description: Data that comply with MimarksS combined with FoodFoodProductionFacility
     title: MimarksSFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_food_production_facility_data
-    multivalued: true
     range: MimarksSFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_food_human_foods_data:
     description: Data that comply with MimarksS combined with FoodHumanFoods
     title: MimarksSFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_human_foods_data
-    multivalued: true
     range: MimarksSFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_host_associated_data:
     description: Data that comply with MimarksS combined with HostAssociated
     title: MimarksSHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_host_associated_data
-    multivalued: true
     range: MimarksSHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_human_associated_data:
     description: Data that comply with MimarksS combined with HumanAssociated
     title: MimarksSHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_associated_data
-    multivalued: true
     range: MimarksSHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_human_gut_data:
     description: Data that comply with MimarksS combined with HumanGut
     title: MimarksSHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_gut_data
-    multivalued: true
     range: MimarksSHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_human_oral_data:
     description: Data that comply with MimarksS combined with HumanOral
     title: MimarksSHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_oral_data
-    multivalued: true
     range: MimarksSHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_human_skin_data:
     description: Data that comply with MimarksS combined with HumanSkin
     title: MimarksSHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_skin_data
-    multivalued: true
     range: MimarksSHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_human_vaginal_data:
     description: Data that comply with MimarksS combined with HumanVaginal
     title: MimarksSHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_vaginal_data
-    multivalued: true
     range: MimarksSHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_hydrocarbon_resources_cores_data:
     description: Data that comply with MimarksS combined with HydrocarbonResourcesCores
     title: MimarksSHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MimarksSHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MimarksS combined with HydrocarbonResourcesFluidsSwabs
     title: MimarksSHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MimarksSHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_microbial_mat_biofilm_data:
     description: Data that comply with MimarksS combined with MicrobialMatBiofilm
     title: MimarksSMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_microbial_mat_biofilm_data
-    multivalued: true
     range: MimarksSMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MimarksS combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimarksSMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MimarksSMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_plant_associated_data:
     description: Data that comply with MimarksS combined with PlantAssociated
     title: MimarksSPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_plant_associated_data
-    multivalued: true
     range: MimarksSPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_sediment_data:
     description: Data that comply with MimarksS combined with Sediment
     title: MimarksSSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_sediment_data
-    multivalued: true
     range: MimarksSSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_soil_data:
     description: Data that comply with MimarksS combined with Soil
     title: MimarksSSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_soil_data
-    multivalued: true
     range: MimarksSSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_symbiont_associated_data:
     description: Data that comply with MimarksS combined with SymbiontAssociated
     title: MimarksSSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_symbiont_associated_data
-    multivalued: true
     range: MimarksSSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_wastewater_sludge_data:
     description: Data that comply with MimarksS combined with WastewaterSludge
     title: MimarksSWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_wastewater_sludge_data
-    multivalued: true
     range: MimarksSWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mimarks_s_water_data:
     description: Data that comply with MimarksS combined with Water
     title: MimarksSWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_water_data
-    multivalued: true
     range: MimarksSWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_data:
     description: Data that comply with checklist Mims
     title: Mims data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_data
-    multivalued: true
     range: Mims
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_agriculture_data:
     description: Data that comply with Mims combined with Agriculture
     title: MimsAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_agriculture_data
-    multivalued: true
     range: MimsAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_air_data:
     description: Data that comply with Mims combined with Air
     title: MimsAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_air_data
-    multivalued: true
     range: MimsAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_built_environment_data:
     description: Data that comply with Mims combined with BuiltEnvironment
     title: MimsBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_built_environment_data
-    multivalued: true
     range: MimsBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_food_animal_and_animal_feed_data:
     description: Data that comply with Mims combined with FoodAnimalAndAnimalFeed
     title: MimsFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_animal_and_animal_feed_data
-    multivalued: true
     range: MimsFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_food_farm_environment_data:
     description: Data that comply with Mims combined with FoodFarmEnvironment
     title: MimsFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_farm_environment_data
-    multivalued: true
     range: MimsFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_food_food_production_facility_data:
     description: Data that comply with Mims combined with FoodFoodProductionFacility
     title: MimsFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_food_production_facility_data
-    multivalued: true
     range: MimsFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_food_human_foods_data:
     description: Data that comply with Mims combined with FoodHumanFoods
     title: MimsFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_human_foods_data
-    multivalued: true
     range: MimsFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_host_associated_data:
     description: Data that comply with Mims combined with HostAssociated
     title: MimsHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_host_associated_data
-    multivalued: true
     range: MimsHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_human_associated_data:
     description: Data that comply with Mims combined with HumanAssociated
     title: MimsHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_associated_data
-    multivalued: true
     range: MimsHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_human_gut_data:
     description: Data that comply with Mims combined with HumanGut
     title: MimsHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_gut_data
-    multivalued: true
     range: MimsHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_human_oral_data:
     description: Data that comply with Mims combined with HumanOral
     title: MimsHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_oral_data
-    multivalued: true
     range: MimsHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_human_skin_data:
     description: Data that comply with Mims combined with HumanSkin
     title: MimsHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_skin_data
-    multivalued: true
     range: MimsHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_human_vaginal_data:
     description: Data that comply with Mims combined with HumanVaginal
     title: MimsHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_vaginal_data
-    multivalued: true
     range: MimsHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_hydrocarbon_resources_cores_data:
     description: Data that comply with Mims combined with HydrocarbonResourcesCores
     title: MimsHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MimsHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Mims combined with HydrocarbonResourcesFluidsSwabs
     title: MimsHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MimsHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_microbial_mat_biofilm_data:
     description: Data that comply with Mims combined with MicrobialMatBiofilm
     title: MimsMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_microbial_mat_biofilm_data
-    multivalued: true
     range: MimsMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Mims combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimsMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MimsMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_plant_associated_data:
     description: Data that comply with Mims combined with PlantAssociated
     title: MimsPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_plant_associated_data
-    multivalued: true
     range: MimsPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_sediment_data:
     description: Data that comply with Mims combined with Sediment
     title: MimsSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_sediment_data
-    multivalued: true
     range: MimsSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_soil_data:
     description: Data that comply with Mims combined with Soil
     title: MimsSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_soil_data
-    multivalued: true
     range: MimsSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_symbiont_associated_data:
     description: Data that comply with Mims combined with SymbiontAssociated
     title: MimsSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_symbiont_associated_data
-    multivalued: true
     range: MimsSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_wastewater_sludge_data:
     description: Data that comply with Mims combined with WastewaterSludge
     title: MimsWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_wastewater_sludge_data
-    multivalued: true
     range: MimsWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   mims_water_data:
     description: Data that comply with Mims combined with Water
     title: MimsWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:mims_water_data
-    multivalued: true
     range: MimsWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_data:
     description: Data that comply with checklist Misag
     title: Misag data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_data
-    multivalued: true
     range: Misag
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_agriculture_data:
     description: Data that comply with Misag combined with Agriculture
     title: MisagAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_agriculture_data
-    multivalued: true
     range: MisagAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_air_data:
     description: Data that comply with Misag combined with Air
     title: MisagAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_air_data
-    multivalued: true
     range: MisagAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_built_environment_data:
     description: Data that comply with Misag combined with BuiltEnvironment
     title: MisagBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_built_environment_data
-    multivalued: true
     range: MisagBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_food_animal_and_animal_feed_data:
     description: Data that comply with Misag combined with FoodAnimalAndAnimalFeed
     title: MisagFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_animal_and_animal_feed_data
-    multivalued: true
     range: MisagFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_food_farm_environment_data:
     description: Data that comply with Misag combined with FoodFarmEnvironment
     title: MisagFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_farm_environment_data
-    multivalued: true
     range: MisagFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_food_food_production_facility_data:
     description: Data that comply with Misag combined with FoodFoodProductionFacility
     title: MisagFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_food_production_facility_data
-    multivalued: true
     range: MisagFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_food_human_foods_data:
     description: Data that comply with Misag combined with FoodHumanFoods
     title: MisagFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_human_foods_data
-    multivalued: true
     range: MisagFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_host_associated_data:
     description: Data that comply with Misag combined with HostAssociated
     title: MisagHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_host_associated_data
-    multivalued: true
     range: MisagHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_human_associated_data:
     description: Data that comply with Misag combined with HumanAssociated
     title: MisagHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_associated_data
-    multivalued: true
     range: MisagHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_human_gut_data:
     description: Data that comply with Misag combined with HumanGut
     title: MisagHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_gut_data
-    multivalued: true
     range: MisagHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_human_oral_data:
     description: Data that comply with Misag combined with HumanOral
     title: MisagHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_oral_data
-    multivalued: true
     range: MisagHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_human_skin_data:
     description: Data that comply with Misag combined with HumanSkin
     title: MisagHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_skin_data
-    multivalued: true
     range: MisagHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_human_vaginal_data:
     description: Data that comply with Misag combined with HumanVaginal
     title: MisagHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_vaginal_data
-    multivalued: true
     range: MisagHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_hydrocarbon_resources_cores_data:
     description: Data that comply with Misag combined with HydrocarbonResourcesCores
     title: MisagHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MisagHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Misag combined with HydrocarbonResourcesFluidsSwabs
     title: MisagHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MisagHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_microbial_mat_biofilm_data:
     description: Data that comply with Misag combined with MicrobialMatBiofilm
     title: MisagMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_microbial_mat_biofilm_data
-    multivalued: true
     range: MisagMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Misag combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MisagMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MisagMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_plant_associated_data:
     description: Data that comply with Misag combined with PlantAssociated
     title: MisagPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_plant_associated_data
-    multivalued: true
     range: MisagPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_sediment_data:
     description: Data that comply with Misag combined with Sediment
     title: MisagSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_sediment_data
-    multivalued: true
     range: MisagSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_soil_data:
     description: Data that comply with Misag combined with Soil
     title: MisagSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_soil_data
-    multivalued: true
     range: MisagSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_symbiont_associated_data:
     description: Data that comply with Misag combined with SymbiontAssociated
     title: MisagSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_symbiont_associated_data
-    multivalued: true
     range: MisagSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_wastewater_sludge_data:
     description: Data that comply with Misag combined with WastewaterSludge
     title: MisagWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_wastewater_sludge_data
-    multivalued: true
     range: MisagWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   misag_water_data:
     description: Data that comply with Misag combined with Water
     title: MisagWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:misag_water_data
-    multivalued: true
     range: MisagWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_data:
     description: Data that comply with checklist Miuvig
     title: Miuvig data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_data
-    multivalued: true
     range: Miuvig
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_agriculture_data:
     description: Data that comply with Miuvig combined with Agriculture
     title: MiuvigAgriculture data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_agriculture_data
-    multivalued: true
     range: MiuvigAgriculture
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_air_data:
     description: Data that comply with Miuvig combined with Air
     title: MiuvigAir data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_air_data
-    multivalued: true
     range: MiuvigAir
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_built_environment_data:
     description: Data that comply with Miuvig combined with BuiltEnvironment
     title: MiuvigBuiltEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_built_environment_data
-    multivalued: true
     range: MiuvigBuiltEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_food_animal_and_animal_feed_data:
     description: Data that comply with Miuvig combined with FoodAnimalAndAnimalFeed
     title: MiuvigFoodAnimalAndAnimalFeed data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_animal_and_animal_feed_data
-    multivalued: true
     range: MiuvigFoodAnimalAndAnimalFeed
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_food_farm_environment_data:
     description: Data that comply with Miuvig combined with FoodFarmEnvironment
     title: MiuvigFoodFarmEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_farm_environment_data
-    multivalued: true
     range: MiuvigFoodFarmEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_food_food_production_facility_data:
     description: Data that comply with Miuvig combined with FoodFoodProductionFacility
     title: MiuvigFoodFoodProductionFacility data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_food_production_facility_data
-    multivalued: true
     range: MiuvigFoodFoodProductionFacility
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_food_human_foods_data:
     description: Data that comply with Miuvig combined with FoodHumanFoods
     title: MiuvigFoodHumanFoods data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_human_foods_data
-    multivalued: true
     range: MiuvigFoodHumanFoods
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_host_associated_data:
     description: Data that comply with Miuvig combined with HostAssociated
     title: MiuvigHostAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_host_associated_data
-    multivalued: true
     range: MiuvigHostAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_human_associated_data:
     description: Data that comply with Miuvig combined with HumanAssociated
     title: MiuvigHumanAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_associated_data
-    multivalued: true
     range: MiuvigHumanAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_human_gut_data:
     description: Data that comply with Miuvig combined with HumanGut
     title: MiuvigHumanGut data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_gut_data
-    multivalued: true
     range: MiuvigHumanGut
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_human_oral_data:
     description: Data that comply with Miuvig combined with HumanOral
     title: MiuvigHumanOral data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_oral_data
-    multivalued: true
     range: MiuvigHumanOral
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_human_skin_data:
     description: Data that comply with Miuvig combined with HumanSkin
     title: MiuvigHumanSkin data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_skin_data
-    multivalued: true
     range: MiuvigHumanSkin
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_human_vaginal_data:
     description: Data that comply with Miuvig combined with HumanVaginal
     title: MiuvigHumanVaginal data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_vaginal_data
-    multivalued: true
     range: MiuvigHumanVaginal
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_hydrocarbon_resources_cores_data:
     description: Data that comply with Miuvig combined with HydrocarbonResourcesCores
     title: MiuvigHydrocarbonResourcesCores data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_hydrocarbon_resources_cores_data
-    multivalued: true
     range: MiuvigHydrocarbonResourcesCores
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Miuvig combined with HydrocarbonResourcesFluidsSwabs
     title: MiuvigHydrocarbonResourcesFluidsSwabs data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_hydrocarbon_resources_fluids_swabs_data
-    multivalued: true
     range: MiuvigHydrocarbonResourcesFluidsSwabs
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_microbial_mat_biofilm_data:
     description: Data that comply with Miuvig combined with MicrobialMatBiofilm
     title: MiuvigMicrobialMatBiofilm data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_microbial_mat_biofilm_data
-    multivalued: true
     range: MiuvigMicrobialMatBiofilm
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Miuvig combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MiuvigMiscellaneousNaturalOrArtificialEnvironment data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_miscellaneous_natural_or_artificial_environment_data
-    multivalued: true
     range: MiuvigMiscellaneousNaturalOrArtificialEnvironment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_plant_associated_data:
     description: Data that comply with Miuvig combined with PlantAssociated
     title: MiuvigPlantAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_plant_associated_data
-    multivalued: true
     range: MiuvigPlantAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_sediment_data:
     description: Data that comply with Miuvig combined with Sediment
     title: MiuvigSediment data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_sediment_data
-    multivalued: true
     range: MiuvigSediment
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_soil_data:
     description: Data that comply with Miuvig combined with Soil
     title: MiuvigSoil data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_soil_data
-    multivalued: true
     range: MiuvigSoil
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_symbiont_associated_data:
     description: Data that comply with Miuvig combined with SymbiontAssociated
     title: MiuvigSymbiontAssociated data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_symbiont_associated_data
-    multivalued: true
     range: MiuvigSymbiontAssociated
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_wastewater_sludge_data:
     description: Data that comply with Miuvig combined with WastewaterSludge
     title: MiuvigWastewaterSludge data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_wastewater_sludge_data
-    multivalued: true
     range: MiuvigWastewaterSludge
+    multivalued: true
     inlined: true
     inlined_as_list: true
   miuvig_water_data:
     description: Data that comply with Miuvig combined with Water
     title: MiuvigWater data
-    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_water_data
-    multivalued: true
     range: MiuvigWater
+    multivalued: true
     inlined: true
     inlined_as_list: true
   HACCP_term:
@@ -3743,8 +3460,8 @@ slots:
       - food
       - term
     slot_uri: MIXS:0001215
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -3752,10 +3469,12 @@ slots:
       partial_match: true
   IFSAC_category:
     annotations:
-      Expected_value: IFSAC term
+      Expected_value:
+        tag: Expected_value
+        value: IFSAC term
     description: 'The IFSAC food categorization scheme has five distinct levels to
-      which foods can be assigned, depending upon the type of food. First, foods are
-      assigned to one of four food groups (aquatic animals, land animals, plants,
+      which foods can be assigned, depending upon the type of food. First, foods
+      are assigned to one of four food groups (aquatic animals, land animals, plants,
       and other). Food groups include increasingly specific food categories; dairy,
       eggs, meat and poultry, and game are in the land animal food group, and the
       category meat and poultry is further subdivided into more specific categories
@@ -3770,13 +3489,15 @@ slots:
       - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
     keywords:
       - food
-    range: string
     slot_uri: MIXS:0001179
-    multivalued: true
+    range: string
     required: true
+    multivalued: true
   abs_air_humidity:
     annotations:
-      Preferred_unit: gram per gram, kilogram per kilogram, kilogram, pound
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram per gram, kilogram per kilogram, kilogram, pound
     description: Actual mass of water vapor - mh20 - present in the air water vapor
       mixture
     title: absolute air humidity
@@ -3790,7 +3511,7 @@ slots:
     range: string
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -3804,15 +3525,16 @@ slots:
       - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
     in_subset:
       - sequencing
+    slot_uri: MIXS:0000048
+    pattern: ^[ACGTRKSYMWBHDVN]+;[ACGTRKSYMWBHDVN]+$
     structured_pattern:
       syntax: ^{adapter_A_DNA_sequence};{adapter_B_DNA_sequence}$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0000048
   add_recov_method:
     description: Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed
-      for increase of hydrocarbon recovery from resource and start date for each one
-      of them. If "other" is specified, please propose entry in "additional info"
+      for increase of hydrocarbon recovery from resource and start date for each
+      one of them. If "other" is specified, please propose entry in "additional info"
       field
     title: secondary and tertiary recovery methods and start date
     examples:
@@ -3823,15 +3545,17 @@ slots:
       - recover
       - secondary
       - start
-    structured_pattern:
-      syntax: '^({add_recov_methods});{date_time_stamp}$'
-      interpolated: true
-      partial_match: true
     slot_uri: MIXS:0001009
     required: true
+    pattern: ^(Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer
+      Addition|Surfactant Addition|Not Applicable|other);(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$$
+    structured_pattern:
+      syntax: ^({add_recov_methods});{date_time_stamp}$
+      interpolated: true
+      partial_match: true
   additional_info:
-    description: Information that doesn't fit anywhere else. Can also be used to propose
-      new entries for fields with controlled vocabulary
+    description: Information that doesn't fit anywhere else. Can also be used to
+      propose new entries for fields with controlled vocabulary
     title: additional info
     keywords:
       - information
@@ -3840,11 +3564,12 @@ slots:
   address:
     description: The street name and building number where the sampling occurred
     title: address
+    slot_uri: MIXS:0000218
+    pattern: ^[1-9][0-9]* .*}$
     structured_pattern:
       syntax: ^{integer} {text}}$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0000218
   adj_room:
     description: List of rooms (room number, room name) immediately adjacent to the
       sampling room
@@ -3861,7 +3586,9 @@ slots:
       partial_match: true
   adjacent_environment:
     annotations:
-      Expected_value: ENVO_01001110 or ENVO_00000070
+      Expected_value:
+        tag: Expected_value
+        value: ENVO_01001110 or ENVO_00000070
     description: Description of the environmental system or features that are adjacent
       to the sampling site. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110)
       and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple
@@ -3887,19 +3614,22 @@ slots:
     range: AeroStrucEnum
   agrochem_addition:
     annotations:
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Addition of fertilizers, pesticides, etc. - amount and time of applications
     title: history/agrochemical additions
     examples:
       - value: roundup;5 milligram per liter;2018-06-21
     keywords:
       - history
+    slot_uri: MIXS:0000639
+    multivalued: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+);(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$$
     structured_pattern:
       syntax: ^{agrochemical_name};{amount} {unit};{date_time_stamp}$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0000639
-    multivalued: true
   air_PM_concen:
     description: Concentration of substances that remain suspended in the air, and
       comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can
@@ -3912,15 +3642,18 @@ slots:
       - concentration
       - particle
       - particulate
+    slot_uri: MIXS:0000108
+    multivalued: true
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{particulate_matter_name};{float} {unit}$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0000108
-    multivalued: true
   air_flow_impede:
     annotations:
-      Expected_value: enumeration;obstruction type; distance from sampling device
+      Expected_value:
+        tag: Expected_value
+        value: enumeration;obstruction type; distance from sampling device
     description: Presence of objects in the area that would influence or impede air
       flow through the air filter
     title: local air flow impediments
@@ -3933,7 +3666,9 @@ slots:
     multivalued: true
   air_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Temperature of the air at the time of sampling
     title: air temperature
     keywords:
@@ -3942,19 +3677,23 @@ slots:
     slot_uri: MIXS:0000124
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   air_temp_regm:
     annotations:
-      Expected_value: temperature value;treatment interval and duration
-      Preferred_unit: meter
+      Expected_value:
+        tag: Expected_value
+        value: temperature value;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: Information about treatment involving an exposure to varying temperatures;
-      should include the temperature, treatment regimen including how many times the
-      treatment was repeated, how long each treatment lasted, and the start and end
-      time of the entire treatment; can include different temperature regimens
+      should include the temperature, treatment regimen including how many times
+      the treatment was repeated, how long each treatment lasted, and the start and
+      end time of the entire treatment; can include different temperature regimens
     title: air temperature regimen
     examples:
       - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -3967,7 +3706,9 @@ slots:
     multivalued: true
   al_sat:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: Aluminum saturation (esp. For tropical soils)
     title: extreme_unusual_properties/Al saturation
     keywords:
@@ -3978,7 +3719,7 @@ slots:
     slot_uri: MIXS:0000607
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4001,7 +3742,9 @@ slots:
       partial_match: true
   alkalinity:
     annotations:
-      Preferred_unit: milliequivalent per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milliequivalent per liter, milligram per liter
     description: Alkalinity, the ability of a solution to neutralize acids to the
       equivalence point of carbonate or bicarbonate
     title: alkalinity
@@ -4012,7 +3755,7 @@ slots:
     slot_uri: MIXS:0000421
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4035,19 +3778,21 @@ slots:
     slot_uri: MIXS:0000490
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   alt:
     annotations:
-      Preferred_unit: meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: Heights of objects such as airplanes, space shuttles, rockets, atmospheric
       balloons and heights of places such as atmospheric layers and clouds. It is
       used to measure the height of an object which is above the earth's surface.
-      In this context, the altitude measurement is the vertical distance between the
-      earth's surface above sea level and the sampled position in the air
+      In this context, the altitude measurement is the vertical distance between
+      the earth's surface above sea level and the sampled position in the air
     title: altitude
     examples:
       - value: 100 meter
@@ -4056,14 +3801,16 @@ slots:
     slot_uri: MIXS:0000094
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   aminopept_act:
     annotations:
-      Preferred_unit: mole per liter per hour
+      Preferred_unit:
+        tag: Preferred_unit
+        value: mole per liter per hour
     description: Measurement of aminopeptidase activity
     title: aminopeptidase activity
     examples:
@@ -4071,14 +3818,16 @@ slots:
     slot_uri: MIXS:0000172
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ammonium:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: Concentration of ammonium in the sample
     title: ammonium
     examples:
@@ -4086,7 +3835,7 @@ slots:
     slot_uri: MIXS:0000427
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4098,7 +3847,9 @@ slots:
     range: string
   amount_light:
     annotations:
-      Preferred_unit: lux, lumens per square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: lux, lumens per square meter
     description: The unit of illuminance and luminous emittance, measuring luminous
       flux per unit area
     title: amount of light
@@ -4107,7 +3858,7 @@ slots:
     slot_uri: MIXS:0000140
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4122,9 +3873,10 @@ slots:
     slot_uri: MIXS:0000247
     range: string
   anim_water_method:
-    description: Description of the equipment or method used to distribute water to
-      livestock. This field accepts termed listed under water delivery equipment (http://opendata.inra.fr/EOL/EOL_0001653).
-      Multiple terms can be separated by pipes
+    description: Description of the equipment or method used to distribute water
+      to livestock. This field accepts termed listed under water delivery equipment
+      (http://opendata.inra.fr/EOL/EOL_0001653). Multiple terms can be separated
+      by pipes
     title: animal water delivery method
     examples:
       - value: water trough [EOL:0001618]
@@ -4134,16 +3886,16 @@ slots:
       - method
       - water
     slot_uri: MIXS:0001115
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
       interpolated: true
       partial_match: true
   animal_am:
-    description: The name(s) (generic or brand) of the antimicrobial(s) given to the
-      food animal within the last 30 days
+    description: The name(s) (generic or brand) of the antimicrobial(s) given to
+      the food animal within the last 30 days
     title: food animal antimicrobial
     examples:
       - value: tetracycline
@@ -4165,14 +3917,15 @@ slots:
       - duration
       - food
       - period
+    slot_uri: MIXS:0001244
+    pattern: ^[-+]?[0-9]*\.?[0-9]+ days$
     structured_pattern:
       syntax: ^{float} days$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0001244
   animal_am_freq:
-    description: The frequency per day that the antimicrobial was administered to the
-      food animal
+    description: The frequency per day that the antimicrobial was administered to
+      the food animal
     title: food animal antimicrobial frequency
     examples:
       - value: '1.5'
@@ -4184,7 +3937,7 @@ slots:
     slot_uri: MIXS:0001245
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4232,9 +3985,11 @@ slots:
     range: AnimalBodyCondEnum
   animal_diet:
     annotations:
-      Expected_value: text or FOODON_03309997
-    description: If the isolate is from a food animal, the type of diet eaten by the
-      food animal.  Please list the main food staple and the setting, if appropriate.  For
+      Expected_value:
+        tag: Expected_value
+        value: text or FOODON_03309997
+    description: If the isolate is from a food animal, the type of diet eaten by
+      the food animal.  Please list the main food staple and the setting, if appropriate.  For
       a list of acceptable animal feed terms or categories, please see http://www.feedipedia.org.  Multiple
       terms may apply and can be separated by pipes |Food product for animal covers
       foods intended for consumption by domesticated animals. Consult http://purl.obolibrary.org/obo/FOODON_03309997.
@@ -4249,12 +4004,14 @@ slots:
       - diet
       - food
       - source
-    range: string
     slot_uri: MIXS:0001130
+    range: string
     multivalued: true
   animal_feed_equip:
     annotations:
-      Expected_value: EOL:0001757
+      Expected_value:
+        tag: Expected_value
+        value: EOL:0001757
     description: Description of the feeding equipment used for livestock. This field
       accepts terms listed under feed delivery (http://opendata.inra.fr/EOL/EOL_0001757).
       Multiple terms can be separated by pipes
@@ -4264,12 +4021,13 @@ slots:
     keywords:
       - animal
       - equipment
+    slot_uri: MIXS:0001113
+    multivalued: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0001113
-    multivalued: true
   animal_group_size:
     description: The number of food animals of the same species that are maintained
       together as a unit, i.e. a herd or flock
@@ -4291,8 +4049,8 @@ slots:
     keywords:
       - animal
     slot_uri: MIXS:0001180
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -4313,8 +4071,8 @@ slots:
       - sample
       - source
     slot_uri: MIXS:0001114
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -4333,7 +4091,9 @@ slots:
     range: AnimalSexEnum
   annot:
     annotations:
-      Expected_value: name of tool or pipeline used, or annotation source description
+      Expected_value:
+        tag: Expected_value
+        value: name of tool or pipeline used, or annotation source description
     description: Tool used for annotation, or for cases where annotation was provided
       by a community jamboree or model organism database rather than by a specific
       submitter
@@ -4342,11 +4102,13 @@ slots:
       - value: prokka
     in_subset:
       - sequencing
-    range: string
     slot_uri: MIXS:0000059
+    range: string
   annual_precpt:
     annotations:
-      Preferred_unit: millimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millimeter
     description: The average of all annual precipitation values known, or an estimated
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean annual precipitation
@@ -4355,14 +4117,16 @@ slots:
     slot_uri: MIXS:0000644
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   annual_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Mean annual temperature
     title: mean annual temperature
     examples:
@@ -4373,15 +4137,19 @@ slots:
     slot_uri: MIXS:0000642
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   antibiotic_regm:
     annotations:
-      Expected_value: antibiotic name;antibiotic amount;treatment interval and duration
-      Preferred_unit: milligram
+      Expected_value:
+        tag: Expected_value
+        value: antibiotic name;antibiotic amount;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram
     description: Information about treatment involving antibiotic administration;
       should include the name of antibiotic, amount administered, treatment regimen
       including how many times the treatment was repeated, how long each treatment
@@ -4397,7 +4165,9 @@ slots:
     multivalued: true
   api:
     annotations:
-      Preferred_unit: degrees API
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degrees API
     description: 'API gravity is a measure of how heavy or light a petroleum liquid
       is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g.
       31.1   API)'
@@ -4408,7 +4178,7 @@ slots:
     range: string
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4423,8 +4193,12 @@ slots:
     range: ArchStrucEnum
   area_samp_size:
     annotations:
-      Expected_value: measurement value
-      Preferred_unit: centimeter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: centimeter
     description: The total amount or size (volume (ml), mass (g) or area (m2) ) of
       sample collected
     title: area sampled size
@@ -4438,41 +4212,47 @@ slots:
     slot_uri: MIXS:0001255
   aromatics_pc:
     annotations:
-      Preferred_unit: percent
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
-      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
+      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: aromatics wt%
     slot_uri: MIXS:0000133
     range: string
     recommended: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   asphaltenes_pc:
     annotations:
-      Preferred_unit: percent
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
-      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
+      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: asphaltenes wt%
     slot_uri: MIXS:0000135
     range: string
     recommended: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   assembly_name:
     annotations:
-      Expected_value: name and version of assembly
+      Expected_value:
+        tag: Expected_value
+        value: name and version of assembly
     description: Name/version of the assembly provided by the submitter that is used
       in the genome browsers and in the community
     title: assembly name
@@ -4487,21 +4267,20 @@ slots:
       for each assembly quality category. For MISAG/MIMAG; Finished: Single, validated,
       contiguous sequence per replicon without gaps or ambiguities with a consensus
       error rate equivalent to Q50 or better. High Quality Draft:Multiple fragments
-      where gaps span repetitive regions. Presence of the large subunit (LSU) RNA, small
-      subunit (SSU) and the presence of 5.8S rRNA or 5S rRNA depending on whether it is
-      a eukaryotic or prokaryotic genome, respectively.
-      Medium Quality Draft:Many fragments with little to no
-      review of assembly other than reporting of standard assembly statistics. Low
-      Quality Draft:Many fragments with little to no review of assembly other than
-      reporting of standard assembly statistics. Assembly statistics include, but
-      are not limited to total assembly size, number of contigs, contig N50/L50, and
-      maximum contig length. For MIUVIG; Finished: Single, validated, contiguous sequence
-      per replicon without gaps or ambiguities, with extensive manual review and editing
-      to annotate putative gene functions and transcriptional units. High-quality
-      draft genome: One or multiple fragments, totaling   90% of the expected genome
-      or replicon sequence or predicted complete. Genome fragment(s): One or multiple
-      fragments, totalling < 90% of the expected genome or replicon sequence, or for
-      which no genome size could be estimated'
+      where gaps span repetitive regions. Presence of the large subunit (LSU) RNA,
+      small subunit (SSU) and the presence of 5.8S rRNA or 5S rRNA depending on whether
+      it is a eukaryotic or prokaryotic genome, respectively. Medium Quality Draft:Many
+      fragments with little to no review of assembly other than reporting of standard
+      assembly statistics. Low Quality Draft:Many fragments with little to no review
+      of assembly other than reporting of standard assembly statistics. Assembly
+      statistics include, but are not limited to total assembly size, number of contigs,
+      contig N50/L50, and maximum contig length. For MIUVIG; Finished: Single, validated,
+      contiguous sequence per replicon without gaps or ambiguities, with extensive
+      manual review and editing to annotate putative gene functions and transcriptional
+      units. High-quality draft genome: One or multiple fragments, totaling   90%
+      of the expected genome or replicon sequence or predicted complete. Genome fragment(s):
+      One or multiple fragments, totalling < 90% of the expected genome or replicon
+      sequence, or for which no genome size could be estimated'
     title: assembly quality
     examples:
       - value: High-quality draft genome
@@ -4509,13 +4288,14 @@ slots:
       - sequencing
     keywords:
       - quality
-    range: AssemblyQualEnum
     slot_uri: MIXS:0000056
+    range: AssemblyQualEnum
   assembly_software:
     description: Tool(s) used for assembly, including version number and parameters
     title: assembly software
     examples:
-      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
+      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters
+          otherwise
     in_subset:
       - sequencing
     keywords:
@@ -4529,7 +4309,9 @@ slots:
       partial_match: true
   associated_resource:
     annotations:
-      Expected_value: reference to resource
+      Expected_value:
+        tag: Expected_value
+        value: reference to resource
     description: A related resource that is referenced, cited, or otherwise associated
       to the sequence
     title: relevant electronic resources
@@ -4541,11 +4323,13 @@ slots:
       - resource
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000091
-    multivalued: true
     recommended: true
+    multivalued: true
   association_duration:
     annotations:
-      Preferred_unit: year, day, hour
+      Preferred_unit:
+        tag: Preferred_unit
+        value: year, day, hour
     description: Time spent in host of the symbiotic organism at the time of sampling;
       relevant scale depends on symbiotic organism and study
     title: duration of association with the host
@@ -4557,14 +4341,16 @@ slots:
     slot_uri: MIXS:0001299
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   atmospheric_data:
     annotations:
-      Expected_value: atmospheric data name;measurement value
+      Expected_value:
+        tag: Expected_value
+        value: atmospheric data name;measurement value
     description: Measurement of atmospheric data; can include multiple data
     title: atmospheric data
     examples:
@@ -4574,7 +4360,9 @@ slots:
     multivalued: true
   avg_dew_point:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: The average of dew point measures taken at the beginning of every
       hour over a 24 hour period on the sampling day
     title: average dew point
@@ -4585,7 +4373,7 @@ slots:
     slot_uri: MIXS:0000141
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4600,7 +4388,9 @@ slots:
     range: float
   avg_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: The average of temperatures taken at the beginning of every hour
       over a 24 hour period on the sampling day
     title: average temperature
@@ -4612,14 +4402,16 @@ slots:
     slot_uri: MIXS:0000142
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bac_prod:
     annotations:
-      Preferred_unit: milligram per cubic meter per day
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per cubic meter per day
     description: Bacterial production in the water column measured by isotope uptake
     title: bacterial production
     examples:
@@ -4629,14 +4421,17 @@ slots:
     slot_uri: MIXS:0000683
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bac_resp:
     annotations:
-      Preferred_unit: milligram per cubic meter per day, micromole oxygen per liter per hour
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per cubic meter per day, micromole oxygen per liter per
+          hour
     description: Measurement of bacterial respiration in the water column
     title: bacterial respiration
     examples:
@@ -4644,7 +4439,7 @@ slots:
     slot_uri: MIXS:0000684
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4660,15 +4455,17 @@ slots:
     slot_uri: MIXS:0000173
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bacterial_density:
     annotations:
-      Preferred_unit: colony forming units per milliliter; colony forming units per gram
-        of dry weight
+      Preferred_unit:
+        tag: Preferred_unit
+        value: colony forming units per milliliter; colony forming units per gram
+          of dry weight
     description: Number of bacteria in sample, as defined by bacteria density (http://purl.obolibrary.org/obo/GENEPIO_0000043)
     title: bacteria density
     examples:
@@ -4678,14 +4475,16 @@ slots:
     slot_uri: MIXS:0001194
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   barometric_press:
     annotations:
-      Preferred_unit: millibar
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millibar
     description: Force per unit area exerted against a surface by the weight of air
       above that surface
     title: barometric pressure
@@ -4696,7 +4495,7 @@ slots:
     slot_uri: MIXS:0000096
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4729,14 +4528,16 @@ slots:
     range: integer
   benzene:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of benzene in the sample
     title: benzene
     slot_uri: MIXS:0000153
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4758,7 +4559,9 @@ slots:
     range: BinParamEnum
   bin_software:
     annotations:
-      Expected_value: names and versions of software(s) used
+      Expected_value:
+        tag: Expected_value
+        value: names and versions of software(s) used
     description: Tool(s) used for the extraction of genomes from metagenomic datasets,
       where possible include a product ID (PID) of the tool(s) used
     title: binning software
@@ -4772,24 +4575,28 @@ slots:
     slot_uri: MIXS:0000078
   biochem_oxygen_dem:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Amount of dissolved oxygen needed by aerobic biological organisms
-      in a body of water to break down organic material present in a given water sample
-      at certain temperature over a specific time period
+      in a body of water to break down organic material present in a given water
+      sample at certain temperature over a specific time period
     title: biochemical oxygen demand
     keywords:
       - oxygen
     slot_uri: MIXS:0000653
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   biocide:
     annotations:
-      Expected_value: name;name;timestamp
+      Expected_value:
+        tag: Expected_value
+        value: name;name;timestamp
     description: List of biocides (commercial name of product and supplier) and date
       of administration
     title: biocide administration
@@ -4802,11 +4609,15 @@ slots:
     recommended: true
   biocide_admin_method:
     annotations:
-      Expected_value: measurement value;frequency;duration;duration
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value;frequency;duration;duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Method of biocide administration (dose, frequency, duration, time
-      elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr; 3
-      days)
+      elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr;
+      3 days)
     title: biocide administration method
     keywords:
       - administration
@@ -4816,19 +4627,21 @@ slots:
     recommended: true
   biocide_used:
     annotations:
-      Expected_value: commercial name of biocide, active ingredient in biocide or class of
-        biocide
+      Expected_value:
+        tag: Expected_value
+        value: commercial name of biocide, active ingredient in biocide or class
+          of biocide
     description: Substance intended for preventing, neutralizing, destroying, repelling,
       or mitigating the effects of any pest or microorganism; that inhibits the growth,
-      reproduction, and activity of organisms, including fungal cells; decreases the
-      number of fungi or pests present; deters microbial growth and degradation of
-      other ingredients in the formulation. Indicate the biocide used on the location
+      reproduction, and activity of organisms, including fungal cells; decreases
+      the number of fungi or pests present; deters microbial growth and degradation
+      of other ingredients in the formulation. Indicate the biocide used on the location
       where the sample was taken. Multiple terms can be separated by pipes
     title: biocide
     examples:
       - value: Quaternary ammonium compound|SterBac
-    range: string
     slot_uri: MIXS:0001258
+    range: string
     multivalued: true
   biol_stat:
     description: The level of genome modification
@@ -4837,12 +4650,16 @@ slots:
       - value: natural
     keywords:
       - status
-    range: BiolStatEnum
     slot_uri: MIXS:0000858
+    range: BiolStatEnum
   biomass:
     annotations:
-      Expected_value: biomass type;measurement value
-      Preferred_unit: ton, kilogram, gram
+      Expected_value:
+        tag: Expected_value
+        value: biomass type;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: ton, kilogram, gram
     description: Amount of biomass; should include the name for the part of biomass
       measured, e.g. Microbial, total. Can include multiple measurements
     title: biomass
@@ -4854,21 +4671,21 @@ slots:
     slot_uri: MIXS:0000174
     multivalued: true
   biotic_regm:
-    description: Information about treatment(s) involving use of biotic factors, such
-      as bacteria, viruses or fungi
+    description: Information about treatment(s) involving use of biotic factors,
+      such as bacteria, viruses or fungi
     title: biotic regimen
     examples:
       - value: sample inoculated with Rhizobium spp. Culture
     keywords:
       - regimen
     slot_uri: MIXS:0001038
-    multivalued: true
     range: string
+    multivalued: true
   biotic_relationship:
-    description: Description of relationship(s) between the subject organism and other
-      organism(s) it is associated with. E.g., parasite on species X; mutualist with
-      species Y. The target organism is the subject of the relationship, and the other
-      organism(s) is the object
+    description: Description of relationship(s) between the subject organism and
+      other organism(s) it is associated with. E.g., parasite on species X; mutualist
+      with species Y. The target organism is the subject of the relationship, and
+      the other organism(s) is the object
     title: observed biotic relationship
     examples:
       - value: free living
@@ -4881,14 +4698,18 @@ slots:
     range: BioticRelationshipEnum
   birth_control:
     annotations:
-      Expected_value: medication name
+      Expected_value:
+        tag: Expected_value
+        value: medication name
     description: Specification of birth control medication used
     title: birth control
-    range: string
     slot_uri: MIXS:0000286
+    range: string
   bishomohopanol:
     annotations:
-      Preferred_unit: microgram per liter, microgram per gram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, microgram per gram
     description: Concentration of bishomohopanol
     title: bishomohopanol
     examples:
@@ -4896,7 +4717,7 @@ slots:
     slot_uri: MIXS:0000175
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4909,11 +4730,13 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000271
-    multivalued: true
     range: string
+    multivalued: true
   blood_press_diast:
     annotations:
-      Preferred_unit: millimeter mercury
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millimeter mercury
     description: Resting diastolic blood pressure, measured as mm mercury
     title: host blood pressure diastolic
     keywords:
@@ -4923,14 +4746,16 @@ slots:
     slot_uri: MIXS:0000258
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   blood_press_syst:
     annotations:
-      Preferred_unit: millimeter mercury
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millimeter mercury
     description: Resting systolic blood pressure, measured as mm mercury
     title: host blood pressure systolic
     keywords:
@@ -4940,14 +4765,16 @@ slots:
     slot_uri: MIXS:0000259
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bromide:
     annotations:
-      Preferred_unit: parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: parts per million
     description: Concentration of bromide
     title: bromide
     examples:
@@ -4955,7 +4782,7 @@ slots:
     slot_uri: MIXS:0000176
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4970,17 +4797,17 @@ slots:
     slot_uri: MIXS:0000787
     range: BuildDocsEnum
   build_occup_type:
-    description: The primary function for which a building or discrete part of a building
-      is intended to be used
+    description: The primary function for which a building or discrete part of a
+      building is intended to be used
     title: building occupancy type
     examples:
       - value: market
     keywords:
       - type
     slot_uri: MIXS:0000761
-    multivalued: true
     range: BuildOccupTypeEnum
     required: true
+    multivalued: true
   building_setting:
     description: A location (geography) where a building is set
     title: building setting
@@ -4991,7 +4818,9 @@ slots:
     required: true
   built_struc_age:
     annotations:
-      Preferred_unit: year
+      Preferred_unit:
+        tag: Preferred_unit
+        value: year
     description: The age of the built structure since construction
     title: built structure age
     examples:
@@ -5001,7 +4830,7 @@ slots:
     slot_uri: MIXS:0000145
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5024,7 +4853,9 @@ slots:
     range: string
   calcium:
     annotations:
-      Preferred_unit: milligram per liter, micromole per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, micromole per liter, parts per million
     description: Concentration of calcium in the sample
     title: calcium
     examples:
@@ -5032,14 +4863,16 @@ slots:
     slot_uri: MIXS:0000432
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   carb_dioxide:
     annotations:
-      Preferred_unit: micromole per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, parts per million
     description: Carbon dioxide (gas) amount or concentration at the time of sampling
     title: carbon dioxide
     examples:
@@ -5049,14 +4882,16 @@ slots:
     slot_uri: MIXS:0000097
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   carb_monoxide:
     annotations:
-      Preferred_unit: micromole per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, parts per million
     description: Carbon monoxide (gas) amount or concentration at the time of sampling
     title: carbon monoxide
     examples:
@@ -5066,14 +4901,16 @@ slots:
     slot_uri: MIXS:0000098
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   carb_nitro_ratio:
     annotations:
-      Expected_value: measurement value
+      Expected_value:
+        tag: Expected_value
+        value: measurement value
     description: Ratio of amount or concentrations of carbon to nitrogen
     title: carbon/nitrogen ratio
     examples:
@@ -5087,7 +4924,9 @@ slots:
     range: float
   ceil_area:
     annotations:
-      Preferred_unit: square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square meter
     description: The area of the ceiling space within the room
     title: ceiling area
     examples:
@@ -5098,7 +4937,7 @@ slots:
     slot_uri: MIXS:0000148
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5145,7 +4984,9 @@ slots:
     range: CeilingWallTextureEnum
   ceil_thermal_mass:
     annotations:
-      Preferred_unit: joule per degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: joule per degree Celsius
     description: The ability of the ceiling to provide inertia against temperature
       fluctuations. Generally this means concrete that is exposed. A metal deck that
       supports a concrete slab will act thermally as long as it is exposed to room
@@ -5157,7 +4998,7 @@ slots:
     slot_uri: MIXS:0000143
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5183,7 +5024,9 @@ slots:
     range: MoldVisibilityEnum
   chem_administration:
     annotations:
-      Expected_value: CHEBI;timestamp
+      Expected_value:
+        tag: Expected_value
+        value: CHEBI;timestamp
     description: List of chemical compounds administered to the host or site where
       sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can
       include multiple compounds. For chemical entities of biological interest ontology
@@ -5198,12 +5041,16 @@ slots:
     multivalued: true
   chem_mutagen:
     annotations:
-      Expected_value: mutagen name;mutagen amount;treatment interval and duration
-      Preferred_unit: milligram per liter
-    description: Treatment involving use of mutagens; should include the name of mutagen,
-      amount administered, treatment regimen including how many times the treatment
-      was repeated, how long each treatment lasted, and the start and end time of
-      the entire treatment; can include multiple mutagen regimens
+      Expected_value:
+        tag: Expected_value
+        value: mutagen name;mutagen amount;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
+    description: Treatment involving use of mutagens; should include the name of
+      mutagen, amount administered, treatment regimen including how many times the
+      treatment was repeated, how long each treatment lasted, and the start and end
+      time of the entire treatment; can include multiple mutagen regimens
     title: chemical mutagen
     examples:
       - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -5212,25 +5059,31 @@ slots:
     multivalued: true
   chem_oxygen_dem:
     annotations:
-      Preferred_unit: milligram per liter
-    description: A measure of the capacity of water to consume oxygen during the decomposition
-      of organic matter and the oxidation of inorganic chemicals such as ammonia and
-      nitrite
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
+    description: A measure of the capacity of water to consume oxygen during the
+      decomposition of organic matter and the oxidation of inorganic chemicals such
+      as ammonia and nitrite
     title: chemical oxygen demand
     keywords:
       - oxygen
     slot_uri: MIXS:0000656
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   chem_treat_method:
     annotations:
-      Expected_value: measurement value;frequency;duration;duration
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value;frequency;duration;duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Method of chemical administration(dose, frequency, duration, time
       elapsed between administration and sampling) (e.g. 50 mg/l; twice a week; 1
       hr; 0 days)
@@ -5242,11 +5095,13 @@ slots:
     slot_uri: MIXS:0000457
   chem_treatment:
     annotations:
-      Expected_value: name;name;timestamp
+      Expected_value:
+        tag: Expected_value
+        value: name;name;timestamp
     description: List of chemical compounds administered upstream the sampling location
       where sampling occurred (e.g. Glycols, H2S scavenger, corrosion and scale inhibitors,
-      demulsifiers, and other production chemicals etc.). The commercial name of the
-      product and name of the supplier should be provided. The date of administration
+      demulsifiers, and other production chemicals etc.). The commercial name of
+      the product and name of the supplier should be provided. The date of administration
       should also be included
     title: chemical treatment
     examples:
@@ -5256,9 +5111,9 @@ slots:
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001012
   chimera_check:
-    description: Tool(s) used for chimera checking, including version number and parameters,
-      to discover and remove chimeric sequences. A chimeric sequence is comprised
-      of two or more phylogenetically distinct parent sequences
+    description: Tool(s) used for chimera checking, including version number and
+      parameters, to discover and remove chimeric sequences. A chimeric sequence
+      is comprised of two or more phylogenetically distinct parent sequences
     title: chimera check software
     examples:
       - value: uchime;v4.1;default parameters
@@ -5275,7 +5130,9 @@ slots:
       partial_match: true
   chloride:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of chloride in the sample
     title: chloride
     examples:
@@ -5283,14 +5140,16 @@ slots:
     slot_uri: MIXS:0000429
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   chlorophyll:
     annotations:
-      Preferred_unit: milligram per cubic meter, microgram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per cubic meter, microgram per liter
     description: Concentration of chlorophyll
     title: chlorophyll
     examples:
@@ -5298,27 +5157,29 @@ slots:
     slot_uri: MIXS:0000177
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   climate_environment:
     description: Treatment involving an exposure to a particular climate; treatment
-      regimen including how many times the treatment was repeated, how long each treatment
-      lasted, and the start and end time of the entire treatment; can include multiple
-      climates
+      regimen including how many times the treatment was repeated, how long each
+      treatment lasted, and the start and end time of the entire treatment; can include
+      multiple climates
     title: climate environment
     examples:
       - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
       - environment
     slot_uri: MIXS:0001040
-    multivalued: true
     range: string
+    multivalued: true
   coll_site_geo_feat:
     annotations:
-      Expected_value: ENVO:00000002 or ENVO:00000070
+      Expected_value:
+        tag: Expected_value
+        value: ENVO:00000002 or ENVO:00000070
     description: 'Text or terms that describe the geographic feature where the food
       sample was obtained by the researcher. This field accepts selected terms listed
       under the following ontologies: anthropogenic geographic feature (http://purl.obolibrary.org/obo/ENVO_00000002),
@@ -5352,7 +5213,9 @@ slots:
     required: true
   compl_appr:
     annotations:
-      Expected_value: text
+      Expected_value:
+        tag: Expected_value
+        value: text
     description: The approach used to determine the completeness of a given genomic
       assembly, which would typically make use of a set of conserved marker genes
       or a closely related reference genome. For UViG completeness, include reference
@@ -5360,15 +5223,17 @@ slots:
     title: completeness approach
     examples:
       - value: other
-        description: was other <colon> UViG length compared to the average length of
-          reference genomes from the P22virus genus (NCBI RefSeq v83)
+        description: was other <colon> UViG length compared to the average length
+          of reference genomes from the P22virus genus (NCBI RefSeq v83)
     in_subset:
       - sequencing
     slot_uri: MIXS:0000071
     range: ComplApprEnum
   compl_score:
     annotations:
-      Expected_value: quality;percent completeness
+      Expected_value:
+        tag: Expected_value
+        value: quality;percent completeness
     description: 'Completeness score is typically based on either the fraction of
       markers found as compared to a database or the percent of a genome found as
       compared to a closely related reference genome. High Quality Draft: >90%, Medium
@@ -5385,7 +5250,9 @@ slots:
     slot_uri: MIXS:0000069
   compl_software:
     annotations:
-      Expected_value: names and versions of software(s) used
+      Expected_value:
+        tag: Expected_value
+        value: names and versions of software(s) used
     description: Tools used for completion estimate, i.e. checkm, anvi'o, busco
     title: completeness software
     examples:
@@ -5398,7 +5265,9 @@ slots:
     slot_uri: MIXS:0000070
   conduc:
     annotations:
-      Preferred_unit: milliSiemens per centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milliSiemens per centimeter
     description: Electrical conductivity of water
     title: conductivity
     examples:
@@ -5406,14 +5275,16 @@ slots:
     slot_uri: MIXS:0000692
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   cons_food_stor_dur:
     annotations:
-      Preferred_unit: hours or days
+      Preferred_unit:
+        tag: Preferred_unit
+        value: hours or days
     description: The storage duration of the food commodity by the consumer, prior
       to onset of illness or sample collection.  Indicate the timepoint written in
       ISO 8601 format
@@ -5434,10 +5305,14 @@ slots:
       partial_match: true
   cons_food_stor_temp:
     annotations:
-      Expected_value: text or measurement value
-      Preferred_unit: degree Celsius
-    description: Temperature at which food commodity was stored by the consumer, prior
-      to onset of illness or sample collection
+      Expected_value:
+        tag: Expected_value
+        value: text or measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
+    description: Temperature at which food commodity was stored by the consumer,
+      prior to onset of illness or sample collection
     title: food stored by consumer (storage temperature)
     examples:
       - value: 4 degree Celsius
@@ -5466,7 +5341,7 @@ slots:
       - quantity
     slot_uri: MIXS:0001198
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -5474,9 +5349,9 @@ slots:
   contam_score:
     description: 'The contamination score is based on the fraction of single-copy
       genes that are observed more than once in a query genome. The following scores
-      are acceptable for; High Quality Draft: < 5%, Medium Quality Draft: < 10%, Low
-      Quality Draft: < 10%. Contamination must be below 5% for a SAG or MAG to be
-      deposited into any of the public databases'
+      are acceptable for; High Quality Draft: < 5%, Medium Quality Draft: < 10%,
+      Low Quality Draft: < 10%. Contamination must be below 5% for a SAG or MAG to
+      be deposited into any of the public databases'
     title: contamination score
     examples:
       - value: '0.01'
@@ -5497,7 +5372,9 @@ slots:
     range: ContamScreenInputEnum
   contam_screen_param:
     annotations:
-      Expected_value: enumeration;value or name
+      Expected_value:
+        tag: Expected_value
+        value: enumeration;value or name
     description: Specific parameters used in the decontamination sofware, such as
       reference database, coverage, and kmers. Combinations of these parameters may
       also be used, i.e. kmer and coverage, or reference database and kmer
@@ -5521,7 +5398,9 @@ slots:
     range: integer
   crop_rotation:
     annotations:
-      Expected_value: crop rotation status;schedule
+      Expected_value:
+        tag: Expected_value
+        value: crop rotation status;schedule
     description: Whether or not crop is rotated, and if yes, rotation schedule
     title: history/crop rotation
     examples:
@@ -5531,7 +5410,9 @@ slots:
     slot_uri: MIXS:0000318
   crop_yield:
     annotations:
-      Preferred_unit: kilogram per metre square
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilogram per metre square
     description: Amount of crop produced per unit or area of land
     title: crop yield
     examples:
@@ -5541,7 +5422,7 @@ slots:
     slot_uri: MIXS:0001116
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5578,8 +5459,8 @@ slots:
       - culture
       - organism
     slot_uri: MIXS:0001118
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -5587,7 +5468,9 @@ slots:
       partial_match: true
   cult_root_med:
     annotations:
-      Expected_value: name, PMID,DOI or url
+      Expected_value:
+        tag: Expected_value
+        value: name, PMID,DOI or url
     description: Name or reference for the hydroponic or in vitro culture rooting
       medium; can be the name of a commonly used medium or reference to a specific
       medium, e.g. Murashige and Skoog medium. If the medium has not been formally
@@ -5601,7 +5484,9 @@ slots:
     slot_uri: MIXS:0001041
   cult_target:
     annotations:
-      Expected_value: NCIT:C14250 or NCBI taxid or culture independent
+      Expected_value:
+        tag: Expected_value
+        value: NCIT:C14250 or NCBI taxid or culture independent
     description: The target microbial analyte in terms of investigation scope. This
       field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
@@ -5617,7 +5502,9 @@ slots:
     multivalued: true
   cur_land_use:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Present state of sample site
     title: current land use
     examples:
@@ -5626,29 +5513,31 @@ slots:
       - land
       - use
     string_serialization: '[cities|farmstead|industrial areas|roads/railroads|rock|sand|gravel|mudflats|salt
-      flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste areas|small
-      grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
+      flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste
+      areas|small grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
       (grass,sedges,rushes)|tundra (mosses,lichens)|rangeland|pastureland (grasslands
       used for livestock grazing)|hayland|meadows (grasses,alfalfa,fescue,bromegrass,timothy)|shrub
       land (e.g. mesquite,sage-brush,creosote bush,shrub oak,eucalyptus)|successional
       shrub land (tree saplings,hazels,sumacs,chokecherry,shrub dogwoods,blackberries)|shrub
       crops (blueberries,nursery ornamentals,filberts)|vine crops (grapes)|conifers
       (e.g. pine,spruce,fir,cypress)|hardwoods (e.g. oak,hickory,elm,aspen)|intermixed
-      hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen forest
-      receiving >406 cm annual rainfall)|swamp (permanent or semi-permanent water
-      body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery
+      hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen
+      forest receiving >406 cm annual rainfall)|swamp (permanent or semi-permanent
+      water body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery
       trees)]'
     slot_uri: MIXS:0001080
   cur_vegetation:
     annotations:
-      Expected_value: current vegetation type
+      Expected_value:
+        tag: Expected_value
+        value: current vegetation type
     description: Vegetation classification from one or more standard classification
       systems, or agricultural crop
     title: current vegetation
     keywords:
       - vegetation
-    range: string
     slot_uri: MIXS:0000312
+    range: string
   cur_vegetation_meth:
     description: Reference or method used in vegetation classification
     title: current vegetation method
@@ -5663,8 +5552,9 @@ slots:
       interpolated: true
       partial_match: true
   date_extr_weath:
-    description: Date of unusual weather events that may have affected microbial populations.
-      Multiple terms can be separated by pipes, listed in reverse chronological order
+    description: Date of unusual weather events that may have affected microbial
+      populations. Multiple terms can be separated by pipes, listed in reverse chronological
+      order
     title: extreme weather date
     examples:
       - value: '2013-03-25T12:42:31+01:00'
@@ -5673,8 +5563,8 @@ slots:
       - extreme
       - weather
     slot_uri: MIXS:0001142
-    multivalued: true
     range: datetime
+    multivalued: true
   date_last_rain:
     description: The date of the last time it rained
     title: date last rain
@@ -5687,7 +5577,9 @@ slots:
     range: datetime
   decontam_software:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Tool(s) used in contamination screening
     title: decontamination software
     examples:
@@ -5700,7 +5592,9 @@ slots:
     slot_uri: MIXS:0000074
   density:
     annotations:
-      Preferred_unit: gram per cubic meter, gram per cubic centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram per cubic meter, gram per cubic centimeter
     description: Density of the sample, which is its mass per unit volume (aka volumetric
       mass density)
     title: density
@@ -5711,7 +5605,7 @@ slots:
     slot_uri: MIXS:0000435
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5727,10 +5621,12 @@ slots:
     recommended: true
   depth:
     annotations:
-      Preferred_unit: meter
-    description: The vertical distance below local surface. For sediment or soil samples
-      depth is measured from sediment or soil surface, respectively. Depth can be
-      reported as an interval for subsurface samples
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
+    description: The vertical distance below local surface. For sediment or soil
+      samples depth is measured from sediment or soil surface, respectively. Depth
+      can be reported as an interval for subsurface samples
     title: depth
     in_subset:
       - environment
@@ -5739,7 +5635,7 @@ slots:
     slot_uri: MIXS:0000018
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5752,11 +5648,13 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000284
-    multivalued: true
     range: string
+    multivalued: true
   detec_type:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Type of UViG detection
     title: detection type
     examples:
@@ -5769,7 +5667,9 @@ slots:
     slot_uri: MIXS:0000084
   dew_point:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: The temperature to which a given parcel of humid air must be cooled,
       at constant barometric pressure, for water vapor to condense into water
     title: dew point
@@ -5778,14 +5678,16 @@ slots:
     slot_uri: MIXS:0000129
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diet_last_six_month:
     annotations:
-      Expected_value: diet change;current diet
+      Expected_value:
+        tag: Expected_value
+        value: diet change;current diet
     description: Specification of major diet changes in the last six months, if yes
       the change should be specified
     title: major diet change in last six months
@@ -5798,7 +5700,9 @@ slots:
     slot_uri: MIXS:0000266
   dietary_claim_use:
     annotations:
-      Expected_value: FOODON:03510023
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03510023
     description: These descriptors are used either for foods intended for special
       dietary use as defined in 21 CFR 105 or for foods that have special characteristics
       indicated in the name or labeling. This field accepts terms listed under dietary
@@ -5816,8 +5720,12 @@ slots:
     multivalued: true
   diether_lipids:
     annotations:
-      Expected_value: diether lipid name;measurement value
-      Preferred_unit: nanogram per liter
+      Expected_value:
+        tag: Expected_value
+        value: diether lipid name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: nanogram per liter
     description: Concentration of diether lipids; can include multiple types of diether
       lipids
     title: diether lipids
@@ -5828,7 +5736,9 @@ slots:
     multivalued: true
   diss_carb_dioxide:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter
     description: Concentration of dissolved carbon dioxide in the sample or liquid
       portion of the sample
     title: dissolved carbon dioxide
@@ -5840,14 +5750,16 @@ slots:
     slot_uri: MIXS:0000436
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_hydrogen:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Concentration of dissolved hydrogen
     title: dissolved hydrogen
     examples:
@@ -5857,14 +5769,16 @@ slots:
     slot_uri: MIXS:0000179
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_inorg_carb:
     annotations:
-      Preferred_unit: microgram per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, milligram per liter, parts per million
     description: Dissolved inorganic carbon concentration in the sample, typically
       measured after filtering the sample using a 0.45 micrometer filter
     title: dissolved inorganic carbon
@@ -5877,14 +5791,16 @@ slots:
     slot_uri: MIXS:0000434
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_inorg_nitro:
     annotations:
-      Preferred_unit: microgram per liter, micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, micromole per liter
     description: Concentration of dissolved inorganic nitrogen
     title: dissolved inorganic nitrogen
     examples:
@@ -5896,7 +5812,7 @@ slots:
     slot_uri: MIXS:0000698
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5913,14 +5829,16 @@ slots:
     slot_uri: MIXS:0000106
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_iron:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Concentration of dissolved iron in the sample
     title: dissolved iron
     keywords:
@@ -5929,16 +5847,18 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_org_carb:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter
-    description: Concentration of dissolved organic carbon in the sample, liquid portion
-      of the sample, or aqueous phase of the fluid
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter
+    description: Concentration of dissolved organic carbon in the sample, liquid
+      portion of the sample, or aqueous phase of the fluid
     title: dissolved organic carbon
     examples:
       - value: 197 micromole per liter
@@ -5949,7 +5869,7 @@ slots:
     slot_uri: MIXS:0000433
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5967,14 +5887,16 @@ slots:
     slot_uri: MIXS:0000162
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_oxygen:
     annotations:
-      Preferred_unit: micromole per kilogram, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per kilogram, milligram per liter
     description: Concentration of dissolved oxygen
     title: dissolved oxygen
     examples:
@@ -5985,14 +5907,16 @@ slots:
     slot_uri: MIXS:0000119
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_oxygen_fluid:
     annotations:
-      Preferred_unit: micromole per kilogram, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per kilogram, milligram per liter
     description: Concentration of dissolved oxygen in the oil field produced fluids
       as it contributes to oxgen-corrosion and microbial activity (e.g. Mic)
     title: dissolved oxygen in fluids
@@ -6002,7 +5926,7 @@ slots:
     slot_uri: MIXS:0000438
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6075,7 +5999,9 @@ slots:
     range: DoorMoveEnum
   door_size:
     annotations:
-      Preferred_unit: square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square meter
     description: The size of the door
     title: door area or size
     examples:
@@ -6087,7 +6013,7 @@ slots:
     slot_uri: MIXS:0000158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6114,7 +6040,9 @@ slots:
     range: DoorTypeMetalEnum
   door_type_wood:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: The type of wood door
     title: door type, wood
     examples:
@@ -6123,8 +6051,8 @@ slots:
       - door
       - type
     string_serialization: '[bettened and ledged|battened|ledged and braced|battened|ledged
-      and framed|battened|ledged, braced and frame|framed and paneled|glashed or sash|flush|louvered|wire
-      gauged]'
+      and framed|battened|ledged, braced and frame|framed and paneled|glashed or
+      sash|flush|louvered|wire gauged]'
     slot_uri: MIXS:0000797
   door_water_mold:
     description: Signs of the presence of mold or mildew on a door
@@ -6144,8 +6072,10 @@ slots:
     range: datetime
   down_par:
     annotations:
-      Preferred_unit: microEinstein per square meter per second, microEinstein per square
-        centimeter per second
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microEinstein per square meter per second, microEinstein per square
+          centimeter per second
     description: Visible waveband radiance and irradiance measurements in the water
       column
     title: downward PAR
@@ -6154,13 +6084,14 @@ slots:
     slot_uri: MIXS:0000703
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   drainage_class:
-    description: Drainage classification from a standard system such as the USDA system
+    description: Drainage classification from a standard system such as the USDA
+      system
     title: drainage classification
     examples:
       - value: well
@@ -6180,7 +6111,9 @@ slots:
     range: DrawingsEnum
   drug_usage:
     annotations:
-      Expected_value: drug name;frequency
+      Expected_value:
+        tag: Expected_value
+        value: drug name;frequency
     description: Any drug used by subject and the frequency of usage; can include
       multiple drugs used
     title: drug usage
@@ -6194,7 +6127,9 @@ slots:
     multivalued: true
   efficiency_percent:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Percentage of volatile solids removed from the anaerobic digestor
     title: efficiency percent
     keywords:
@@ -6202,14 +6137,16 @@ slots:
     slot_uri: MIXS:0000657
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   elev:
     annotations:
-      Preferred_unit: meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: Elevation of the sampling site is its height above a fixed reference
       point, most commonly the mean sea level. Elevation is mainly used when referring
       to points on the earth's surface, while altitude is used for points above the
@@ -6224,7 +6161,7 @@ slots:
     slot_uri: MIXS:0000093
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6240,8 +6177,12 @@ slots:
     range: integer
   emulsions:
     annotations:
-      Expected_value: emulsion name;measurement value
-      Preferred_unit: gram per liter
+      Expected_value:
+        tag: Expected_value
+        value: emulsion name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram per liter
     description: Amount or concentration of substances such as paints, adhesives,
       mayonnaise, hair colorants, emulsified oils, etc.; can include multiple emulsion
       types
@@ -6251,7 +6192,9 @@ slots:
     multivalued: true
   encoded_traits:
     annotations:
-      Expected_value: 'for plasmid: antibiotic resistance; for phage: converting genes'
+      Expected_value:
+        tag: Expected_value
+        value: 'for plasmid: antibiotic resistance; for phage: converting genes'
     description: Should include key traits like antibiotic resistance or xenobiotic
       degradation phenotypes for plasmids, converting genes for phage
     title: encoded traits
@@ -6259,12 +6202,12 @@ slots:
       - value: beta-lactamase class A
     in_subset:
       - nucleic acid sequence source
-    range: string
     slot_uri: MIXS:0000034
+    range: string
   enrichment_protocol:
     description: The microbiological workflow or protocol followed to test for the
-      presence or enumeration of the target microbial analyte(s). Please provide a
-      PubMed or DOI reference for published protocols
+      presence or enumeration of the target microbial analyte(s). Please provide
+      a PubMed or DOI reference for published protocols
     title: enrichment protocol
     examples:
       - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
@@ -6273,7 +6216,7 @@ slots:
       - protocol
     slot_uri: MIXS:0001177
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
@@ -6302,8 +6245,10 @@ slots:
       partial_match: true
   env_local_scale:
     annotations:
-      Expected_value: Environmental entities having causal influences upon the entity at
-        time of sampling
+      Expected_value:
+        tag: Expected_value
+        value: Environmental entities having causal influences upon the entity at
+          time of sampling
     description: 'Report the entity or entities which are in the sample or specimen
       s local vicinity and which you believe have significant causal influences on
       your sample or specimen. We recommend using EnvO terms which are of smaller
@@ -6319,17 +6264,18 @@ slots:
     keywords:
       - context
       - environmental
+    slot_uri: MIXS:0000013
+    required: true
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
       interpolated: true
       partial_match: true
-    slot_uri: MIXS:0000013
-    required: true
   env_medium:
     description: 'Report the environmental material(s) immediately surrounding the
       sample or specimen at the time of sampling. We recommend using subclasses of
-      ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO
-      documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS
+      ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483).
+      EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS
       . Terms from other OBO ontologies are permissible as long as they reference
       mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities
       (e.g. a tree, a leaf, a table top)'
@@ -6350,14 +6296,16 @@ slots:
       partial_match: true
   env_monitoring_zone:
     annotations:
-      Expected_value: ENVO
+      Expected_value:
+        tag: Expected_value
+        value: ENVO
     description: An environmental monitoring zone is a formal designation as part
       of an environmental monitoring program, in which areas of a food production
       facility are categorized, commonly as zones 1-4, based on likelihood or risk
-      of foodborne pathogen contamination. This field accepts terms listed under food
-      production environmental monitoring zone (http://purl.obolibrary.org/obo/ENVO).
-      Please add a term to indicate the environmental monitoring zone the sample was
-      taken from
+      of foodborne pathogen contamination. This field accepts terms listed under
+      food production environmental monitoring zone (http://purl.obolibrary.org/obo/ENVO).
+      Please add a term to indicate the environmental monitoring zone the sample
+      was taken from
     title: food production environmental monitoring zone
     examples:
       - value: Zone 1
@@ -6365,8 +6313,8 @@ slots:
       - environmental
       - food
       - production
-    range: string
     slot_uri: MIXS:0001254
+    range: string
   escalator:
     description: The number of escalators within the built structure
     title: escalator count
@@ -6378,7 +6326,9 @@ slots:
     range: integer
   estimated_size:
     annotations:
-      Expected_value: number of base pairs
+      Expected_value:
+        tag: Expected_value
+        value: number of base pairs
     description: The estimated size of the genome prior to sequencing. Of particular
       importance in the sequencing of (eukaryotic) genome which could remain in draft
       form for a long or unspecified period
@@ -6393,39 +6343,45 @@ slots:
     slot_uri: MIXS:0000024
   ethnicity:
     annotations:
-      Expected_value: text recommend from Wikipedia list
+      Expected_value:
+        tag: Expected_value
+        value: text recommend from Wikipedia list
     description: A category of people who identify with each other, usually on the
       basis of presumed similarities such as a common language, ancestry, history,
       society, culture, nation or social treatment within their residing area. https://en.wikipedia.org/wiki/List_of_contemporary_ethnic_groups
     title: ethnicity
     examples:
       - value: native american
-    range: string
     slot_uri: MIXS:0000895
+    range: string
     multivalued: true
   ethylbenzene:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of ethylbenzene in the sample
     title: ethylbenzene
     slot_uri: MIXS:0000155
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   exp_duct:
     annotations:
-      Preferred_unit: square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square meter
     description: The amount of exposed ductwork in the room
     title: exposed ductwork
     slot_uri: MIXS:0000144
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6437,14 +6393,16 @@ slots:
       - pipes
     slot_uri: MIXS:0000220
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
       partial_match: true
   experimental_factor:
     annotations:
-      Expected_value: text or EFO and/or OBI
+      Expected_value:
+        tag: Expected_value
+        value: text or EFO and/or OBI
     description: Variable aspects of an experiment design that can be used to describe
       an experiment, or set of experiments, in an increasingly detailed manner. This
       field accepts ontology terms from Experimental Factor Ontology (EFO) and/or
@@ -6459,8 +6417,8 @@ slots:
       - factor
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000008
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^\S+.*\S+ \[[a-zA-Z]{2,}:\d+\]$
   ext_door:
     description: The number of exterior doors in the built structure
@@ -6502,8 +6460,8 @@ slots:
       - extreme
       - weather
     slot_uri: MIXS:0001141
-    multivalued: true
     range: ExtrWeatherEventEnum
+    multivalued: true
   extrachrom_elements:
     description: Do plasmids exist of significant phenotypic consequence (e.g. ones
       that determine virulence or antibiotic resistance). Megaplasmids? Other plasmids
@@ -6533,10 +6491,12 @@ slots:
       - facility
       - type
     slot_uri: MIXS:0001252
-    multivalued: true
     range: FacilityTypeEnum
+    multivalued: true
   fao_class:
-    description: Soil classification from the FAO World soil distribution from International Soil Reference and Information Centre (ISRIC). The list of available soil classifications can be found at https://www.isric.org/explore/world-soil-distribution
+    description: Soil classification from the FAO World soil distribution from International
+      Soil Reference and Information Centre (ISRIC). The list of available soil classifications
+      can be found at https://www.isric.org/explore/world-soil-distribution
     title: soil_taxonomic/FAO classification
     examples:
       - value: Luvisols
@@ -6545,10 +6505,11 @@ slots:
     slot_uri: MIXS:0001083
     range: FaoClassEnum
   farm_equip:
-    description: List of equipment used for planting, fertilization, harvesting, irrigation,
-      land levelling, residue management, weeding or transplanting during the growing
-      season.  This field accepts terms listed under agricultural implement (http://purl.obolibrary.org/obo/AGRO_00000416).
-      Multiple terms can be separated by pipes
+    description: List of equipment used for planting, fertilization, harvesting,
+      irrigation, land levelling, residue management, weeding or transplanting during
+      the growing season.  This field accepts terms listed under agricultural implement
+      (http://purl.obolibrary.org/obo/AGRO_00000416). Multiple terms can be separated
+      by pipes
     title: farm equipment used
     examples:
       - value: combine harvester [AGRO:00000473]
@@ -6557,8 +6518,8 @@ slots:
       - farm
       - use
     slot_uri: MIXS:0001126
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -6566,9 +6527,13 @@ slots:
       partial_match: true
   farm_equip_san:
     annotations:
-      Expected_value: text or commercial name of sanitizer or class of sanitizer or active
-        ingredient in sanitizer
-      Preferred_unit: parts per million
+      Expected_value:
+        tag: Expected_value
+        value: text or commercial name of sanitizer or class of sanitizer or active
+          ingredient in sanitizer
+      Preferred_unit:
+        tag: Preferred_unit
+        value: parts per million
     description: Method used to sanitize growing and harvesting equipment. This can
       including type and concentration of sanitizing solution.  Multiple terms can
       be separated by one or more pipes
@@ -6604,8 +6569,8 @@ slots:
       - equipment
       - farm
     slot_uri: MIXS:0001123
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -6626,8 +6591,8 @@ slots:
     range: FarmWaterSourceEnum
     recommended: true
   feat_pred:
-    description: Method used to predict UViGs features such as ORFs, integration site,
-      etc
+    description: Method used to predict UViGs features such as ORFs, integration
+      site, etc
     title: feature prediction
     examples:
       - value: Prodigal;2.6.3;default parameters
@@ -6645,7 +6610,9 @@ slots:
       partial_match: true
   ferm_chem_add:
     annotations:
-      Expected_value: chemical ingredient
+      Expected_value:
+        tag: Expected_value
+        value: chemical ingredient
     description: Any chemicals that are added to the fermentation process to achieve
       the desired final product
     title: fermentation chemical additives
@@ -6655,11 +6622,13 @@ slots:
       - fermentation
     string_serialization: '{float} {unit}'
     slot_uri: MIXS:0001185
-    multivalued: true
     recommended: true
+    multivalued: true
   ferm_chem_add_perc:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: The amount of chemical added to the fermentation process
     title: fermentation chemical additives percentage
     examples:
@@ -6668,12 +6637,14 @@ slots:
       - fermentation
       - percent
     slot_uri: MIXS:0001186
-    multivalued: true
     range: float
     recommended: true
+    multivalued: true
   ferm_headspace_oxy:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: The amount of headspace oxygen in a fermentation vessel
     title: fermentation headspace oxygen
     examples:
@@ -6686,8 +6657,8 @@ slots:
     recommended: true
   ferm_medium:
     description: The growth medium used for the fermented food fermentation process,
-      which supplies the required nutrients.  Usually this includes a carbon and nitrogen
-      source, water, micronutrients and chemical additives
+      which supplies the required nutrients.  Usually this includes a carbon and
+      nitrogen source, water, micronutrients and chemical additives
     title: fermentation medium
     examples:
       - value: molasses
@@ -6709,7 +6680,9 @@ slots:
     recommended: true
   ferm_rel_humidity:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: The relative humidity of the fermented food fermentation process
     title: fermentation relative humidity
     comments:
@@ -6724,14 +6697,16 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ferm_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: The temperature of the fermented food fermentation process
     title: fermentation temperature
     examples:
@@ -6743,14 +6718,16 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ferm_time:
     annotations:
-      Preferred_unit: days
+      Preferred_unit:
+        tag: Preferred_unit
+        value: days
     description: The time duration of the fermented food fermentation process
     title: fermentation time
     examples:
@@ -6780,8 +6757,8 @@ slots:
     description: Type of fertilizer or amendment added to the soil or water for the
       purpose of improving substrate health and quality for plant growth. This field
       accepts terms listed under agronomic fertilizer (http://purl.obolibrary.org/obo/AGRO_00002062).
-      Multiple terms may apply and can be separated by pipes, listing in reverse chronological
-      order
+      Multiple terms may apply and can be separated by pipes, listing in reverse
+      chronological order
     title: fertilizer administration
     examples:
       - value: fish emulsion [AGRO:00000082]
@@ -6808,12 +6785,16 @@ slots:
     range: datetime
   fertilizer_regm:
     annotations:
-      Expected_value: fertilizer name;fertilizer amount;treatment interval and duration
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: fertilizer name;fertilizer amount;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of fertilizers; should
       include the name of fertilizer, amount administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted, and
-      the start and end time of the entire treatment; can include multiple fertilizer
+      how many times the treatment was repeated, how long each treatment lasted,
+      and the start and end time of the entire treatment; can include multiple fertilizer
       regimens
     title: fertilizer regimen
     examples:
@@ -6830,7 +6811,8 @@ slots:
     range: string
     recommended: true
   filter_type:
-    description: A device which removes solid particulates or airborne molecular contaminants
+    description: A device which removes solid particulates or airborne molecular
+      contaminants
     title: filter type
     examples:
       - value: HEPA
@@ -6838,9 +6820,9 @@ slots:
       - filter
       - type
     slot_uri: MIXS:0000765
-    multivalued: true
     range: FilterTypeEnum
     required: true
+    multivalued: true
   fire:
     description: Historical and/or physical evidence of fire
     title: history/fire
@@ -6866,7 +6848,9 @@ slots:
     range: datetime
   floor_age:
     annotations:
-      Preferred_unit: years, weeks, days
+      Preferred_unit:
+        tag: Preferred_unit
+        value: years, weeks, days
     description: The time period since installment of the carpet or flooring
     title: floor age
     keywords:
@@ -6875,14 +6859,16 @@ slots:
     slot_uri: MIXS:0000164
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   floor_area:
     annotations:
-      Preferred_unit: square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square meter
     description: The area of the floor space within the room
     title: floor area
     keywords:
@@ -6891,7 +6877,7 @@ slots:
     slot_uri: MIXS:0000165
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6918,7 +6904,9 @@ slots:
     range: integer
   floor_finish_mat:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: The floor covering type; the finished surface that is walked on
     title: floor finish material
     examples:
@@ -6942,8 +6930,11 @@ slots:
     range: FloorStrucEnum
   floor_thermal_mass:
     annotations:
-      Preferred_unit: joule per degree Celsius
-    description: The ability of the floor to provide inertia against temperature fluctuations
+      Preferred_unit:
+        tag: Preferred_unit
+        value: joule per degree Celsius
+    description: The ability of the floor to provide inertia against temperature
+      fluctuations
     title: floor thermal mass
     keywords:
       - floor
@@ -6951,7 +6942,7 @@ slots:
     slot_uri: MIXS:0000166
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6967,7 +6958,9 @@ slots:
     range: FloorWaterMoldEnum
   fluor:
     annotations:
-      Preferred_unit: milligram chlorophyll a per cubic meter, volts
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram chlorophyll a per cubic meter, volts
     description: Raw or converted fluorescence of water
     title: fluorescence
     examples:
@@ -6975,7 +6968,7 @@ slots:
     slot_uri: MIXS:0000704
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6989,13 +6982,15 @@ slots:
     range: string
   food_additive:
     annotations:
-      Expected_value: FOODON:03412972
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03412972
     description: A substance or substances added to food to maintain or improve safety
-      and freshness, to improve or maintain nutritional value, or improve taste, texture
-      and appearance.  This field accepts terms listed under food additive (http://purl.obolibrary.org/obo/FOODON_03412972).
-      Multiple terms can be separated by one or more pipes, but please consider limiting
-      this list to the top 5 ingredients listed in order as on the food label.  See
-      also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
+      and freshness, to improve or maintain nutritional value, or improve taste,
+      texture and appearance.  This field accepts terms listed under food additive
+      (http://purl.obolibrary.org/obo/FOODON_03412972). Multiple terms can be separated
+      by one or more pipes, but please consider limiting this list to the top 5 ingredients
+      listed in order as on the food label.  See also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
     title: food additive
     examples:
       - value: xanthan gum [FOODON:03413321]
@@ -7006,7 +7001,9 @@ slots:
     multivalued: true
   food_allergen_label:
     annotations:
-      Expected_value: FOODON:03510213
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03510213
     description: A label indication that the product contains a recognized allergen.
       This field accepts terms listed under dietary claim or use (http://purl.obolibrary.org/obo/FOODON_03510213)
     title: food allergen labeling
@@ -7033,7 +7030,9 @@ slots:
     range: FoodCleanProcEnum
   food_contact_surf:
     annotations:
-      Expected_value: FOODON:03500010
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03500010
     description: The specific container or coating materials in direct contact with
       the food. Multiple values can be assigned.  This field accepts terms listed
       under food contact surface (http://purl.obolibrary.org/obo/FOODON_03500010)
@@ -7048,7 +7047,9 @@ slots:
     multivalued: true
   food_contain_wrap:
     annotations:
-      Expected_value: FOODON:03490100
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03490100
     description: Type of container or wrapping defined by the main container material,
       the container form, and the material of the liner lids or ends. Also type of
       container or wrapping by form; prefer description by material first, then by
@@ -7062,9 +7063,11 @@ slots:
     slot_uri: MIXS:0001132
   food_cooking_proc:
     annotations:
-      Expected_value: FOODON:03450002
-    description: The transformation of raw food by the application of heat. This field
-      accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03450002
+    description: The transformation of raw food by the application of heat. This
+      field accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
     title: food cooking process
     examples:
       - value: food blanching [FOODON:03470175]
@@ -7089,16 +7092,18 @@ slots:
       - geographic
       - location
     slot_uri: MIXS:0001203
-    multivalued: true
     range: string
-    pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
+    multivalued: true
+    pattern: '^.*: .*, .*$'
     structured_pattern:
       syntax: '^{text}: {text}, {text}$'
       interpolated: true
       partial_match: true
   food_dis_point_city:
     annotations:
-      Expected_value: GAZ:00000448
+      Expected_value:
+        tag: Expected_value
+        value: GAZ:00000448
     description: 'A reference to a place on the Earth, by its name or by its geographical
       location that refers to a distribution point along the food chain. This field
       accepts terms listed under geographic location (http://purl.obolibrary.org/obo/GAZ_00000448).
@@ -7127,11 +7132,13 @@ slots:
       - food
       - process
     slot_uri: MIXS:0001133
-    multivalued: true
     range: string
+    multivalued: true
   food_ingredient:
     annotations:
-      Expected_value: FOODON
+      Expected_value:
+        tag: Expected_value
+        value: FOODON
     description: In this field, please list individual ingredients for multi-component
       food [FOODON:00002501] and simple foods that is not captured in food_type.  Please
       use terms that are present in FoodOn.  Multiple terms can be separated by one
@@ -7147,8 +7154,8 @@ slots:
     slot_uri: MIXS:0001205
     multivalued: true
   food_name_status:
-    description: A datum indicating that use of a food product name is regulated in
-      some legal jurisdiction. This field accepts terms listed under food product
+    description: A datum indicating that use of a food product name is regulated
+      in some legal jurisdiction. This field accepts terms listed under food product
       name legal status (http://purl.obolibrary.org/obo/FOODON_03530087)
     title: food product name legal status
     examples:
@@ -7179,14 +7186,16 @@ slots:
       - product
     slot_uri: MIXS:0001207
     range: string
-    pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
+    pattern: '^.*: .*, .*$'
     structured_pattern:
       syntax: '^{text}: {text}, {text}$'
       interpolated: true
       partial_match: true
   food_pack_capacity:
     annotations:
-      Preferred_unit: grams
+      Preferred_unit:
+        tag: Preferred_unit
+        value: grams
     description: The maximum number of product units within a package
     title: food package capacity
     examples:
@@ -7197,14 +7206,16 @@ slots:
     slot_uri: MIXS:0001208
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   food_pack_integrity:
     annotations:
-      Expected_value: FOODON:03530218
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03530218
     description: A term label and term id to describe the state of the packing material
       and text to explain the exact condition.  This field accepts terms listed under
       food packing medium integrity (http://purl.obolibrary.org/obo/FOODON_03530218)
@@ -7218,15 +7229,17 @@ slots:
     multivalued: true
   food_pack_medium:
     annotations:
-      Expected_value: FOODON:03480020
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03480020
     description: The medium in which the food is packed for preservation and handling
       or the medium surrounding homemade foods, e.g., peaches cooked in sugar syrup.
       The packing medium may provide a controlled environment for the food. It may
       also serve to improve palatability and consumer appeal.  This includes edible
       packing media (e.g. fruit juice), gas other than air (e.g. carbon dioxide),
-      vacuum packed, or packed with aerosol propellant. This field accepts terms under
-      food packing medium (http://purl.obolibrary.org/obo/FOODON_03480020). Multiple
-      terms may apply and can be separated by pipes
+      vacuum packed, or packed with aerosol propellant. This field accepts terms
+      under food packing medium (http://purl.obolibrary.org/obo/FOODON_03480020).
+      Multiple terms may apply and can be separated by pipes
     title: food packing medium
     keywords:
       - food
@@ -7235,7 +7248,9 @@ slots:
     multivalued: true
   food_preserv_proc:
     annotations:
-      Expected_value: FOODON:03470107
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03470107
     description: The methods contributing to the prevention or retardation of microbial,
       enzymatic or oxidative spoilage and thus to the extension of shelf life. This
       field accepts terms listed under food preservation process (http://purl.obolibrary.org/obo/FOODON_03470107)
@@ -7250,12 +7265,14 @@ slots:
     multivalued: true
   food_prior_contact:
     annotations:
-      Expected_value: FOODON:03530077
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03530077
     description: The material the food contacted (e.g., was processed in) prior to
-      packaging. This field accepts terms listed under material of contact prior to
-      food packaging (http://purl.obolibrary.org/obo/FOODON_03530077). If the proper
-      descriptor is not listed please use text to describe the material of contact
-      prior to food packaging
+      packaging. This field accepts terms listed under material of contact prior
+      to food packaging (http://purl.obolibrary.org/obo/FOODON_03530077). If the
+      proper descriptor is not listed please use text to describe the material of
+      contact prior to food packaging
     title: material of contact prior to food packaging
     examples:
       - value: processed in stainless steel container [FOODON:03530081]
@@ -7269,9 +7286,10 @@ slots:
   food_prod:
     description: Descriptors of the food production system or of the agricultural
       environment and growing conditions related to the farm production system, such
-      as wild caught, organic, free-range, industrial, dairy, beef,  domestic or cultivated
-      food production. This field accepts terms listed under food production (http://purl.obolibrary.org/obo/FOODON_03530206).
-      Multiple terms may apply and can be separated by pipes
+      as wild caught, organic, free-range, industrial, dairy, beef,  domestic or
+      cultivated food production. This field accepts terms listed under food production
+      (http://purl.obolibrary.org/obo/FOODON_03530206). Multiple terms may apply
+      and can be separated by pipes
     title: food production system characteristics
     examples:
       - value: organic plant cultivation [FOODON:03530253]
@@ -7279,8 +7297,8 @@ slots:
       - food
       - production
     slot_uri: MIXS:0001211
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -7296,8 +7314,8 @@ slots:
       - food
       - production
     slot_uri: MIXS:0001136
-    multivalued: true
     range: string
+    multivalued: true
   food_prod_synonym:
     description: Other names by which the food product is known by (e.g., regional
       or non-English names)
@@ -7308,14 +7326,14 @@ slots:
       - food
       - product
     slot_uri: MIXS:0001212
-    multivalued: true
     range: string
+    multivalued: true
   food_product_qual:
     description: Descriptors for describing food visually or via other senses, which
       is useful for tasks like food inspection where little prior knowledge of how
-      the food came to be is available. Some terms like "food (frozen)" are both a
-      quality descriptor and the output of a process. This field accepts terms listed
-      under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
+      the food came to be is available. Some terms like "food (frozen)" are both
+      a quality descriptor and the output of a process. This field accepts terms
+      listed under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
     title: food product by quality
     examples:
       - value: raw [FOODON:03311126]
@@ -7332,13 +7350,15 @@ slots:
       partial_match: true
   food_product_type:
     annotations:
-      Expected_value: FOODON:00001002 or FOODON:03309997
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:00001002 or FOODON:03309997
     description: A food product type is a class of food products that is differentiated
       by its food composition (e.g., single- or multi-ingredient), processing and/or
-      consumption characteristics. This does not include brand name products but it
-      may include generic food dish categories. This field accepts terms under food
-      product type (http://purl.obolibrary.org/obo/FOODON:03400361). For terms related
-      to food product for an animal, consult food product for animal (http://purl.obolibrary.org/obo/FOODON_03309997).
+      consumption characteristics. This does not include brand name products but
+      it may include generic food dish categories. This field accepts terms under
+      food product type (http://purl.obolibrary.org/obo/FOODON:03400361). For terms
+      related to food product for an animal, consult food product for animal (http://purl.obolibrary.org/obo/FOODON_03309997).
       If the proper descriptor is not listed please use text to describe the food
       type. Multiple terms can be separated by one or more pipes
     title: food product type
@@ -7350,11 +7370,13 @@ slots:
     slot_uri: MIXS:0001184
   food_quality_date:
     annotations:
-      Expected_value: enumeration, date
+      Expected_value:
+        tag: Expected_value
+        value: enumeration, date
     description: The date recommended for the use of the product while at peak quality,
-      this date is not a reflection of safety unless used on infant formula this date
-      is not a reflection of safety and is typically labeled on a food product as
-      "best if used by," best by," "use by," or "freeze by."
+      this date is not a reflection of safety unless used on infant formula this
+      date is not a reflection of safety and is typically labeled on a food product
+      as "best if used by," best by," "use by," or "freeze by."
     title: food quality date
     examples:
       - value: best by 2020-05-24
@@ -7366,7 +7388,9 @@ slots:
     slot_uri: MIXS:0001178
   food_source:
     annotations:
-      Expected_value: FOODON term
+      Expected_value:
+        tag: Expected_value
+        value: FOODON term
     description: Type of plant or animal from which the food product or its major
       ingredient is derived or a chemical food source [FDA CFSAN 1995]
     title: food source
@@ -7377,7 +7401,9 @@ slots:
     slot_uri: MIXS:0001139
   food_source_age:
     annotations:
-      Preferred_unit: days
+      Preferred_unit:
+        tag: Preferred_unit
+        value: days
     description: The age of the food source host organim. Depending on the type of
       host organism, age may be more appropriate to report in days, weeks, or years
     title: food source age
@@ -7392,19 +7418,19 @@ slots:
     slot_uri: MIXS:0001251
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   food_trace_list:
     description: The FDA is proposing to establish additional traceability recordkeeping
-      requirements (beyond what is already required in existing regulations) for persons
-      who manufacture, process, pack, or hold foods the Agency has designated for
-      inclusion on the Food Traceability List. The Food Traceability List (FTL) identifies
-      the foods for which the additional traceability records described in the proposed
-      rule would be required. The term  Food Traceability List  (FTL) refers not only
-      to the foods specifically listed (https://www.fda.gov/media/142303/download),
+      requirements (beyond what is already required in existing regulations) for
+      persons who manufacture, process, pack, or hold foods the Agency has designated
+      for inclusion on the Food Traceability List. The Food Traceability List (FTL)
+      identifies the foods for which the additional traceability records described
+      in the proposed rule would be required. The term  Food Traceability List  (FTL)
+      refers not only to the foods specifically listed (https://www.fda.gov/media/142303/download),
       but also to any foods that contain listed foods as ingredients
     title: food traceability list category
     examples:
@@ -7414,11 +7440,11 @@ slots:
     slot_uri: MIXS:0001214
     range: FoodTraceListEnum
   food_trav_mode:
-    description: A descriptor for the method of movement of food commodity along the
-      food distribution system.  This field accepts terms listed under travel mode
-      (http://purl.obolibrary.org/obo/GENEPIO_0001064). If the proper descrptor is
-      not listed please use text to describe the mode of travel. Multiple terms can
-      be separated by one or more pipes
+    description: A descriptor for the method of movement of food commodity along
+      the food distribution system.  This field accepts terms listed under travel
+      mode (http://purl.obolibrary.org/obo/GENEPIO_0001064). If the proper descrptor
+      is not listed please use text to describe the mode of travel. Multiple terms
+      can be separated by one or more pipes
     title: food shipping transportation method
     examples:
       - value: train travel [GENEPIO:0001060]
@@ -7427,8 +7453,8 @@ slots:
       - method
       - transport
     slot_uri: MIXS:0001137
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -7436,7 +7462,9 @@ slots:
       partial_match: true
   food_trav_vehic:
     annotations:
-      Expected_value: ENVO:01000604
+      Expected_value:
+        tag: Expected_value
+        value: ENVO:01000604
     description: A descriptor for the mobile machine which is used to transport food
       commodities along the food distribution system.  This field accepts terms listed
       under vehicle (http://purl.obolibrary.org/obo/ENVO_01000604). If the proper
@@ -7453,7 +7481,9 @@ slots:
     multivalued: true
   food_treat_proc:
     annotations:
-      Expected_value: FOODON:03460111
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03460111
     description: Used to specifically characterize a food product based on the treatment
       or processes applied to the product or any indexed ingredient. The processes
       include adding, substituting or removing components or modifying the food or
@@ -7486,26 +7516,29 @@ slots:
       - frequency
     slot_uri: MIXS:0000227
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
       partial_match: true
   fungicide_regm:
     annotations:
-      Preferred_unit: gram, mole per liter, milligram per liter
-    description: Information about treatment involving use of fungicides; should include
-      the name of fungicide, amount administered, treatment regimen including how
-      many times the treatment was repeated, how long each treatment lasted, and the
-      start and end time of the entire treatment; can include multiple fungicide regimens
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
+    description: Information about treatment involving use of fungicides; should
+      include the name of fungicide, amount administered, treatment regimen including
+      how many times the treatment was repeated, how long each treatment lasted,
+      and the start and end time of the entire treatment; can include multiple fungicide
+      regimens
     title: fungicide regimen
     examples:
       - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
       - regimen
     slot_uri: MIXS:0000557
-    multivalued: true
     range: string
+    multivalued: true
   furniture:
     description: The types of furniture present in the sampled room
     title: furniture
@@ -7515,7 +7548,9 @@ slots:
     range: FurnitureEnum
   gaseous_environment:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Use of conditions with differing gaseous environments; should include
       the name of gaseous compound, amount administered, treatment duration, interval
       and total experimental duration; can include multiple gaseous environment regimens
@@ -7525,14 +7560,18 @@ slots:
     keywords:
       - environment
     slot_uri: MIXS:0000558
-    multivalued: true
     range: string
+    multivalued: true
   gaseous_substances:
     annotations:
-      Expected_value: gaseous substance name;measurement value
-      Preferred_unit: micromole per liter
-    description: Amount or concentration of substances such as hydrogen sulfide, carbon
-      dioxide, methane, etc.; can include multiple substances
+      Expected_value:
+        tag: Expected_value
+        value: gaseous substance name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
+    description: Amount or concentration of substances such as hydrogen sulfide,
+      carbon dioxide, methane, etc.; can include multiple substances
     title: gaseous substances
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000661
@@ -7546,8 +7585,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000280
-    multivalued: true
     range: string
+    multivalued: true
   gender_restroom:
     description: The gender type of the restroom
     title: gender of restroom
@@ -7557,7 +7596,9 @@ slots:
     range: GenderRestroomEnum
   genetic_mod:
     annotations:
-      Expected_value: PMID, DOI, URL or text
+      Expected_value:
+        tag: Expected_value
+        value: PMID, DOI, URL or text
     description: Genetic modifications of the genome of an organism, which may occur
       naturally by spontaneous mutation, or be introduced by some experimental means,
       e.g. specification of a transgene or the gene knocked-out or details of transient
@@ -7568,10 +7609,10 @@ slots:
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000859
   geo_loc_name:
-    description: The geographical origin of the sample as defined by the country or
-      sea name followed by specific region name. Country or sea names should be chosen
-      from the INSDC country list (http://insdc.org/country.html), or the GAZ ontology
-      (http://purl.bioontology.org/ontology/GAZ)
+    description: The geographical origin of the sample as defined by the country
+      or sea name followed by specific region name. Country or sea names should be
+      chosen from the INSDC country list (http://insdc.org/country.html), or the
+      GAZ ontology (http://purl.bioontology.org/ontology/GAZ)
     title: geographic location (country and/or sea,region)
     examples:
       - value: 'USA: Maryland, Bethesda'
@@ -7583,7 +7624,7 @@ slots:
     slot_uri: MIXS:0000010
     range: string
     required: true
-    pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
+    pattern: '^.*: .*, .*$'
     structured_pattern:
       syntax: '^{text}: {text}, {text}$'
       interpolated: true
@@ -7595,7 +7636,9 @@ slots:
     range: string
   glucosidase_act:
     annotations:
-      Preferred_unit: mol per liter per hour
+      Preferred_unit:
+        tag: Preferred_unit
+        value: mol per liter per hour
     description: Measurement of glucosidase activity
     title: glucosidase activity
     examples:
@@ -7603,7 +7646,7 @@ slots:
     slot_uri: MIXS:0000137
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7618,13 +7661,17 @@ slots:
     slot_uri: MIXS:0000875
   gravity:
     annotations:
-      Expected_value: gravity factor value;treatment interval and duration
-      Preferred_unit: meter per square second, g
+      Expected_value:
+        tag: Expected_value
+        value: gravity factor value;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter per square second, g
     description: Information about treatment involving use of gravity factor to study
       various types of responses in presence, absence or modified levels of gravity;
-      treatment regimen including how many times the treatment was repeated, how long
-      each treatment lasted, and the start and end time of the entire treatment; can
-      include multiple treatments
+      treatment regimen including how many times the treatment was repeated, how
+      long each treatment lasted, and the start and end time of the entire treatment;
+      can include multiple treatments
     title: gravity
     examples:
       - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -7633,10 +7680,12 @@ slots:
     multivalued: true
   growth_facil:
     annotations:
-      Expected_value: free text or CO
-    description: 'Type of facility where the sampled plant was grown; controlled vocabulary:
-      growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively
-      use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
+      Expected_value:
+        tag: Expected_value
+        value: free text or CO
+    description: 'Type of facility where the sampled plant was grown; controlled
+      vocabulary: growth chamber, open top chamber, glasshouse, experimental garden,
+      field. Alternatively use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
     title: growth facility
     examples:
       - value: Growth chamber [CO_715:0000189]
@@ -7656,13 +7705,17 @@ slots:
     range: GrowthHabitEnum
   growth_hormone_regm:
     annotations:
-      Expected_value: growth hormone name;growth hormone amount;treatment interval and duration
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: growth hormone name;growth hormone amount;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of growth hormones; should
-      include the name of growth hormone, amount administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted, and
-      the start and end time of the entire treatment; can include multiple growth
-      hormone regimens
+      include the name of growth hormone, amount administered, treatment regimen
+      including how many times the treatment was repeated, how long each treatment
+      lasted, and the start and end time of the entire treatment; can include multiple
+      growth hormone regimens
     title: growth hormone regimen
     examples:
       - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -7674,8 +7727,8 @@ slots:
     multivalued: true
   growth_medium:
     description: A liquid or gel containing nutrients, salts, and other factors formulated
-      to support the growth of microorganisms, cells, or plants (National Cancer Institute
-      Thesaurus).  The name of the medium used to grow the microorganism
+      to support the growth of microorganisms, cells, or plants (National Cancer
+      Institute Thesaurus).  The name of the medium used to grow the microorganism
     title: growth medium
     examples:
       - value: LB broth
@@ -7691,8 +7744,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000288
-    multivalued: true
     range: string
+    multivalued: true
   hall_count:
     description: The total count of hallways and cooridors in the built structure
     title: hallway/corridor count
@@ -7722,13 +7775,13 @@ slots:
     range: HcProducedEnum
     required: true
   hcr:
-    description: Main Hydrocarbon Resource type. The term "Hydrocarbon Resource" HCR
-      defined as a natural environmental feature containing large amounts of hydrocarbons
-      at high concentrations potentially suitable for commercial exploitation. This
-      term should not be confused with the Hydrocarbon Occurrence term which also
-      includes hydrocarbon-rich environments with currently limited commercial interest
-      such as seeps, outcrops, gas hydrates etc. If "other" is specified, please propose
-      entry in "additional info" field
+    description: Main Hydrocarbon Resource type. The term "Hydrocarbon Resource"
+      HCR defined as a natural environmental feature containing large amounts of
+      hydrocarbons at high concentrations potentially suitable for commercial exploitation.
+      This term should not be confused with the Hydrocarbon Occurrence term which
+      also includes hydrocarbon-rich environments with currently limited commercial
+      interest such as seeps, outcrops, gas hydrates etc. If "other" is specified,
+      please propose entry in "additional info" field
     title: hydrocarbon resource type
     examples:
       - value: Oil Sand
@@ -7741,7 +7794,9 @@ slots:
     required: true
   hcr_fw_salinity:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Original formation water salinity (prior to secondary recovery e.g.
       Waterflooding) expressed as TDS
     title: formation water salinity
@@ -7752,7 +7807,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7772,7 +7827,9 @@ slots:
     recommended: true
   hcr_pressure:
     annotations:
-      Preferred_unit: atmosphere, kilopascal
+      Preferred_unit:
+        tag: Preferred_unit
+        value: atmosphere, kilopascal
     description: Original pressure of the hydrocarbon resource
     title: hydrocarbon resource original pressure
     keywords:
@@ -7788,7 +7845,9 @@ slots:
       partial_match: true
   hcr_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Original temperature of the hydrocarbon resource
     title: hydrocarbon resource original temperature
     examples:
@@ -7812,9 +7871,9 @@ slots:
     keywords:
       - type
     slot_uri: MIXS:0000766
-    multivalued: true
     range: HeatCoolTypeEnum
     required: true
+    multivalued: true
   heat_deliv_loc:
     description: The location of heat delivery within the room
     title: heating delivery locations
@@ -7845,8 +7904,12 @@ slots:
     range: integer
   heavy_metals:
     annotations:
-      Expected_value: heavy metal name;measurement value unit
-      Preferred_unit: microgram per gram
+      Expected_value:
+        tag: Expected_value
+        value: heavy metal name;measurement value unit
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per gram
     description: Heavy metals present in the sequenced sample and their concentrations.
       For multiple heavy metals and concentrations, add multiple copies of this field
     title: extreme_unusual_properties/heavy metals
@@ -7876,7 +7939,9 @@ slots:
       partial_match: true
   height_carper_fiber:
     annotations:
-      Preferred_unit: centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: centimeter
     description: The average carpet fiber height in the indoor environment
     title: height carpet fiber mat
     keywords:
@@ -7884,27 +7949,29 @@ slots:
     slot_uri: MIXS:0000167
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   herbicide_regm:
     annotations:
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of herbicides; information
       about treatment involving use of growth hormones; should include the name of
-      herbicide, amount administered, treatment regimen including how many times the
-      treatment was repeated, how long each treatment lasted, and the start and end
-      time of the entire treatment; can include multiple regimens
+      herbicide, amount administered, treatment regimen including how many times
+      the treatment was repeated, how long each treatment lasted, and the start and
+      end time of the entire treatment; can include multiple regimens
     title: herbicide regimen
     examples:
       - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
       - regimen
     slot_uri: MIXS:0000561
-    multivalued: true
     range: string
+    multivalued: true
   horizon_meth:
     description: Reference or method used in determining the horizon
     title: horizon method
@@ -7920,7 +7987,9 @@ slots:
       partial_match: true
   host_age:
     annotations:
-      Preferred_unit: year, day, hour
+      Preferred_unit:
+        tag: Preferred_unit
+        value: year, day, hour
     description: Age of host at the time of sampling; relevant scale depends on species
       and study, e.g. Could be seconds for amoebae or centuries for trees
     title: host age
@@ -7931,7 +8000,7 @@ slots:
     slot_uri: MIXS:0000255
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7948,7 +8017,9 @@ slots:
     range: string
   host_body_mass_index:
     annotations:
-      Preferred_unit: kilogram per square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilogram per square meter
     description: Body mass index, calculated as weight/(height)squared
     title: host body-mass index
     examples:
@@ -7959,14 +8030,16 @@ slots:
     slot_uri: MIXS:0000317
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_body_product:
     annotations:
-      Expected_value: FMA or UBERON
+      Expected_value:
+        tag: Expected_value
+        value: FMA or UBERON
     description: Substance produced by the body, e.g. Stool, mucus, where the sample
       was obtained from. Use terms from the foundational model of anatomy ontology
       (fma) or Uber-anatomy ontology (UBERON)
@@ -7982,10 +8055,12 @@ slots:
     slot_uri: MIXS:0000888
   host_body_site:
     annotations:
-      Expected_value: FMA or UBERON
-    description: Name of body site where the sample was obtained from, such as a specific
-      organ or tissue (tongue, lung etc...). Use terms from the foundational model
-      of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
+      Expected_value:
+        tag: Expected_value
+        value: FMA or UBERON
+    description: Name of body site where the sample was obtained from, such as a
+      specific organ or tissue (tongue, lung etc...). Use terms from the foundational
+      model of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
     title: host body site
     keywords:
       - body
@@ -7995,7 +8070,9 @@ slots:
     slot_uri: MIXS:0000867
   host_body_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Core body temperature of the host when sample was collected
     title: host body temperature
     keywords:
@@ -8006,7 +8083,7 @@ slots:
     slot_uri: MIXS:0000274
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8036,7 +8113,9 @@ slots:
     range: string
   host_common_name:
     annotations:
-      Preferred_unit: ''
+      Preferred_unit:
+        tag: Preferred_unit
+        value: ''
     description: Common name of the host
     title: host common name
     keywords:
@@ -8064,14 +8143,16 @@ slots:
       - host
       - host.
     slot_uri: MIXS:0000869
-    multivalued: true
     range: string
+    multivalued: true
   host_disease_stat:
     annotations:
-      Expected_value: disease name or Disease Ontology term
+      Expected_value:
+        tag: Expected_value
+        value: disease name or Disease Ontology term
     description: List of diseases with which the host has been diagnosed; can include
-      multiple diagnoses. The value of the field depends on host; for humans the terms
-      should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org,
+      multiple diagnoses. The value of the field depends on host; for humans the
+      terms should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org,
       non-human host diseases are free text
     title: host disease status
     in_subset:
@@ -8085,7 +8166,9 @@ slots:
     slot_uri: MIXS:0000031
   host_dry_mass:
     annotations:
-      Preferred_unit: kilogram, gram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilogram, gram
     description: Measurement of dry mass
     title: host dry mass
     examples:
@@ -8098,14 +8181,16 @@ slots:
     slot_uri: MIXS:0000257
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_fam_rel:
     annotations:
-      Expected_value: relationship type;arbitrary identifier
+      Expected_value:
+        tag: Expected_value
+        value: relationship type;arbitrary identifier
     description: Relationships to other hosts in the same study; can include multiple
       relationships
     title: host family relationship
@@ -8137,14 +8222,16 @@ slots:
       - host.
     slot_uri: MIXS:0000871
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   host_height:
     annotations:
-      Preferred_unit: centimeter, millimeter, meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: centimeter, millimeter, meter
     description: The height of subject
     title: host height
     keywords:
@@ -8154,14 +8241,16 @@ slots:
     slot_uri: MIXS:0000264
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_hiv_stat:
     annotations:
-      Expected_value: HIV status;HAART initiation status
+      Expected_value:
+        tag: Expected_value
+        value: HIV status;HAART initiation status
     description: HIV status of subject, if yes HAART initiation status should also
       be indicated as [YES or NO]
     title: host HIV status
@@ -8193,7 +8282,9 @@ slots:
     range: string
   host_last_meal:
     annotations:
-      Expected_value: content;duration
+      Expected_value:
+        tag: Expected_value
+        value: content;duration
     description: Content of last meal and time since feeding; can include multiple
       values
     title: host last meal
@@ -8205,7 +8296,9 @@ slots:
     multivalued: true
   host_length:
     annotations:
-      Preferred_unit: centimeter, millimeter, meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: centimeter, millimeter, meter
     description: The length of subject
     title: host length
     examples:
@@ -8217,25 +8310,29 @@ slots:
     slot_uri: MIXS:0000256
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_life_stage:
     annotations:
-      Expected_value: stage
+      Expected_value:
+        tag: Expected_value
+        value: stage
     description: Description of life stage of host
     title: host life stage
     keywords:
       - host
       - host.
       - life
-    range: string
     slot_uri: MIXS:0000251
+    range: string
   host_number:
     annotations:
-      Expected_value: count
+      Expected_value:
+        tag: Expected_value
+        value: count
     description: Number of symbiotic host individuals pooled at the time of collection
     title: host number individual
     examples:
@@ -8251,8 +8348,8 @@ slots:
     title: host occupation
     comments:
       - Couldn't convert host_occupation with value veterinary to integer
-      - almost all host_occupation values in the NCBI biosample_set are strings, not
-        integers
+      - almost all host_occupation values in the NCBI biosample_set are strings,
+        not integers
     examples:
       - value: veterinary
     keywords:
@@ -8262,7 +8359,9 @@ slots:
     range: string
   host_of_host_coinf:
     annotations:
-      Expected_value: species name of coinfecting organism(s)
+      Expected_value:
+        tag: Expected_value
+        value: species name of coinfecting organism(s)
     description: The taxonomic name of any coinfecting organism observed in a symbiotic
       relationship with the host of the sampled host organism. e.g. where a sample
       collected from a host trematode species (A) which was collected from a host_of_host
@@ -8278,15 +8377,18 @@ slots:
       - host.
       - observed
       - organism
-    range: string
     slot_uri: MIXS:0001310
+    range: string
   host_of_host_disease:
     annotations:
-      Expected_value: disease name or Disease Ontology term
+      Expected_value:
+        tag: Expected_value
+        value: disease name or Disease Ontology term
     description: List of diseases with which the host of the symbiotic host organism
-      has been diagnosed; can include multiple diagnoses. The value of the field depends
-      on host; for humans the terms should be chosen from the DO (Human Disease Ontology)
-      at https://www.disease-ontology.org, non-human host diseases are free text
+      has been diagnosed; can include multiple diagnoses. The value of the field
+      depends on host; for humans the terms should be chosen from the DO (Human Disease
+      Ontology) at https://www.disease-ontology.org, non-human host diseases are
+      free text
     title: host of the symbiotic host disease status
     examples:
       - value: rabies [DOID:11260]
@@ -8301,13 +8403,16 @@ slots:
     multivalued: true
   host_of_host_env_loc:
     annotations:
-      Expected_value: UBERON term(s), multiple values can be separated by pipes
+      Expected_value:
+        tag: Expected_value
+        value: UBERON term(s), multiple values can be separated by pipes
     description: For a symbiotic host organism the local anatomical environment within
-      its host may have causal influences. Report the anatomical entity(s) which are
-      in the direct environment of the symbiotic host organism being sampled and which
-      you believe have significant causal influences on your sample or specimen. For
-      example, if the symbiotic host organism being sampled is an intestinal worm,
-      its local environmental context will be the term for intestine from UBERON (http://uberon.github.io/)
+      its host may have causal influences. Report the anatomical entity(s) which
+      are in the direct environment of the symbiotic host organism being sampled
+      and which you believe have significant causal influences on your sample or
+      specimen. For example, if the symbiotic host organism being sampled is an intestinal
+      worm, its local environmental context will be the term for intestine from UBERON
+      (http://uberon.github.io/)
     title: host of the symbiotic host local environmental context
     examples:
       - value: small intestine[uberon:0002108]
@@ -8322,7 +8427,10 @@ slots:
     multivalued: true
   host_of_host_env_med:
     annotations:
-      Expected_value: An ontology term for a material such as a tissue type or excreted substance
+      Expected_value:
+        tag: Expected_value
+        value: An ontology term for a material such as a tissue type or excreted
+          substance
     description: 'Report the environmental material(s) immediately surrounding the
       symbiotic host organism at the time of sampling. This usually will be a tissue
       or substance type from the host, but may be another material if the symbiont
@@ -8346,7 +8454,9 @@ slots:
     slot_uri: MIXS:0001326
   host_of_host_fam_rel:
     annotations:
-      Expected_value: relationship type;arbitrary identifier
+      Expected_value:
+        tag: Expected_value
+        value: relationship type;arbitrary identifier
     description: Familial relationship of the host of the symbiotic host organisms
       to other hosts of symbiotic host organism in the same study; can include multiple
       relationships
@@ -8371,7 +8481,9 @@ slots:
     range: string
   host_of_host_gravid:
     annotations:
-      Expected_value: gravidity status;timestamp
+      Expected_value:
+        tag: Expected_value
+        value: gravidity status;timestamp
     description: Whether or not the host of the symbiotic host organism is gravid,
       and if yes date due or date post-conception, specifying which is used
     title: host of the symbiotic host gravidity
@@ -8392,8 +8504,8 @@ slots:
     slot_uri: MIXS:0001329
     range: string
   host_of_host_infrank:
-    description: Taxonomic rank information about the host of the symbiotic host organism
-      below subspecies level, such as variety, form, rank etc
+    description: Taxonomic rank information about the host of the symbiotic host
+      organism below subspecies level, such as variety, form, rank etc
     title: host of the symbiotic host infra-specific rank
     keywords:
       - host
@@ -8415,7 +8527,9 @@ slots:
     range: string
   host_of_host_pheno:
     annotations:
-      Expected_value: phenotype of the host of the symbiotic organism; PATO
+      Expected_value:
+        tag: Expected_value
+        value: phenotype of the host of the symbiotic organism; PATO
     description: Phenotype of the host of the symbiotic host organism. For phenotypic
       quality ontology (PATO) terms, see http://purl.bioontology.org/ontology/pato
     title: host of the symbiotic host phenotype
@@ -8440,7 +8554,9 @@ slots:
     range: string
   host_of_host_taxid:
     annotations:
-      Expected_value: NCBI taxon identifier of the host of the symbiotic taxon organism
+      Expected_value:
+        tag: Expected_value
+        value: NCBI taxon identifier of the host of the symbiotic taxon organism
     description: NCBI taxon id of the host of the symbiotic host organism
     title: host of the symbiotic host taxon id
     examples:
@@ -8466,16 +8582,18 @@ slots:
     slot_uri: MIXS:0001334
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_phenotype:
     annotations:
-      Expected_value: PATO or HP
-    description: Phenotype of human or other host. Use terms from the phenotypic quality
-      ontology (pato) or the Human Phenotype Ontology (HP)
+      Expected_value:
+        tag: Expected_value
+        value: PATO or HP
+    description: Phenotype of human or other host. Use terms from the phenotypic
+      quality ontology (pato) or the Human Phenotype Ontology (HP)
     title: host phenotype
     keywords:
       - host
@@ -8501,7 +8619,7 @@ slots:
     title: host prediction estimated accuracy
     examples:
       - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
-        genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
+          genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
     in_subset:
       - sequencing
     keywords:
@@ -8512,7 +8630,9 @@ slots:
     range: string
   host_pulse:
     annotations:
-      Preferred_unit: beats per minute
+      Preferred_unit:
+        tag: Preferred_unit
+        value: beats per minute
     description: Resting pulse, measured as beats per minute
     title: host pulse
     examples:
@@ -8523,14 +8643,16 @@ slots:
     slot_uri: MIXS:0000333
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_sex:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Gender or physical sex of the host
     title: host sex
     comments:
@@ -8556,7 +8678,9 @@ slots:
     range: string
   host_spec_range:
     annotations:
-      Expected_value: NCBI taxid
+      Expected_value:
+        tag: Expected_value
+        value: NCBI taxid
     description: The range and diversity of host species that an organism is capable
       of infecting, defined by NCBI taxonomy identifier
     title: host specificity or range
@@ -8594,13 +8718,15 @@ slots:
     range: string
   host_subspecf_genlin:
     annotations:
-      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
-        e.g. serovar, biotype, ecotype, variety, cultivar
-    description: Information about the genetic distinctness of the host organism below
-      the subspecies level e.g., serovar, serotype, biotype, ecotype, variety, cultivar,
-      or any relevant genetic typing schemes like Group I plasmid. Subspecies should
-      not be recorded in this term, but in the NCBI taxonomy. Supply both the lineage
-      name and the lineage rank separated by a colon, e.g., biovar:abc123
+      Expected_value:
+        tag: Expected_value
+        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
+          e.g. serovar, biotype, ecotype, variety, cultivar
+    description: Information about the genetic distinctness of the host organism
+      below the subspecies level e.g., serovar, serotype, biotype, ecotype, variety,
+      cultivar, or any relevant genetic typing schemes like Group I plasmid. Subspecies
+      should not be recorded in this term, but in the NCBI taxonomy. Supply both
+      the lineage name and the lineage rank separated by a colon, e.g., biovar:abc123
     title: host subspecific genetic lineage
     examples:
       - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
@@ -8623,23 +8749,27 @@ slots:
     range: string
   host_symbiont:
     annotations:
-      Expected_value: species name or common name
+      Expected_value:
+        tag: Expected_value
+        value: species name or common name
     description: The taxonomic name of the organism(s) found living in mutualistic,
-      commensalistic, or parasitic symbiosis with the specific host. The sampled symbiont
-      can have its own symbionts. For example, parasites may have hyperparasites (=parasites
-      of the parasite)
+      commensalistic, or parasitic symbiosis with the specific host. The sampled
+      symbiont can have its own symbionts. For example, parasites may have hyperparasites
+      (=parasites of the parasite)
     title: observed host symbionts
     keywords:
       - host
       - host.
       - observed
       - symbiosis
-    range: string
     slot_uri: MIXS:0001298
+    range: string
     multivalued: true
   host_taxid:
     annotations:
-      Expected_value: NCBI taxon identifier
+      Expected_value:
+        tag: Expected_value
+        value: NCBI taxon identifier
     description: NCBI taxon id of the host, e.g. 9606
     title: host taxid
     keywords:
@@ -8649,7 +8779,9 @@ slots:
     slot_uri: MIXS:0000250
   host_tot_mass:
     annotations:
-      Preferred_unit: kilogram, gram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilogram, gram
     description: Total mass of the host at collection, the unit depends on host
     title: host total mass
     keywords:
@@ -8660,14 +8792,16 @@ slots:
     slot_uri: MIXS:0000263
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_wet_mass:
     annotations:
-      Preferred_unit: kilogram, gram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilogram, gram
     description: Measurement of wet mass
     title: host wet mass
     examples:
@@ -8680,7 +8814,7 @@ slots:
     slot_uri: MIXS:0000567
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8701,20 +8835,24 @@ slots:
     slot_uri: MIXS:0000100
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   humidity_regm:
     annotations:
-      Expected_value: humidity value;treatment interval and duration
-      Preferred_unit: gram per cubic meter
+      Expected_value:
+        tag: Expected_value
+        value: humidity value;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram per cubic meter
     description: Information about treatment involving an exposure to varying degree
-      of humidity; information about treatment involving use of growth hormones; should
-      include amount of humidity administered, treatment regimen including how many
-      times the treatment was repeated, how long each treatment lasted, and the start
-      and end time of the entire treatment; can include multiple regimens
+      of humidity; information about treatment involving use of growth hormones;
+      should include amount of humidity administered, treatment regimen including
+      how many times the treatment was repeated, how long each treatment lasted,
+      and the start and end time of the entire treatment; can include multiple regimens
     title: humidity regimen
     examples:
       - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -8726,7 +8864,9 @@ slots:
     multivalued: true
   hygienic_area:
     annotations:
-      Expected_value: Expected value
+      Expected_value:
+        tag: Expected_value
+        value: Expected value
     description: The subdivision of areas within a food production facility according
       to hygienic requirements. This field accepts terms listed under hygienic food
       production area (http://purl.obolibrary.org/obo/ENVO). Please add a term that
@@ -8739,8 +8879,8 @@ slots:
       - area
       - food
       - production
-    range: string
     slot_uri: MIXS:0001253
+    range: string
   hysterectomy:
     description: Specification of whether hysterectomy was performed
     title: hysterectomy
@@ -8756,8 +8896,8 @@ slots:
     keywords:
       - code
     slot_uri: MIXS:0000884
-    multivalued: true
     range: integer
+    multivalued: true
   indoor_space:
     description: A distinguishable space within a structure, the purpose for which
       discrete areas of a building is used
@@ -8781,7 +8921,9 @@ slots:
     range: IndoorSurfEnum
   indust_eff_percent:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: Percentage of industrial effluents received by wastewater treatment
       plant
     title: industrial effluent percent
@@ -8790,17 +8932,21 @@ slots:
     slot_uri: MIXS:0000662
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   inorg_particles:
     annotations:
-      Expected_value: inorganic particle name;measurement value
-      Preferred_unit: mole per liter, milligram per liter
-    description: Concentration of particles such as sand, grit, metal particles, ceramics,
-      etc.; can include multiple particles
+      Expected_value:
+        tag: Expected_value
+        value: inorganic particle name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: mole per liter, milligram per liter
+    description: Concentration of particles such as sand, grit, metal particles,
+      ceramics, etc.; can include multiple particles
     title: inorganic particles
     keywords:
       - inorganic
@@ -8810,7 +8956,9 @@ slots:
     multivalued: true
   inside_lux:
     annotations:
-      Preferred_unit: kilowatt per square metre
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilowatt per square metre
     description: The recorded value at sampling time (power density)
     title: inside lux light
     keywords:
@@ -8819,7 +8967,7 @@ slots:
     slot_uri: MIXS:0000168
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8838,10 +8986,12 @@ slots:
     range: DamagedEnum
   intended_consumer:
     annotations:
-      Expected_value: FOODON_03510136 or NCBI taxid
-    description: Food consumer type, human or animal, for which the food product is
-      produced and marketed. This field accepts terms listed under food consumer group
-      (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
+      Expected_value:
+        tag: Expected_value
+        value: FOODON_03510136 or NCBI taxid
+    description: Food consumer type, human or animal, for which the food product
+      is produced and marketed. This field accepts terms listed under food consumer
+      group (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
     title: intended consumer
     examples:
       - value: 9606 o rsenior as food consumer [FOODON:03510254]
@@ -8883,7 +9033,9 @@ slots:
     range: datetime
   iwf:
     annotations:
-      Preferred_unit: percent
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percent
     description: Proportion of the produced fluids derived from injected water at
       the time of sampling. (e.g. 87%)
     title: injection water fraction
@@ -8899,7 +9051,7 @@ slots:
     range: float
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8912,8 +9064,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000277
-    multivalued: true
     range: string
+    multivalued: true
   last_clean:
     description: The last time the floor was cleaned (swept, mopped, vacuumed)
     title: last time swept/mopped/vacuumed
@@ -8925,8 +9077,8 @@ slots:
     range: datetime
   lat_lon:
     description: The geographical origin of the sample as defined by latitude and
-      longitude. The values should be reported in decimal degrees, limited to 8 decimal points,
-      and in WGS84 system
+      longitude. The values should be reported in decimal degrees, limited to 8 decimal
+      points, and in WGS84 system
     title: geographic location (latitude and longitude)
     examples:
       - value: 50.586825 6.408977
@@ -8967,7 +9119,9 @@ slots:
     range: integer
   lib_screen:
     annotations:
-      Expected_value: screening strategy name
+      Expected_value:
+        tag: Expected_value
+        value: screening strategy name
     description: Specific enrichment or screening methods applied before and/or after
       creating libraries
     title: library screening strategy
@@ -8977,8 +9131,8 @@ slots:
       - sequencing
     keywords:
       - library
-    range: string
     slot_uri: MIXS:0000043
+    range: string
   lib_size:
     description: Total number of clones in the library prepared for the project
     title: library size
@@ -8993,7 +9147,9 @@ slots:
     range: integer
   lib_vector:
     annotations:
-      Expected_value: vector
+      Expected_value:
+        tag: Expected_value
+        value: vector
     description: Cloning vector type(s) used in construction of libraries
     title: library vector
     examples:
@@ -9002,11 +9158,13 @@ slots:
       - sequencing
     keywords:
       - library
-    range: string
     slot_uri: MIXS:0000042
+    range: string
   library_prep_kit:
     annotations:
-      Expected_value: name of library preparation kit
+      Expected_value:
+        tag: Expected_value
+        value: name of library preparation kit
     description: Packaged kits (containing adapters, indexes, enzymes, buffers etc.),
       tailored for specific sequencing workflows, which allow the simplified preparation
       of sequencing-ready libraries for small genomes, amplicons, and plasmids
@@ -9015,11 +9173,13 @@ slots:
       - kit
       - library
       - preparation
-    range: string
     slot_uri: MIXS:0001145
+    range: string
   light_intensity:
     annotations:
-      Preferred_unit: lux
+      Preferred_unit:
+        tag: Preferred_unit
+        value: lux
     description: Measurement of light intensity
     title: light intensity
     examples:
@@ -9030,15 +9190,19 @@ slots:
     slot_uri: MIXS:0000706
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   light_regm:
     annotations:
-      Expected_value: exposure type;light intensity;light quality
-      Preferred_unit: lux; micrometer, nanometer, angstrom
+      Expected_value:
+        tag: Expected_value
+        value: exposure type;light intensity;light quality
+      Preferred_unit:
+        tag: Preferred_unit
+        value: lux; micrometer, nanometer, angstrom
     description: Information about treatment(s) involving exposure to light, including
       both light intensity and quality
     title: light regimen
@@ -9052,8 +9216,8 @@ slots:
   light_type:
     description: Application of light to achieve some practical or aesthetic effect.
       Lighting includes the use of both artificial light sources such as lamps and
-      light fixtures, as well as natural illumination by capturing daylight. Can also
-      include absence of light
+      light fixtures, as well as natural illumination by capturing daylight. Can
+      also include absence of light
     title: light type
     examples:
       - value: desk lamp
@@ -9061,9 +9225,9 @@ slots:
       - light
       - type
     slot_uri: MIXS:0000769
-    multivalued: true
     range: LightTypeEnum
     required: true
+    multivalued: true
   link_addit_analys:
     description: Link to additional analysis results performed on the sample
     title: links to additional analysis
@@ -9078,7 +9242,9 @@ slots:
       partial_match: true
   link_class_info:
     annotations:
-      Expected_value: PMID,DOI or url
+      Expected_value:
+        tag: Expected_value
+        value: PMID,DOI or url
     description: Link to digitized soil maps or other soil classification information
     title: link to classification information
     keywords:
@@ -9112,24 +9278,26 @@ slots:
     range: LithologyEnum
     recommended: true
   liver_disord:
-    description: History of liver disorders; can include multiple disorders. The terms
-      should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
+    description: History of liver disorders; can include multiple disorders. The
+      terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
       liver disease (https://disease-ontology.org/?id=DOID:409)
     title: liver disorder
     keywords:
       - disorder
     slot_uri: MIXS:0000282
-    multivalued: true
     range: string
+    multivalued: true
   local_class:
     annotations:
-      Expected_value: local classification name
+      Expected_value:
+        tag: Expected_value
+        value: local classification name
     description: Soil classification based on local soil classification system
     title: soil_taxonomic/local classification
     keywords:
       - classification
-    range: string
     slot_uri: MIXS:0000330
+    range: string
   local_class_meth:
     description: Reference or method used in determining the local soil classification
     title: soil_taxonomic/local classification method
@@ -9145,7 +9313,9 @@ slots:
       partial_match: true
   lot_number:
     annotations:
-      Expected_value: lot number, item
+      Expected_value:
+        tag: Expected_value
+        value: lot number, item
     description: 'A distinctive alpha-numeric identification code assigned by the
       manufacturer or distributor to a specific quantity of manufactured material
       or product within a batch. Synonym: Batch Number.  The submitter should provide
@@ -9173,8 +9343,10 @@ slots:
     range: MagCovSoftwareEnum
   magnesium:
     annotations:
-      Preferred_unit: mole per liter, milligram per liter, parts per million, micromole per
-        kilogram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: mole per liter, milligram per liter, parts per million, micromole
+          per kilogram
     description: Concentration of magnesium in the sample
     title: magnesium
     examples:
@@ -9182,7 +9354,7 @@ slots:
     slot_uri: MIXS:0000431
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9201,14 +9373,16 @@ slots:
       - maximum
     slot_uri: MIXS:0000229
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
       partial_match: true
   mean_frict_vel:
     annotations:
-      Preferred_unit: meter per second
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter per second
     description: Measurement of mean friction velocity
     title: mean friction velocity
     examples:
@@ -9219,14 +9393,16 @@ slots:
     slot_uri: MIXS:0000498
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   mean_peak_frict_vel:
     annotations:
-      Preferred_unit: meter per second
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter per second
     description: Measurement of mean peak friction velocity
     title: mean peak friction velocity
     examples:
@@ -9238,7 +9414,7 @@ slots:
     slot_uri: MIXS:0000502
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9252,7 +9428,9 @@ slots:
     range: MechStrucEnum
   mechanical_damage:
     annotations:
-      Expected_value: damage type;body site
+      Expected_value:
+        tag: Expected_value
+        value: damage type;body site
     description: Information about any mechanical damage exerted on the plant; can
       include multiple damages and sites
     title: mechanical damage
@@ -9286,13 +9464,15 @@ slots:
     range: datetime
   methane:
     annotations:
-      Preferred_unit: micromole per liter, parts per billion, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, parts per billion, parts per million
     description: Methane (gas) amount or concentration at the time of sampling
     title: methane
     slot_uri: MIXS:0000101
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9329,16 +9509,18 @@ slots:
       - microbiological
     slot_uri: MIXS:0001216
     range: string
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   microb_start:
     annotations:
-      Expected_value: FOODON:03544453
-    description: Any type of microorganisms used in food production.  This field accepts
-      terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03544453
+    description: Any type of microorganisms used in food production.  This field
+      accepts terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
     title: microbial starter
     examples:
       - value: starter cultures [FOODON:03544454]
@@ -9348,16 +9530,21 @@ slots:
     slot_uri: MIXS:0001217
   microb_start_count:
     annotations:
-      Expected_value: organism name; measurement value; enumeration
-      Preferred_unit: colony forming units per milliliter; colony forming units per gram
-        of dry weight
+      Expected_value:
+        tag: Expected_value
+        value: organism name; measurement value; enumeration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: colony forming units per milliliter; colony forming units per gram
+          of dry weight
     description: 'Total cell count of starter culture per gram, volume or area of
       sample and the method that was used for the enumeration (e.g. qPCR, atp, mpn,
       etc.) should also be provided. (example : total prokaryotes; 3.5e7 cells per
       ml; qPCR)'
     title: microbial starter organism count
     examples:
-      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
+      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread
+          plate
     keywords:
       - count
       - microbial
@@ -9366,7 +9553,9 @@ slots:
     slot_uri: MIXS:0001218
   microb_start_inoc:
     annotations:
-      Preferred_unit: milligram or gram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram or gram
     description: The amount of starter culture used to inoculate a new batch
     title: microbial starter inoculation
     examples:
@@ -9376,7 +9565,7 @@ slots:
     slot_uri: MIXS:0001219
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9424,7 +9613,9 @@ slots:
       partial_match: true
   microbial_biomass:
     annotations:
-      Preferred_unit: ton, kilogram, gram per kilogram soil
+      Preferred_unit:
+        tag: Preferred_unit
+        value: ton, kilogram, gram per kilogram soil
     description: The part of the organic matter in the soil that constitutes living
       microorganisms smaller than 5-10 micrometer. If you keep this, you would need
       to have correction factors used for conversion to the final units
@@ -9435,7 +9626,7 @@ slots:
     slot_uri: MIXS:0000650
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9460,14 +9651,18 @@ slots:
       partial_match: true
   mineral_nutr_regm:
     annotations:
-      Expected_value: mineral nutrient name;mineral nutrient amount;treatment interval and
-        duration
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: mineral nutrient name;mineral nutrient amount;treatment interval and
+          duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of mineral supplements;
       should include the name of mineral nutrient, amount administered, treatment
-      regimen including how many times the treatment was repeated, how long each treatment
-      lasted, and the start and end time of the entire treatment; can include multiple
-      mineral nutrient regimens
+      regimen including how many times the treatment was repeated, how long each
+      treatment lasted, and the start and end time of the entire treatment; can include
+      multiple mineral nutrient regimens
     title: mineral nutrient regimen
     examples:
       - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -9480,9 +9675,11 @@ slots:
     multivalued: true
   misc_param:
     annotations:
-      Expected_value: parameter name;measurement value
-    description: Any other measurement performed or parameter collected, that is not
-      listed here
+      Expected_value:
+        tag: Expected_value
+        value: parameter name;measurement value
+    description: Any other measurement performed or parameter collected, that is
+      not listed here
     title: miscellaneous parameter
     examples:
       - value: Bicarbonate ion concentration;2075 micromole per kilogram
@@ -9502,7 +9699,9 @@ slots:
     recommended: true
   n_alkanes:
     annotations:
-      Expected_value: n-alkane name;measurement value
+      Expected_value:
+        tag: Expected_value
+        value: n-alkane name;measurement value
     description: Concentration of n-alkanes; can include multiple n-alkanes
     title: n-alkanes
     examples:
@@ -9512,7 +9711,9 @@ slots:
     multivalued: true
   neg_cont_type:
     annotations:
-      Expected_value: enumeration or text
+      Expected_value:
+        tag: Expected_value
+        value: enumeration or text
     description: The substance or equipment used as a negative control in an investigation
     title: negative control type
     in_subset:
@@ -9524,7 +9725,9 @@ slots:
     recommended: true
   nitrate:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: Concentration of nitrate in the sample
     title: nitrate
     examples:
@@ -9534,14 +9737,16 @@ slots:
     slot_uri: MIXS:0000425
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   nitrite:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: Concentration of nitrite in the sample
     title: nitrite
     examples:
@@ -9551,14 +9756,16 @@ slots:
     slot_uri: MIXS:0000426
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   nitro:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Concentration of nitrogen (total)
     title: nitrogen
     examples:
@@ -9568,14 +9775,16 @@ slots:
     slot_uri: MIXS:0000504
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   non_min_nutr_regm:
     annotations:
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Information about treatment involving the exposure of plant to non-mineral
       nutrient such as oxygen, hydrogen or carbon; should include the name of non-mineral
       nutrient, amount administered, treatment regimen including how many times the
@@ -9589,20 +9798,20 @@ slots:
       - nutrient
       - regimen
     slot_uri: MIXS:0000571
-    multivalued: true
     range: string
+    multivalued: true
   nose_mouth_teeth_throat_disord:
     description: History of nose/mouth/teeth/throat disorders; can include multiple
-      disorders. The terms should be chosen from the DO (Human Disease Ontology) at
-      http://www.disease-ontology.org, nose disease (https://disease-ontology.org/?id=DOID:2825),
+      disorders. The terms should be chosen from the DO (Human Disease Ontology)
+      at http://www.disease-ontology.org, nose disease (https://disease-ontology.org/?id=DOID:2825),
       mouth disease (https://disease-ontology.org/?id=DOID:403), tooth disease (https://disease-ontology.org/?id=DOID:1091),
       or upper respiratory tract disease (https://disease-ontology.org/?id=DOID:974)
     title: nose/mouth/teeth/throat disorder
     keywords:
       - disorder
     slot_uri: MIXS:0000283
-    multivalued: true
     range: string
+    multivalued: true
   nose_throat_disord:
     description: History of nose-throat disorders; can include multiple disorders,  The
       terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
@@ -9612,8 +9821,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000270
-    multivalued: true
     range: string
+    multivalued: true
   nucl_acid_amp:
     description: A link to a literature reference, electronic resource or a standard
       operating procedure (SOP), that describes the enzymatic amplification (PCR,
@@ -9648,20 +9857,24 @@ slots:
       partial_match: true
   nucl_acid_ext_kit:
     annotations:
-      Expected_value: The name of an extraction kit
-    description: The name of the extraction kit used to recover the nucleic acid fraction
-      of an input material is performed
+      Expected_value:
+        tag: Expected_value
+        value: The name of an extraction kit
+    description: The name of the extraction kit used to recover the nucleic acid
+      fraction of an input material is performed
     title: nucleic acid extraction kit
     examples:
       - value: Qiagen PowerSoil Kit
     keywords:
       - kit
-    range: string
     slot_uri: MIXS:0001223
+    range: string
     multivalued: true
   num_replicons:
     annotations:
-      Expected_value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses:
+      Expected_value:
+        tag: Expected_value
+        value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses:
           segments'
     description: Reports the number of replicons in a nuclear genome of eukaryotes,
       in the genome of a bacterium or archaea or the number of segments in a segmented
@@ -9687,7 +9900,7 @@ slots:
     slot_uri: MIXS:0001224
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9711,7 +9924,7 @@ slots:
       - number
     slot_uri: MIXS:0000231
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -9723,7 +9936,7 @@ slots:
       - number
     slot_uri: MIXS:0000230
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -9735,7 +9948,7 @@ slots:
       - number
     slot_uri: MIXS:0000232
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -9767,7 +9980,7 @@ slots:
     slot_uri: MIXS:0000772
     range: float
     required: true
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -9783,22 +9996,26 @@ slots:
     slot_uri: MIXS:0000508
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   org_count_qpcr_info:
     annotations:
-      Expected_value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
-        denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
-        elongation:degrees_minutes; total cycles
-      Preferred_unit: number of cells per gram (or ml or cm^2)
-    description: 'If qpcr was used for the cell count, the target gene name, the primer
-      sequence and the cycling conditions should also be provided. (Example: 16S rrna;
-      FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min; denaturation:90C_2min;
-      annealing:52C_30 sec; elongation:72C_30 sec; 90 C for 1 min; final elongation:72C_5min;
-      30 cycles)'
+      Expected_value:
+        tag: Expected_value
+        value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
+          denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
+          elongation:degrees_minutes; total cycles
+      Preferred_unit:
+        tag: Preferred_unit
+        value: number of cells per gram (or ml or cm^2)
+    description: 'If qpcr was used for the cell count, the target gene name, the
+      primer sequence and the cycling conditions should also be provided. (Example:
+      16S rrna; FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min;
+      denaturation:90C_2min; annealing:52C_30 sec; elongation:72C_30 sec; 90 C for
+      1 min; final elongation:72C_5min; 30 cycles)'
     title: organism count qPCR information
     keywords:
       - count
@@ -9809,7 +10026,9 @@ slots:
     slot_uri: MIXS:0000099
   org_matter:
     annotations:
-      Preferred_unit: microgram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter
     description: Concentration of organic matter
     title: organic matter
     examples:
@@ -9819,7 +10038,7 @@ slots:
     slot_uri: MIXS:0000204
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9835,15 +10054,19 @@ slots:
     slot_uri: MIXS:0000205
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   org_particles:
     annotations:
-      Expected_value: particle name;measurement value
-      Preferred_unit: gram per liter
+      Expected_value:
+        tag: Expected_value
+        value: particle name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram per liter
     description: Concentration of particles such as faeces, hairs, food, vomit, paper
       fibers, plant material, humus, etc
     title: organic particles
@@ -9855,7 +10078,9 @@ slots:
     multivalued: true
   organism_count:
     annotations:
-      Expected_value: organism name;measurement value;enumeration
+      Expected_value:
+        tag: Expected_value
+        value: organism name;measurement value;enumeration
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
       The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should
@@ -9869,11 +10094,13 @@ slots:
     multivalued: true
   otu_class_appr:
     annotations:
-      Expected_value: cutoffs and method used
-    description: Cutoffs and approach used when clustering  species-level  OTUs. Note
-      that results from standard 95% ANI / 85% AF clustering should be provided alongside
-      OTUS defined from another set of thresholds, even if the latter are the ones
-      primarily used during the analysis
+      Expected_value:
+        tag: Expected_value
+        value: cutoffs and method used
+    description: Cutoffs and approach used when clustering  species-level  OTUs.
+      Note that results from standard 95% ANI / 85% AF clustering should be provided
+      alongside OTUS defined from another set of thresholds, even if the latter are
+      the ones primarily used during the analysis
     title: OTU classification approach
     examples:
       - value: 95% ANI;85% AF; greedy incremental clustering
@@ -9886,9 +10113,11 @@ slots:
     slot_uri: MIXS:0000085
   otu_db:
     annotations:
-      Expected_value: database and version
-    description: Reference database (i.e. sequences not generated as part of the current
-      study) used to cluster new genomes in "species-level" OTUs, if any
+      Expected_value:
+        tag: Expected_value
+        value: database and version
+    description: Reference database (i.e. sequences not generated as part of the
+      current study) used to cluster new genomes in "species-level" OTUs, if any
     title: OTU database
     examples:
       - value: NCBI Viral RefSeq;83
@@ -9901,7 +10130,9 @@ slots:
     slot_uri: MIXS:0000087
   otu_seq_comp_appr:
     annotations:
-      Expected_value: software name, version and relevant parameters
+      Expected_value:
+        tag: Expected_value
+        value: software name, version and relevant parameters
     description: Tool and thresholds used to compare sequences when computing "species-level"
       OTUs
     title: OTU sequence comparison approach
@@ -9915,8 +10146,11 @@ slots:
     slot_uri: MIXS:0000086
   owc_tvdss:
     annotations:
-      Preferred_unit: meter
-    description: Depth of the original oil water contact (OWC) zone (average) (m TVDSS)
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
+    description: Depth of the original oil water contact (OWC) zone (average) (m
+      TVDSS)
     title: oil water contact depth
     keywords:
       - depth
@@ -9925,7 +10159,7 @@ slots:
     slot_uri: MIXS:0000405
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9943,7 +10177,9 @@ slots:
     range: OxyStatSampEnum
   oxygen:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Oxygen (gas) amount or concentration at the time of sampling
     title: oxygen
     examples:
@@ -9953,7 +10189,7 @@ slots:
     slot_uri: MIXS:0000104
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9971,14 +10207,16 @@ slots:
     slot_uri: MIXS:0000515
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   part_org_nitro:
     annotations:
-      Preferred_unit: microgram per liter, micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, micromole per liter
     description: Concentration of particulate organic nitrogen
     title: particulate organic nitrogen
     examples:
@@ -9991,14 +10229,16 @@ slots:
     slot_uri: MIXS:0000719
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   part_plant_animal:
     annotations:
-      Expected_value: FOODON:03420116
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03420116
     description: The anatomical part of the organism being involved in food production
       or consumption; e.g., a carrot is the root of the plant (root vegetable). This
       field accepts terms listed under part of plant or animal (http://purl.obolibrary.org/obo/FOODON_03420116)
@@ -10013,11 +10253,16 @@ slots:
     multivalued: true
   particle_class:
     annotations:
-      Expected_value: particle name;measurement value
-      Preferred_unit: micrometer
-    description: Particles are classified, based on their size, into six general categories:clay,
-      silt, sand, gravel, cobbles, and boulders; should include amount of particle
-      preceded by the name of the particle type; can include multiple values
+      Expected_value:
+        tag: Expected_value
+        value: particle name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micrometer
+    description: Particles are classified, based on their size, into six general
+      categories:clay, silt, sand, gravel, cobbles, and boulders; should include
+      amount of particle preceded by the name of the particle type; can include multiple
+      values
     title: particle classification
     keywords:
       - classification
@@ -10027,20 +10272,25 @@ slots:
     multivalued: true
   pathogenicity:
     annotations:
-      Expected_value: names of organisms that the entity is pathogenic to
+      Expected_value:
+        tag: Expected_value
+        value: names of organisms that the entity is pathogenic to
     description: To what is the entity pathogenic
     title: known pathogenicity
     examples:
       - value: human, animal, plant, fungi, bacteria
     in_subset:
       - nucleic acid sequence source
-    range: string
     slot_uri: MIXS:0000027
+    range: string
   pcr_cond:
     annotations:
-      Expected_value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
-        elongation:degrees_minutes;total cycles
-    description: Description of reaction conditions and components of polymerase chain reaction performed during library preparation.
+      Expected_value:
+        tag: Expected_value
+        value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
+          elongation:degrees_minutes;total cycles
+    description: Description of reaction conditions and components of polymerase
+      chain reaction performed during library preparation.
     title: pcr conditions
     examples:
       - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
@@ -10055,11 +10305,14 @@ slots:
     slot_uri: MIXS:0000049
   pcr_primers:
     annotations:
-      Expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
+      Expected_value:
+        tag: Expected_value
+        value: 'FWD: forward primer sequence;REV:reverse primer sequence'
     description: PCR primers that were used to amplify the sequence of the targeted
-      gene, locus or subfragment. This field should contain all the primers used for
-      a single PCR reaction if multiple forward or reverse primers are present in
-      a single PCR reaction. The primer sequence should be reported in uppercase letters
+      gene, locus or subfragment. This field should contain all the primers used
+      for a single PCR reaction if multiple forward or reverse primers are present
+      in a single PCR reaction. The primer sequence should be reported in uppercase
+      letters
     title: pcr primers
     examples:
       - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
@@ -10071,8 +10324,12 @@ slots:
     slot_uri: MIXS:0000046
   permeability:
     annotations:
-      Expected_value: measurement value range
-      Preferred_unit: mD
+      Expected_value:
+        tag: Expected_value
+        value: measurement value range
+      Preferred_unit:
+        tag: Preferred_unit
+        value: mD
     description: 'Measure of the ability of a hydrocarbon resource to allow fluids
       to pass through it. (Additional information: https://en.wikipedia.org/wiki/Permeability_(earth_sciences))'
     title: permeability
@@ -10080,7 +10337,9 @@ slots:
     slot_uri: MIXS:0000404
   perturbation:
     annotations:
-      Expected_value: perturbation type name;perturbation interval and duration
+      Expected_value:
+        tag: Expected_value
+        value: perturbation type name;perturbation interval and duration
     description: Type of perturbation, e.g. chemical administration, physical disturbance,
       etc., coupled with perturbation regimen including how many times the perturbation
       was repeated, how long each perturbation lasted, and the start and end time
@@ -10095,11 +10354,13 @@ slots:
     multivalued: true
   pesticide_regm:
     annotations:
-      Preferred_unit: gram, mole per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of insecticides; should
       include the name of pesticide, amount administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted, and
-      the start and end time of the entire treatment; can include multiple pesticide
+      how many times the treatment was repeated, how long each treatment lasted,
+      and the start and end time of the entire treatment; can include multiple pesticide
       regimens
     title: pesticide regimen
     examples:
@@ -10107,11 +10368,13 @@ slots:
     keywords:
       - regimen
     slot_uri: MIXS:0000573
-    multivalued: true
     range: string
+    multivalued: true
   pet_farm_animal:
     annotations:
-      Expected_value: presence status;type of animal or pet
+      Expected_value:
+        tag: Expected_value
+        value: presence status;type of animal or pet
     description: Specification of presence of pets or farm animals in the environment
       of subject, if yes the animals should be specified; can include multiple animals
       present
@@ -10127,7 +10390,9 @@ slots:
     multivalued: true
   petroleum_hydrocarb:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Concentration of petroleum hydrocarbon
     title: petroleum hydrocarbon
     examples:
@@ -10138,7 +10403,7 @@ slots:
     slot_uri: MIXS:0000516
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10180,12 +10445,16 @@ slots:
       - ph
       - regimen
     slot_uri: MIXS:0001056
-    multivalued: true
     range: string
+    multivalued: true
   phaeopigments:
     annotations:
-      Expected_value: phaeopigment name;measurement value
-      Preferred_unit: milligram per cubic meter
+      Expected_value:
+        tag: Expected_value
+        value: phaeopigment name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per cubic meter
     description: Concentration of phaeopigments; can include multiple phaeopigments
     title: phaeopigments
     examples:
@@ -10195,7 +10464,9 @@ slots:
     multivalued: true
   phosphate:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Concentration of phosphate
     title: phosphate
     examples:
@@ -10205,15 +10476,18 @@ slots:
     slot_uri: MIXS:0000505
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   phosplipid_fatt_acid:
     annotations:
-      Expected_value: phospholipid fatty acid name;measurement value
-    description: Concentration of phospholipid fatty acids; can include multiple values
+      Expected_value:
+        tag: Expected_value
+        value: phospholipid fatty acid name;measurement value
+    description: Concentration of phospholipid fatty acids; can include multiple
+      values
     title: phospholipid fatty acid
     examples:
       - value: 2.98 milligram per liter
@@ -10222,7 +10496,9 @@ slots:
     multivalued: true
   photon_flux:
     annotations:
-      Preferred_unit: number of photons per second per unit area
+      Preferred_unit:
+        tag: Preferred_unit
+        value: number of photons per second per unit area
     description: Measurement of photon flux
     title: photon flux
     examples:
@@ -10230,17 +10506,19 @@ slots:
     slot_uri: MIXS:0000725
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   photosynt_activ:
     annotations:
-      Preferred_unit: mol m-2 s-1
-    description: Measurement of photosythetic activity (i.e. leaf gas exchange / chlorophyll
-      fluorescence emissions / reflectance / transpiration) Please also include the
-      term method term detailing the method of activity measurement
+      Preferred_unit:
+        tag: Preferred_unit
+        value: mol m-2 s-1
+    description: Measurement of photosythetic activity (i.e. leaf gas exchange /
+      chlorophyll fluorescence emissions / reflectance / transpiration) Please also
+      include the term method term detailing the method of activity measurement
     title: photosynthetic activity
     examples:
       - value: 0.1 mol CO2 m-2 s-1
@@ -10250,7 +10528,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10261,17 +10539,19 @@ slots:
     keywords:
       - method
     slot_uri: MIXS:0001336
-    multivalued: true
     range: string
     recommended: true
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    multivalued: true
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   plant_growth_med:
     annotations:
-      Expected_value: EO or enumeration
+      Expected_value:
+        tag: Expected_value
+        value: EO or enumeration
     description: Specification of the media for growing the plants or tissue cultured
       samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in
       vitro liquid culture medium. Recommended value is a specific value from EO:plant
@@ -10286,7 +10566,9 @@ slots:
     slot_uri: MIXS:0001057
   plant_part_maturity:
     annotations:
-      Expected_value: FOODON:03530050
+      Expected_value:
+        tag: Expected_value
+        value: FOODON:03530050
     description: A description of the stage of development of a plant or plant part
       based on maturity or ripeness. This field accepts terms listed under degree
       of plant maturity (http://purl.obolibrary.org/obo/FOODON_03530050)
@@ -10300,7 +10582,9 @@ slots:
     slot_uri: MIXS:0001120
   plant_product:
     annotations:
-      Expected_value: product name
+      Expected_value:
+        tag: Expected_value
+        value: product name
     description: Substance produced by the plant, where the sample was obtained from
     title: plant product
     examples:
@@ -10308,8 +10592,8 @@ slots:
     keywords:
       - plant
       - product
-    range: string
     slot_uri: MIXS:0001058
+    range: string
   plant_reprod_crop:
     description: Plant reproductive part used in the field during planting to start
       the crop
@@ -10319,8 +10603,8 @@ slots:
     keywords:
       - plant
     slot_uri: MIXS:0001150
-    multivalued: true
     range: PlantReprodCropEnum
+    multivalued: true
   plant_sex:
     description: Sex of the reproductive parts on the whole plant, e.g. pistillate,
       staminate, monoecieous, hermaphrodite
@@ -10332,8 +10616,8 @@ slots:
     slot_uri: MIXS:0001059
     range: PlantSexEnum
   plant_struc:
-    description: Name of plant structure the sample was obtained from; for Plant Ontology
-      (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO,
+    description: Name of plant structure the sample was obtained from; for Plant
+      Ontology (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO,
       e.g. petiole epidermis (PO_0000051). If an individual flower is sampled, the
       sex of it can be recorded here
     title: plant structure
@@ -10349,8 +10633,8 @@ slots:
       interpolated: true
       partial_match: true
   plant_water_method:
-    description: Description of the equipment or method used to distribute water to
-      crops. This field accepts termed listed under irrigation process (http://purl.obolibrary.org/obo/AGRO_00000006).
+    description: Description of the equipment or method used to distribute water
+      to crops. This field accepts termed listed under irrigation process (http://purl.obolibrary.org/obo/AGRO_00000006).
       Multiple terms can be separated by pipes
     title: plant water delivery method
     examples:
@@ -10389,8 +10673,12 @@ slots:
       partial_match: true
   pollutants:
     annotations:
-      Expected_value: pollutant name;measurement value
-      Preferred_unit: gram, mole per liter, milligram per liter, microgram per cubic meter
+      Expected_value:
+        tag: Expected_value
+        value: pollutant name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, mole per liter, milligram per liter, microgram per cubic meter
     description: Pollutant types and, amount or concentrations measured at the time
       of sampling; can report multiple pollutants by entering numeric values preceded
       by name of pollutant
@@ -10402,8 +10690,12 @@ slots:
     multivalued: true
   pool_dna_extracts:
     annotations:
-      Expected_value: pooling status;number of pooled extracts
-      Preferred_unit: gram, milliliter, microliter
+      Expected_value:
+        tag: Expected_value
+        value: pooling status;number of pooled extracts
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, milliliter, microliter
     description: Indicate whether multiple DNA extractions were mixed. If the answer
       yes, the number of extracts that were pooled should be given
     title: pooling of DNA extracts (if done)
@@ -10415,8 +10707,12 @@ slots:
     slot_uri: MIXS:0000325
   porosity:
     annotations:
-      Expected_value: measurement value or range
-      Preferred_unit: percentage
+      Expected_value:
+        tag: Expected_value
+        value: measurement value or range
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: Porosity of deposited sediment is volume of voids divided by the
       total volume of sample
     title: porosity
@@ -10437,7 +10733,9 @@ slots:
     recommended: true
   potassium:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of potassium in the sample
     title: potassium
     examples:
@@ -10445,35 +10743,39 @@ slots:
     slot_uri: MIXS:0000430
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   pour_point:
     annotations:
-      Preferred_unit: degree Celsius
-    description: 'Temperature at which a liquid becomes semi solid and loses its flow
-      characteristics. In crude oil a high  pour point  is generally associated with
-      a high paraffin content, typically found in crude deriving from a larger proportion
-      of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
+    description: 'Temperature at which a liquid becomes semi solid and loses its
+      flow characteristics. In crude oil a high  pour point  is generally associated
+      with a high paraffin content, typically found in crude deriving from a larger
+      proportion of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
     title: pour point
     slot_uri: MIXS:0000127
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   pre_treatment:
     annotations:
-      Expected_value: pre-treatment type
+      Expected_value:
+        tag: Expected_value
+        value: pre-treatment type
     description: The process of pre-treatment removes materials that can be easily
       collected from the raw wastewater
     title: pre-treatment
-    range: string
     slot_uri: MIXS:0000348
+    range: string
   pred_genome_struc:
     description: Expected structure of the viral genome
     title: predicted genome structure
@@ -10487,7 +10789,9 @@ slots:
     range: PredGenomeStrucEnum
   pred_genome_type:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Type of genome predicted for the UViG
     title: predicted genome type
     examples:
@@ -10508,7 +10812,9 @@ slots:
     range: datetime
   pres_animal_insect:
     annotations:
-      Expected_value: enumeration;count
+      Expected_value:
+        tag: Expected_value
+        value: enumeration;count
     description: The type and number of animals or insects present in the sampling
       space
     title: presence of pets, animals, or insects
@@ -10521,7 +10827,9 @@ slots:
     slot_uri: MIXS:0000819
   pressure:
     annotations:
-      Preferred_unit: atmosphere
+      Preferred_unit:
+        tag: Preferred_unit
+        value: atmosphere
     description: Pressure to which the sample is subject to, in atmospheres
     title: pressure
     examples:
@@ -10531,7 +10839,7 @@ slots:
     slot_uri: MIXS:0000412
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10553,7 +10861,9 @@ slots:
       partial_match: true
   previous_land_use:
     annotations:
-      Expected_value: land use name;date
+      Expected_value:
+        tag: Expected_value
+        value: land use name;date
     description: Previous land use and dates
     title: history/previous land use
     examples:
@@ -10566,7 +10876,9 @@ slots:
     slot_uri: MIXS:0000315
   primary_prod:
     annotations:
-      Preferred_unit: milligram per cubic meter per day, gram per square meter per day
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per cubic meter per day, gram per square meter per day
     description: Measurement of primary production, generally measured as isotope
       uptake
     title: primary production
@@ -10578,14 +10890,16 @@ slots:
     slot_uri: MIXS:0000728
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   primary_treatment:
     annotations:
-      Expected_value: primary treatment type
+      Expected_value:
+        tag: Expected_value
+        value: primary treatment type
     description: The process to produce both a generally homogeneous liquid capable
       of being treated biologically and a sludge that can be separately treated or
       processed
@@ -10593,23 +10907,25 @@ slots:
     keywords:
       - primary
       - treatment
-    range: string
     slot_uri: MIXS:0000349
+    range: string
   prod_label_claims:
     description: Labeling claims containing descriptors such as wild caught, free-range,
-      organic, free-range, industrial, hormone-free, antibiotic free, cage free. Can
-      include more than one term, separated by ";"
+      organic, free-range, industrial, hormone-free, antibiotic free, cage free.
+      Can include more than one term, separated by ";"
     title: production labeling claims
     examples:
       - value: free range
     keywords:
       - production
     slot_uri: MIXS:prod_label_claims
-    multivalued: true
     range: string
+    multivalued: true
   prod_rate:
     annotations:
-      Preferred_unit: cubic meter per day
+      Preferred_unit:
+        tag: Preferred_unit
+        value: cubic meter per day
     description: Oil and/or gas production rates per well (e.g. 524 m3 / day)
     title: production rate
     keywords:
@@ -10619,7 +10935,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10658,7 +10974,9 @@ slots:
     required: true
   propagation:
     annotations:
-      Expected_value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid:
+      Expected_value:
+        tag: Expected_value
+        value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid:
           incompatibility group; for eukaryote: asexual, sexual; other more specific
           values (e.g., incompatibility group) are allowed'
     description: 'The type of reproduction from the parent stock. Values for this
@@ -10669,18 +10987,18 @@ slots:
       - value: lytic
     in_subset:
       - nucleic acid sequence source
-    range: string
     slot_uri: MIXS:0000033
+    range: string
   pulmonary_disord:
-    description: History of pulmonary disorders; can include multiple disorders. The
-      terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
+    description: History of pulmonary disorders; can include multiple disorders.
+      The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
       lung disease (https://disease-ontology.org/?id=DOID:850)
     title: lung/pulmonary disorder
     keywords:
       - disorder
     slot_uri: MIXS:0000269
-    multivalued: true
     range: string
+    multivalued: true
   quad_pos:
     description: The quadrant position of the sampling room within the building
     title: quadrant position
@@ -10690,13 +11008,17 @@ slots:
     range: QuadPosEnum
   radiation_regm:
     annotations:
-      Expected_value: radiation type name;radiation amount;treatment interval and duration
-      Preferred_unit: rad, gray
+      Expected_value:
+        tag: Expected_value
+        value: radiation type name;radiation amount;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: rad, gray
     description: Information about treatment involving exposure of plant or a plant
-      part to a particular radiation regimen; should include the radiation type, amount
-      or intensity administered, treatment regimen including how many times the treatment
-      was repeated, how long each treatment lasted, and the start and end time of
-      the entire treatment; can include multiple radiation regimens
+      part to a particular radiation regimen; should include the radiation type,
+      amount or intensity administered, treatment regimen including how many times
+      the treatment was repeated, how long each treatment lasted, and the start and
+      end time of the entire treatment; can include multiple radiation regimens
     title: radiation regimen
     examples:
       - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -10707,8 +11029,12 @@ slots:
     multivalued: true
   rainfall_regm:
     annotations:
-      Expected_value: measurement value;treatment interval and duration
-      Preferred_unit: millimeter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value;treatment interval and duration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millimeter
     description: Information about treatment involving an exposure to a given amount
       of rainfall, treatment regimen including how many times the treatment was repeated,
       how long each treatment lasted, and the start and end time of the entire treatment;
@@ -10724,18 +11050,20 @@ slots:
     multivalued: true
   reactor_type:
     annotations:
-      Expected_value: reactor type name
+      Expected_value:
+        tag: Expected_value
+        value: reactor type name
     description: Anaerobic digesters can be designed and engineered to operate using
       a number of different process configurations, as batch or continuous, mesophilic,
       high solid or low solid, and single stage or multistage
     title: reactor type
     keywords:
       - type
-    range: string
     slot_uri: MIXS:0000350
+    range: string
   reassembly_bin:
-    description: Has an assembly been performed on a genome bin extracted from a metagenomic
-      assembly?
+    description: Has an assembly been performed on a genome bin extracted from a
+      metagenomic assembly?
     title: reassembly post binning
     examples:
       - value: 'no'
@@ -10747,7 +11075,9 @@ slots:
     range: boolean
   redox_potential:
     annotations:
-      Preferred_unit: millivolt
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millivolt
     description: Redox potential, measured relative to a hydrogen cell, indicating
       oxidation or reduction potential
     title: redox potential
@@ -10756,7 +11086,7 @@ slots:
     slot_uri: MIXS:0000182
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10778,9 +11108,11 @@ slots:
       partial_match: true
   ref_db:
     annotations:
-      Expected_value: names, versions, and references of databases
-    description: List of database(s) used for ORF annotation, along with version number
-      and reference to website or publication
+      Expected_value:
+        tag: Expected_value
+        value: names, versions, and references of databases
+    description: List of database(s) used for ORF annotation, along with version
+      number and reference to website or publication
     title: reference database(s)
     examples:
       - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017
@@ -10793,7 +11125,9 @@ slots:
     slot_uri: MIXS:0000062
   rel_air_humidity:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: Partial vapor and air pressure, density of the vapor and air, or
       by the actual mass of the vapor and air
     title: relative air humidity
@@ -10809,14 +11143,16 @@ slots:
     range: float
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   rel_humidity_out:
     annotations:
-      Preferred_unit: gram of air, kilogram of air
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram of air, kilogram of air
     description: The recorded outside relative humidity value at the time of sampling
     title: outside relative humidity
     examples:
@@ -10827,7 +11163,7 @@ slots:
     slot_uri: MIXS:0000188
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10869,15 +11205,17 @@ slots:
     range: RelToOxygenEnum
   repository_name:
     annotations:
-      Expected_value: Institution
+      Expected_value:
+        tag: Expected_value
+        value: Institution
     description: The name of the institution where the sample or DNA extract is held
       or "sample not available" if the sample was used in its entirety for analysis
       or otherwise not retained
     title: repository name
     examples:
       - value: FDA CFSAN Microbiology Laboratories
-    range: string
     slot_uri: MIXS:0001152
+    range: string
     multivalued: true
   reservoir:
     description: Name of the reservoir (e.g. Carapebus)
@@ -10887,24 +11225,28 @@ slots:
     recommended: true
   resins_pc:
     annotations:
-      Preferred_unit: percent
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
-      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
+      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: resins wt%
     slot_uri: MIXS:0000134
     range: string
     recommended: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   room_air_exch_rate:
     annotations:
-      Preferred_unit: liter per hour
+      Preferred_unit:
+        tag: Preferred_unit
+        value: liter per hour
     description: The rate at which outside air replaces indoor air in a given space
     title: room air exchange rate
     keywords:
@@ -10914,14 +11256,14 @@ slots:
     slot_uri: MIXS:0000169
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   room_architec_elem:
-    description: The unique details and component parts that, together, form the architecture
-      of a distinguisahable space within a built structure
+    description: The unique details and component parts that, together, form the
+      architecture of a distinguisahable space within a built structure
     title: room architectural elements
     keywords:
       - room
@@ -10958,8 +11300,12 @@ slots:
     range: integer
   room_dim:
     annotations:
-      Expected_value: measurement value
-      Preferred_unit: meter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: The length, width and height of sampling room
     title: room dimensions
     examples:
@@ -10971,7 +11317,9 @@ slots:
     slot_uri: MIXS:0000192
   room_door_dist:
     annotations:
-      Preferred_unit: meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: Distance between doors (meters) in the hallway between the sampling
       room and adjacent rooms
     title: room door distance
@@ -10981,7 +11329,7 @@ slots:
       - room
     slot_uri: MIXS:0000193
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11036,7 +11384,9 @@ slots:
     range: integer
   room_net_area:
     annotations:
-      Preferred_unit: square feet, square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square feet, square meter
     description: The net floor area of sampling room. Net area excludes wall thicknesses
     title: room net area
     keywords:
@@ -11044,7 +11394,7 @@ slots:
       - room
     slot_uri: MIXS:0000194
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11056,7 +11406,7 @@ slots:
       - room
     slot_uri: MIXS:0000236
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11073,7 +11423,9 @@ slots:
     range: RoomSampPosEnum
   room_type:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: The main purpose or activity of the sampling room. A room is any
       distinguishable space within a structure
     title: room type
@@ -11088,7 +11440,9 @@ slots:
     slot_uri: MIXS:0000825
   room_vol:
     annotations:
-      Preferred_unit: cubic feet, cubic meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: cubic feet, cubic meter
     description: Volume of sampling room
     title: room volume
     keywords:
@@ -11096,7 +11450,7 @@ slots:
       - volume
     slot_uri: MIXS:0000195
     range: string
-    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^[1-9][0-9]* .*$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11134,15 +11488,19 @@ slots:
       - condition
     slot_uri: MIXS:0001061
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   root_med_carbon:
     annotations:
-      Expected_value: carbon source name;measurement value
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: carbon source name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Source of organic carbon in the culture rooting medium; e.g. sucrose
     title: rooting medium carbon
     examples:
@@ -11153,8 +11511,12 @@ slots:
     slot_uri: MIXS:0000577
   root_med_macronutr:
     annotations:
-      Expected_value: macronutrient name;measurement value
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: macronutrient name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Measurement of the culture rooting medium macronutrients (N,P, K,
       Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
     title: rooting medium macronutrients
@@ -11166,8 +11528,12 @@ slots:
     slot_uri: MIXS:0000578
   root_med_micronutr:
     annotations:
-      Expected_value: micronutrient name;measurement value
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: micronutrient name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Measurement of the culture rooting medium micronutrients (Fe, Mn,
       Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
     title: rooting medium micronutrients
@@ -11188,8 +11554,12 @@ slots:
     range: float
   root_med_regl:
     annotations:
-      Expected_value: regulator name;measurement value
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: regulator name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Growth regulators in the culture rooting medium such as cytokinins,
       auxins, gybberellins, abscisic acid; e.g. 0.5  mg/L NAA
     title: rooting medium regulators
@@ -11207,11 +11577,15 @@ slots:
     range: string
   root_med_suppl:
     annotations:
-      Expected_value: supplement name;measurement value
-      Preferred_unit: milligram per liter
+      Expected_value:
+        tag: Expected_value
+        value: supplement name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Organic supplements of the culture rooting medium, such as vitamins,
-      amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid
-      (0.5  mg/L)
+      amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic
+      acid (0.5  mg/L)
     title: rooting medium organic supplements
     examples:
       - value: nicotinic acid;0.5 milligram per liter
@@ -11231,13 +11605,15 @@ slots:
     range: RouteTransmissionEnum
   salinity:
     annotations:
-      Preferred_unit: practical salinity unit, percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: practical salinity unit, percentage
     description: The total concentration of all dissolved salts in a liquid or solid
       sample. While salinity can be measured by a complete chemical analysis, this
       method is difficult and time consuming. More often, it is instead derived from
       the conductivity measurement. This is known as practical salinity. These derivations
-      compare the specific conductance of the sample to a salinity standard such as
-      seawater
+      compare the specific conductance of the sample to a salinity standard such
+      as seawater
     title: salinity
     examples:
       - value: 25 practical salinity unit
@@ -11246,19 +11622,21 @@ slots:
     slot_uri: MIXS:0000183
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   salt_regm:
     annotations:
-      Preferred_unit: gram, microgram, mole per liter, gram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, microgram, mole per liter, gram per liter
     description: Information about treatment involving use of salts as supplement
       to liquid and soil growth media; should include the name of salt, amount administered,
-      treatment regimen including how many times the treatment was repeated, how long
-      each treatment lasted, and the start and end time of the entire treatment; can
-      include multiple salt regimens
+      treatment regimen including how many times the treatment was repeated, how
+      long each treatment lasted, and the start and end time of the entire treatment;
+      can include multiple salt regimens
     title: salt regimen
     examples:
       - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -11266,8 +11644,8 @@ slots:
       - regimen
       - salt
     slot_uri: MIXS:0000582
-    multivalued: true
     range: string
+    multivalued: true
   samp_capt_status:
     description: Reason for the sample
     title: sample capture status
@@ -11280,7 +11658,9 @@ slots:
     range: SampCaptStatusEnum
   samp_collect_device:
     annotations:
-      Expected_value: device name
+      Expected_value:
+        tag: Expected_value
+        value: device name
     description: The device used to collect an environmental sample. This field accepts
       terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
       This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094)
@@ -11302,7 +11682,7 @@ slots:
       - sample
     slot_uri: MIXS:0001225
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
@@ -11332,7 +11712,9 @@ slots:
     range: SampDisStageEnum
   samp_floor:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: The floor of the building, where the sampling room is located
     title: sampling floor
     examples:
@@ -11354,14 +11736,16 @@ slots:
     range: SampLocConditionEnum
   samp_loc_corr_rate:
     annotations:
-      Preferred_unit: millimeter per year
-    description: Metal corrosion rate is the speed of metal deterioration due to environmental
-      conditions. As environmental conditions change corrosion rates change accordingly.
-      Therefore, long term corrosion rates are generally more informative than short
-      term rates and for that reason they are preferred during reporting. In the case
-      of suspected MIC, corrosion rate measurements at the time of sampling might
-      provide insights into the involvement of certain microbial community members
-      in MIC as well as potential microbial interplays
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millimeter per year
+    description: Metal corrosion rate is the speed of metal deterioration due to
+      environmental conditions. As environmental conditions change corrosion rates
+      change accordingly. Therefore, long term corrosion rates are generally more
+      informative than short term rates and for that reason they are preferred during
+      reporting. In the case of suspected MIC, corrosion rate measurements at the
+      time of sampling might provide insights into the involvement of certain microbial
+      community members in MIC as well as potential microbial interplays
     title: corrosion rate at sample location
     keywords:
       - location
@@ -11377,8 +11761,8 @@ slots:
       partial_match: true
   samp_mat_process:
     description: A brief description of any processing applied to the sample during
-      or after retrieving the sample from environment, or a link to the relevant protocol(s)
-      performed
+      or after retrieving the sample from environment, or a link to the relevant
+      protocol(s) performed
     title: sample material processing
     examples:
       - value: filtering of seawater, storing samples in ethanol
@@ -11392,8 +11776,12 @@ slots:
     range: string
   samp_md:
     annotations:
-      Expected_value: measurement value;enumeration
-      Preferred_unit: meter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value;enumeration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: In non deviated well, measured depth is equal to the true vertical
       depth, TVD (TVD=TVDSS plus the reference or datum it refers to). In deviated
       wells, the MD is the length of trajectory of the borehole measured from the
@@ -11411,14 +11799,16 @@ slots:
     slot_uri: MIXS:0000413
   samp_name:
     annotations:
-      Preferred_unit: ''
+      Preferred_unit:
+        tag: Preferred_unit
+        value: ''
     description: A local identifier or name that for the material sample used for
       extracting nucleic acids, and subsequent sequencing. It can refer either to
-      the original material collected or to any derived sub-samples. It can have any
-      format, but we suggest that you make it concise, unique and consistent within
-      your lab, and as informative as possible. INSDC requires every sample name from
-      a single Submitter to be unique. Use of a globally unique identifier for the
-      field source_mat_id is recommended in addition to sample_name
+      the original material collected or to any derived sub-samples. It can have
+      any format, but we suggest that you make it concise, unique and consistent
+      within your lab, and as informative as possible. INSDC requires every sample
+      name from a single Submitter to be unique. Use of a globally unique identifier
+      for the field source_mat_id is recommended in addition to sample_name
     title: sample name
     examples:
       - value: ISDsoil1
@@ -11431,8 +11821,8 @@ slots:
     required: true
   samp_pooling:
     description: Physical combination of several instances of like material, e.g.
-      RNA extracted from samples or dishes of cell cultures into one big aliquot of
-      cells. Please provide a short description of the samples that were pooled
+      RNA extracted from samples or dishes of cell cultures into one big aliquot
+      of cells. Please provide a short description of the samples that were pooled
     title: sample pooling
     examples:
       - value: 5uL of extracted genomic DNA from 5 leaves were pooled
@@ -11440,11 +11830,13 @@ slots:
       - pooling
       - sample
     slot_uri: MIXS:0001153
-    multivalued: true
     range: string
+    multivalued: true
   samp_preserv:
     annotations:
-      Preferred_unit: milliliter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milliliter
     description: Preservative added to the sample (e.g. Rnalater, alcohol, formaldehyde,
       etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)
     title: preservative added to sample
@@ -11452,14 +11844,16 @@ slots:
       - sample
     slot_uri: MIXS:0000463
     range: string
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   samp_purpose:
     annotations:
-      Expected_value: enumeration or {text}
+      Expected_value:
+        tag: Expected_value
+        value: enumeration or {text}
     description: The reason that the sample was collected
     title: purpose of sampling
     examples:
@@ -11469,8 +11863,8 @@ slots:
     string_serialization: '[active surveillance in response to an outbreak|active
       surveillance not initiated by an outbreak|clinical trial|cluster investigation|environmental
       assessment|farm sample|field trial|for cause|industry internal investigation|market
-      sample|passive surveillance|population based studies|research|research and development]
-      or {text}'
+      sample|passive surveillance|population based studies|research|research and
+      development] or {text}'
     slot_uri: MIXS:0001151
   samp_rep_biol:
     description: Measurements of biologically distinct samples that show biological
@@ -11483,7 +11877,7 @@ slots:
     slot_uri: MIXS:0001226
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11499,7 +11893,7 @@ slots:
     slot_uri: MIXS:0001227
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11527,14 +11921,14 @@ slots:
     slot_uri: MIXS:0000001
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   samp_sort_meth:
-    description: Method by which samples are sorted; open face filter collecting total
-      suspended particles, prefilter to remove particles larger than X micrometers
+    description: Method by which samples are sorted; open face filter collecting
+      total suspended particles, prefilter to remove particles larger than X micrometers
       in diameter, where common values of X would be 10 and 2.5 full size sorting
       in a cascade impactor
     title: sample size sorting method
@@ -11543,11 +11937,13 @@ slots:
       - sample
       - size
     slot_uri: MIXS:0000216
-    multivalued: true
     range: string
+    multivalued: true
   samp_source_mat_cat:
     annotations:
-      Expected_value: GENEPIO:0001237
+      Expected_value:
+        tag: Expected_value
+        value: GENEPIO:0001237
     description: This is the scientific role or category that the subject organism
       or material has with respect to an investigation.  This field accepts terms
       listed under specimen source material category (http://purl.obolibrary.org/obo/GENEPIO_0001237
@@ -11563,7 +11959,9 @@ slots:
     slot_uri: MIXS:0001154
   samp_stor_device:
     annotations:
-      Expected_value: NCIT:C4318
+      Expected_value:
+        tag: Expected_value
+        value: NCIT:C4318
     description: The container used to store the  sample. This field accepts terms
       listed under container (http://purl.obolibrary.org/obo/NCIT_C43186). If the
       proper descriptor is not listed please use text to describe the storage device
@@ -11579,8 +11977,8 @@ slots:
   samp_stor_media:
     description: The liquid that is added to the sample collection device prior to
       sampling. If the sample is pre-hydrated, indicate the liquid media the sample
-      is pre-hydrated with for storage purposes. This field accepts terms listed under
-      microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067).
+      is pre-hydrated with for storage purposes. This field accepts terms listed
+      under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067).
       If the proper descriptor is not listed please use text to describe the sample
       storage media
     title: sample storage media
@@ -11591,14 +11989,14 @@ slots:
       - storage
     slot_uri: MIXS:0001229
     range: string
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   samp_store_dur:
-    description: Duration for which the sample was stored. Indicate the duration for
-      which the sample was stored written in ISO 8601 format
+    description: Duration for which the sample was stored. Indicate the duration
+      for which the sample was stored written in ISO 8601 format
     title: sample storage duration
     examples:
       - value: P1Y6M
@@ -11616,8 +12014,11 @@ slots:
       partial_match: true
   samp_store_loc:
     annotations:
-      Expected_value: location name
-    description: Location at which sample was stored, usually name of a specific freezer/room
+      Expected_value:
+        tag: Expected_value
+        value: location name
+    description: Location at which sample was stored, usually name of a specific
+      freezer/room
     title: sample storage location
     examples:
       - value: Freezer no:5
@@ -11625,11 +12026,13 @@ slots:
       - location
       - sample
       - storage
-    range: string
     slot_uri: MIXS:0000755
+    range: string
   samp_store_sol:
     annotations:
-      Expected_value: solution name
+      Expected_value:
+        tag: Expected_value
+        value: solution name
     description: Solution within which sample was stored, if any
     title: sample storage solution
     examples:
@@ -11637,11 +12040,13 @@ slots:
     keywords:
       - sample
       - storage
-    range: string
     slot_uri: MIXS:0001317
+    range: string
   samp_store_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Temperature at which sample was stored, e.g. -80 degree Celsius
     title: sample storage temperature
     examples:
@@ -11653,7 +12058,7 @@ slots:
     slot_uri: MIXS:0000110
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11682,8 +12087,8 @@ slots:
       - sample
       - surface
     slot_uri: MIXS:0001256
-    multivalued: true
     range: SampSurfMoistureEnum
+    multivalued: true
   samp_taxon_id:
     description: NCBI taxon id of the sample.  Maybe be a single taxon or mixed taxa
       sample. Use 'synthetic metagenome  for mock community/positive controls, or
@@ -11701,15 +12106,19 @@ slots:
     slot_uri: MIXS:0001320
     range: string
     required: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[NCBITaxon:\d+\]$
+    pattern: ^.* \[NCBITaxon:\d+\]$
     structured_pattern:
       syntax: ^{text} \[{NCBItaxon_id}\]$
       interpolated: true
       partial_match: true
   samp_time_out:
     annotations:
-      Expected_value: time
-      Preferred_unit: hour
+      Expected_value:
+        tag: Expected_value
+        value: time
+      Preferred_unit:
+        tag: Preferred_unit
+        value: hour
     description: The recent and long term history of outside sampling
     title: sampling time outside
     keywords:
@@ -11718,8 +12127,12 @@ slots:
     slot_uri: MIXS:0000196
   samp_transport_cond:
     annotations:
-      Expected_value: measurement value;measurement value
-      Preferred_unit: days;degree Celsius
+      Expected_value:
+        tag: Expected_value
+        value: measurement value;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: days;degree Celsius
     description: Sample transport duration (in days or hrs) and temperature the sample
       was exposed to (e.g. 5.5 days; 20   C)
     title: sample transport conditions
@@ -11744,7 +12157,9 @@ slots:
     range: SampTransportContEnum
   samp_transport_dur:
     annotations:
-      Preferred_unit: days
+      Preferred_unit:
+        tag: Preferred_unit
+        value: days
     description: The duration of time from when the sample was collected until processed.
       Indicate the duration for which the sample was stored written in ISO 8601 format
     title: sample transport duration
@@ -11764,8 +12179,12 @@ slots:
       partial_match: true
   samp_transport_temp:
     annotations:
-      Expected_value: text or measurement value
-      Preferred_unit: degree Celsius
+      Expected_value:
+        tag: Expected_value
+        value: text or measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Temperature at which sample was transported, e.g. -20 or 4 degree
       Celsius
     title: sample transport temperature
@@ -11779,8 +12198,12 @@ slots:
     slot_uri: MIXS:0001232
   samp_tvdss:
     annotations:
-      Expected_value: measurement value or measurement value range
-      Preferred_unit: meter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value or measurement value range
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: Depth of the sample i.e. The vertical distance between the sea level
       and the sampled position in the subsurface. Depth can be reported as an interval
       for subsurface samples e.g. 1325.75-1362.25 m
@@ -11814,7 +12237,9 @@ slots:
       partial_match: true
   samp_vol_we_dna_ext:
     annotations:
-      Preferred_unit: milliliter, gram, milligram, square centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milliliter, gram, milligram, square centimeter
     description: 'Volume (ml) or mass (g) of total collected sample processed for
       DNA extraction. Note: total sample collected should be entered under the term
       Sample Size (MIXS:0000001)'
@@ -11831,7 +12256,7 @@ slots:
     slot_uri: MIXS:0000111
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11856,17 +12281,19 @@ slots:
     recommended: true
   saturates_pc:
     annotations:
-      Preferred_unit: percent
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
-      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
+      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: saturates wt%
     slot_uri: MIXS:0000131
     range: string
     recommended: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
@@ -11885,7 +12312,9 @@ slots:
     range: ScLysisApproachEnum
   sc_lysis_method:
     annotations:
-      Expected_value: kit, protocol name
+      Expected_value:
+        tag: Expected_value
+        value: kit, protocol name
     description: Name of the kit or standard protocol used for cell(s) or particle(s)
       lysis
     title: single cell or viral particle lysis kit protocol
@@ -11898,15 +12327,17 @@ slots:
       - particle
       - protocol
       - single
-    range: string
     slot_uri: MIXS:0000054
+    range: string
   season:
     annotations:
-      Expected_value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732], winter
-        [NCIT:C94730]
-    description: The season when sampling occurred. Any of the four periods into which
-      the year is divided by the equinoxes and solstices. This field accepts terms
-      listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
+      Expected_value:
+        tag: Expected_value
+        value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732],
+          winter [NCIT:C94730]
+    description: The season when sampling occurred. Any of the four periods into
+      which the year is divided by the equinoxes and solstices. This field accepts
+      terms listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
     title: season
     comments:
       - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
@@ -11931,8 +12362,8 @@ slots:
       - environment
       - season
     slot_uri: MIXS:0001068
-    multivalued: true
     range: string
+    multivalued: true
   season_humidity:
     description: Average humidity of the region throughout the growing season
     title: mean seasonal humidity
@@ -11947,14 +12378,16 @@ slots:
     slot_uri: MIXS:0001148
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   season_precpt:
     annotations:
-      Preferred_unit: millimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: millimeter
     description: The average of all seasonal precipitation values known, or an estimated
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean seasonal precipitation
@@ -11966,14 +12399,16 @@ slots:
     slot_uri: MIXS:0000645
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   season_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Mean seasonal temperature
     title: mean seasonal temperature
     examples:
@@ -11985,7 +12420,7 @@ slots:
     slot_uri: MIXS:0000643
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12002,15 +12437,17 @@ slots:
     range: SeasonUseEnum
   secondary_treatment:
     annotations:
-      Expected_value: secondary treatment type
+      Expected_value:
+        tag: Expected_value
+        value: secondary treatment type
     description: The process for substantially degrading the biological content of
       the sewage
     title: secondary treatment
     keywords:
       - secondary
       - treatment
-    range: string
     slot_uri: MIXS:0000351
+    range: string
   sediment_type:
     description: Information about the sediment type based on major constituents
     title: sediment type
@@ -12034,14 +12471,16 @@ slots:
     slot_uri: MIXS:0000050
     range: string
     required: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   seq_quality_check:
     annotations:
-      Expected_value: none or manually edited
+      Expected_value:
+        tag: Expected_value
+        value: none or manually edited
     description: Indicate if the sequence has been called by automatic systems (none)
       or undergone a manual editing procedure (e.g. by inspecting the raw data or
       chromatograms). Applied only for sequences that are not submitted to SRA,ENA
@@ -12057,7 +12496,9 @@ slots:
     range: SeqQualityCheckEnum
   sequencing_kit:
     annotations:
-      Expected_value: name of sequencing kit used
+      Expected_value:
+        tag: Expected_value
+        value: name of sequencing kit used
     description: Pre-filled, ready-to-use reagent cartridges. Used to produce improved
       chemistry, cluster density and read length as well as improve quality (Q) scores.
       Reagent components are encoded to interact with the sequencing system to validate
@@ -12068,8 +12509,8 @@ slots:
       - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
     keywords:
       - kit
-    range: string
     slot_uri: MIXS:0001155
+    range: string
   sequencing_location:
     description: The location the sequencing run was performed. Indicate the name
       of the lab or core facility where samples were sequenced
@@ -12082,15 +12523,15 @@ slots:
     range: string
   serovar_or_serotype:
     description: A characterization of a cell or microorganism based on the antigenic
-      properties of the molecules on its surface. Indicate the name of a serovar or
-      serotype of interest. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
+      properties of the molecules on its surface. Indicate the name of a serovar
+      or serotype of interest. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
     title: serovar or serotype
     examples:
       - value: Escherichia coli strain O157:H7 [NCIT:C86883]
     slot_uri: MIXS:0001157
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -12098,20 +12539,24 @@ slots:
       partial_match: true
   sewage_type:
     annotations:
-      Expected_value: sewage type name
+      Expected_value:
+        tag: Expected_value
+        value: sewage type name
     description: Type of wastewater treatment plant as municipial or industrial
     title: sewage type
     keywords:
       - type
-    range: string
     slot_uri: MIXS:0000215
+    range: string
   sexual_act:
     annotations:
-      Expected_value: partner sex;frequency
+      Expected_value:
+        tag: Expected_value
+        value: partner sex;frequency
     description: Current sexual partner and frequency of sex
     title: sexual activity
-    range: string
     slot_uri: MIXS:0000285
+    range: string
   shad_dev_water_mold:
     description: Signs of the presence of mold or mildew on the shading device
     title: shading device signs of water/mold
@@ -12143,14 +12588,16 @@ slots:
     range: ShadingDeviceLocEnum
   shading_device_mat:
     annotations:
-      Expected_value: material name
+      Expected_value:
+        tag: Expected_value
+        value: material name
     description: The material the shading device is composed of
     title: shading device material
     keywords:
       - device
       - material
-    range: string
     slot_uri: MIXS:0000245
+    range: string
   shading_device_type:
     description: The type of shading device
     title: shading device type
@@ -12164,7 +12611,9 @@ slots:
     range: ShadingDeviceTypeEnum
   sieving:
     annotations:
-      Expected_value: design name and/or size;amount
+      Expected_value:
+        tag: Expected_value
+        value: design name and/or size;amount
     description: Collection design of pooled samples and/or sieve size and amount
       of sample sieved
     title: sieving
@@ -12172,7 +12621,9 @@ slots:
     slot_uri: MIXS:0000322
   silicate:
     annotations:
-      Preferred_unit: micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter
     description: Concentration of silicate
     title: silicate
     examples:
@@ -12180,14 +12631,14 @@ slots:
     slot_uri: MIXS:0000184
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sim_search_meth:
-    description: Tool used to compare ORFs with database, along with version and cutoffs
-      used
+    description: Tool used to compare ORFs with database, along with version and
+      cutoffs used
     title: similarity search method
     examples:
       - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
@@ -12204,7 +12655,9 @@ slots:
       partial_match: true
   size_frac:
     annotations:
-      Expected_value: filter size value range
+      Expected_value:
+        tag: Expected_value
+        value: filter size value range
     description: Filtering pore size used in sample preparation
     title: size fraction selected
     examples:
@@ -12218,8 +12671,11 @@ slots:
     slot_uri: MIXS:0000017
   size_frac_low:
     annotations:
-      Preferred_unit: micrometer
-    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials smaller than the size threshold are excluded from the sample
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micrometer
+    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample.
+      Materials smaller than the size threshold are excluded from the sample
     title: size-fraction lower threshold
     examples:
       - value: 0.2 micrometer
@@ -12228,15 +12684,18 @@ slots:
     slot_uri: MIXS:0000735
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   size_frac_up:
     annotations:
-      Preferred_unit: micrometer
-    description: Mesh or pore size of the device used to retain the sample. Materials larger than the size threshold are excluded from the sample.
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micrometer
+    description: Mesh or pore size of the device used to retain the sample. Materials
+      larger than the size threshold are excluded from the sample.
     title: size-fraction upper threshold
     examples:
       - value: 20 micrometer
@@ -12245,49 +12704,55 @@ slots:
     slot_uri: MIXS:0000736
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   slope_aspect:
     annotations:
-      Preferred_unit: degree
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree
     description: The direction a slope faces. While looking down a slope use a compass
-      to record the direction you are facing (direction or degrees); e.g., nw or 315
-      degrees. This measure provides an indication of sun and wind exposure that will
-      influence soil temperature and evapotranspiration
+      to record the direction you are facing (direction or degrees); e.g., nw or
+      315 degrees. This measure provides an indication of sun and wind exposure that
+      will influence soil temperature and evapotranspiration
     title: slope aspect
     keywords:
       - slope
     slot_uri: MIXS:0000647
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   slope_gradient:
     annotations:
-      Preferred_unit: percentage
-    description: Commonly called 'slope'. The angle between ground surface and a horizontal
-      line (in percent). This is the direction that overland water would flow. This
-      measure is usually taken with a hand level meter or clinometer
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
+    description: Commonly called 'slope'. The angle between ground surface and a
+      horizontal line (in percent). This is the direction that overland water would
+      flow. This measure is usually taken with a hand level meter or clinometer
     title: slope gradient
     keywords:
       - slope
     slot_uri: MIXS:0000646
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sludge_retent_time:
     annotations:
-      Preferred_unit: hours
+      Preferred_unit:
+        tag: Preferred_unit
+        value: hours
     description: The time activated sludge remains in reactor
     title: sludge retention time
     keywords:
@@ -12295,7 +12760,7 @@ slots:
     slot_uri: MIXS:0000669
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12309,7 +12774,9 @@ slots:
     range: boolean
   sodium:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Sodium concentration in the sample
     title: sodium
     examples:
@@ -12317,14 +12784,16 @@ slots:
     slot_uri: MIXS:0000428
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soil_conductivity:
     annotations:
-      Preferred_unit: milliSiemens per centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milliSiemens per centimeter
     title: soil conductivity
     examples:
       - value: 10 milliSiemens per centimeter
@@ -12333,14 +12802,16 @@ slots:
     slot_uri: MIXS:0001158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soil_cover:
     annotations:
-      Expected_value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
+      Expected_value:
+        tag: Expected_value
+        value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
     description: Material covering the sampled soil. This field accepts terms under
       ENVO:00010483, environmental material
     title: soil cover
@@ -12373,8 +12844,12 @@ slots:
     range: float
   soil_porosity:
     annotations:
-      Expected_value: percent porosity
-      Preferred_unit: percentage
+      Expected_value:
+        tag: Expected_value
+        value: percent porosity
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: Porosity of soil or deposited sediment is volume of voids divided
       by the total volume of sample
     title: soil sediment porosity
@@ -12388,7 +12863,9 @@ slots:
     slot_uri: MIXS:0001162
   soil_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Temperature of soil at the time of sampling
     title: soil temperature
     examples:
@@ -12399,7 +12876,7 @@ slots:
     slot_uri: MIXS:0001163
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12416,15 +12893,15 @@ slots:
     slot_uri: MIXS:0000335
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soil_texture_class:
-    description: One of the 12 soil texture classes use to describe soil texture based
-      on the relative proportion of different grain sizes  of mineral particles [sand
-      (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
+    description: One of the 12 soil texture classes use to describe soil texture
+      based on the relative proportion of different grain sizes  of mineral particles
+      [sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
     title: soil texture classification
     examples:
       - value: silty clay loam
@@ -12452,10 +12929,12 @@ slots:
       partial_match: true
   soil_type:
     annotations:
-      Expected_value: ENVO:00001998
+      Expected_value:
+        tag: Expected_value
+        value: ENVO:00001998
     description: Description of the soil type or classification. This field accepts
-      terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple terms
-      can be separated by pipes
+      terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple
+      terms can be separated by pipes
     title: soil type
     examples:
       - value: plinthosol [ENVO:00002250]
@@ -12482,26 +12961,32 @@ slots:
       partial_match: true
   solar_irradiance:
     annotations:
-      Preferred_unit: kilowatts per square meter per day, ergs per square centimeter per
-        second
-    description: The amount of solar energy that arrives at a specific area of a surface
-      during a specific time interval
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilowatts per square meter per day, ergs per square centimeter per
+          second
+    description: The amount of solar energy that arrives at a specific area of a
+      surface during a specific time interval
     title: solar irradiance
     examples:
       - value: 1.36 kilowatts per square meter per day
     slot_uri: MIXS:0000112
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soluble_inorg_mat:
     annotations:
-      Expected_value: soluble inorganic material name;measurement value
-      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
+      Expected_value:
+        tag: Expected_value
+        value: soluble inorganic material name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, microgram, mole per liter, gram per liter, parts per million
     description: Concentration of substances such as ammonia, road-salt, sea-salt,
       cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc
     title: soluble inorganic material
@@ -12514,10 +12999,14 @@ slots:
     multivalued: true
   soluble_org_mat:
     annotations:
-      Expected_value: soluble organic material name;measurement value
-      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
-    description: Concentration of substances such as urea, fruit sugars, soluble proteins,
-      drugs, pharmaceuticals, etc
+      Expected_value:
+        tag: Expected_value
+        value: soluble organic material name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, microgram, mole per liter, gram per liter, parts per million
+    description: Concentration of substances such as urea, fruit sugars, soluble
+      proteins, drugs, pharmaceuticals, etc
     title: soluble organic material
     keywords:
       - material
@@ -12528,7 +13017,9 @@ slots:
     multivalued: true
   soluble_react_phosp:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: Concentration of soluble reactive phosphorus
     title: soluble reactive phosphorus
     examples:
@@ -12539,14 +13030,16 @@ slots:
     slot_uri: MIXS:0000738
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sop:
     annotations:
-      Expected_value: reference to SOP
+      Expected_value:
+        tag: Expected_value
+        value: reference to SOP
     description: Standard operating procedures used in assembly and/or annotation
       of genomes, metagenomes or environmental sequences
     title: relevant standard operating procedures
@@ -12570,7 +13063,9 @@ slots:
     range: SortTechEnum
   source_mat_id:
     annotations:
-      Expected_value: 'for cultures of microorganisms: identifiers for two culture collections;
+      Expected_value:
+        tag: Expected_value
+        value: 'for cultures of microorganisms: identifiers for two culture collections;
           for other material a unique arbitrary identifer'
     description: A unique identifier assigned to a material sample (as defined by
       http://rs.tdwg.org/dwc/terms/materialSampleID, and as opposed to a particular
@@ -12578,12 +13073,12 @@ slots:
       subsequent sequencing. The identifier can refer either to the original material
       collected or to any derived sub-samples. The INSDC qualifiers /specimen_voucher,
       /bio_material, or /culture_collection may or may not share the same value as
-      the source_mat_id field. For instance, the /specimen_voucher qualifier and source_mat_id
-      may both contain 'UAM:Herps:14' , referring to both the specimen voucher and
-      sampled tissue with the same identifier. However, the /culture_collection qualifier
-      may refer to a value from an initial culture (e.g. ATCC:11775) while source_mat_id
-      would refer to an identifier from some derived culture from which the nucleic
-      acids were extracted (e.g. xatc123 or ark:/2154/R2)
+      the source_mat_id field. For instance, the /specimen_voucher qualifier and
+      source_mat_id may both contain 'UAM:Herps:14' , referring to both the specimen
+      voucher and sampled tissue with the same identifier. However, the /culture_collection
+      qualifier may refer to a value from an initial culture (e.g. ATCC:11775) while
+      source_mat_id would refer to an identifier from some derived culture from which
+      the nucleic acids were extracted (e.g. xatc123 or ark:/2154/R2)
     title: source material identifiers
     examples:
       - value: MPI012345
@@ -12593,12 +13088,14 @@ slots:
       - identifier
       - material
       - source
-    range: string
     slot_uri: MIXS:0000026
+    range: string
     multivalued: true
   source_uvig:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Type of dataset from which the UViG was obtained
     title: source of UViGs
     examples:
@@ -12610,8 +13107,8 @@ slots:
     string_serialization: '[metagenome (not viral targeted)|viral fraction metagenome
       (virome)|sequence-targeted metagenome|metatranscriptome (not viral targeted)|viral
       fraction RNA metagenome (RNA virome)|sequence-targeted RNA metagenome|microbial
-      single amplified genome (SAG)|viral single amplified genome (vSAG)|isolate microbial
-      genome|other]'
+      single amplified genome (SAG)|viral single amplified genome (vSAG)|isolate
+      microbial genome|other]'
     slot_uri: MIXS:0000035
   space_typ_state:
     description: Customary or normal state of the space
@@ -12622,17 +13119,17 @@ slots:
     range: SpaceTypStateEnum
     required: true
   spec_intended_cons:
-    description: Food consumer type, human or animal, for which the food product is
-      produced and marketed. This field accepts terms listed under food consumer group
-      (http://purl.obolibrary.org/obo/FOODON_03510136)
+    description: Food consumer type, human or animal, for which the food product
+      is produced and marketed. This field accepts terms listed under food consumer
+      group (http://purl.obolibrary.org/obo/FOODON_03510136)
     title: specific intended consumer
     examples:
       - value: senior as food consumer [FOODON:03510254]
     keywords:
       - consumer
     slot_uri: MIXS:0001234
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -12640,7 +13137,9 @@ slots:
       partial_match: true
   special_diet:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Specification of special diet; can include multiple special diets
     title: special diet
     examples:
@@ -12660,7 +13159,9 @@ slots:
     range: SpecificEnum
   specific_host:
     annotations:
-      Expected_value: host scientific name, taxonomy ID
+      Expected_value:
+        tag: Expected_value
+        value: host scientific name, taxonomy ID
     description: Report the host's taxonomic name and/or NCBI taxonomy ID
     title: host scientific name
     examples:
@@ -12674,10 +13175,12 @@ slots:
     slot_uri: MIXS:0000029
   specific_humidity:
     annotations:
-      Preferred_unit: gram of air, kilogram of air
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram of air, kilogram of air
     description: The mass of water vapour in a unit mass of moist air, usually expressed
-      as grams of vapour per kilogram of air, or, in air conditioning, as grains per
-      pound
+      as grams of vapour per kilogram of air, or, in air conditioning, as grains
+      per pound
     title: specific humidity
     examples:
       - value: 15 per kilogram of air
@@ -12686,14 +13189,16 @@ slots:
     slot_uri: MIXS:0000214
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   spikein_AMR:
     annotations:
-      Expected_value: measurement value ARO:3004299
+      Expected_value:
+        tag: Expected_value
+        value: measurement value ARO:3004299
     description: Qualitative description of a microbial response to antimicrobial
       agents. Bacteria may be susceptible or resistant to a broad range of antibiotic
       drugs or drug classes, with several intermediate states or phases. This field
@@ -12709,7 +13214,9 @@ slots:
     multivalued: true
   spikein_antibiotic:
     annotations:
-      Expected_value: drug name; concentration
+      Expected_value:
+        tag: Expected_value
+        value: drug name; concentration
     description: Antimicrobials used in research study to assess effects of exposure
       on microbiome of a specific site.  Please list antimicrobial, common name and/or
       class and concentration used for spike-in
@@ -12723,9 +13230,13 @@ slots:
     multivalued: true
   spikein_count:
     annotations:
-      Expected_value: organism name;measurement value;enumeration
-      Preferred_unit: colony forming units per milliliter; colony forming units per gram
-        of dry weight
+      Expected_value:
+        tag: Expected_value
+        value: organism name;measurement value;enumeration
+      Preferred_unit:
+        tag: Preferred_unit
+        value: colony forming units per milliliter; colony forming units per gram
+          of dry weight
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
       The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) should
@@ -12741,10 +13252,10 @@ slots:
     slot_uri: MIXS:0001335
   spikein_growth_med:
     description: A liquid or gel containing nutrients, salts, and other factors formulated
-      to support the growth of microorganisms, cells, or plants (National Cancer Institute
-      Thesaurus).  A growth medium is a culture medium which has the disposition to
-      encourage growth of particular bacteria to the exclusion of others in the same
-      growth environment.  In this case, list the culture medium used to propagate
+      to support the growth of microorganisms, cells, or plants (National Cancer
+      Institute Thesaurus).  A growth medium is a culture medium which has the disposition
+      to encourage growth of particular bacteria to the exclusion of others in the
+      same growth environment.  In this case, list the culture medium used to propagate
       the spike-in bacteria during preparation of spike-in inoculum. This field accepts
       terms listed under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067).
       If the proper descriptor is not listed please use text to describe the spike
@@ -12756,16 +13267,18 @@ slots:
       - growth
       - spike
     slot_uri: MIXS:0001169
-    multivalued: true
     range: string
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    multivalued: true
+    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   spikein_metal:
     annotations:
-      Expected_value: heavy metal name or chemical symbol; concentration
+      Expected_value:
+        tag: Expected_value
+        value: heavy metal name or chemical symbol; concentration
     description: Heavy metals used in research study to assess effects of exposure
       on microbiome of a specific site.  Please list heavy metals and concentration
       used for spike-in
@@ -12780,8 +13293,8 @@ slots:
     multivalued: true
   spikein_org:
     description: Taxonomic information about the spike-in organism(s). This field
-      accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This
-      field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
+      accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
+      This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
       Multiple terms can be separated by pipes
     title: spike in organism
     examples:
@@ -12790,8 +13303,8 @@ slots:
       - organism
       - spike
     slot_uri: MIXS:0001167
-    multivalued: true
     range: string
+    multivalued: true
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -12799,7 +13312,9 @@ slots:
       partial_match: true
   spikein_serovar:
     annotations:
-      Expected_value: NCIT:C14250 or antigenic formula or serovar name
+      Expected_value:
+        tag: Expected_value
+        value: NCIT:C14250 or antigenic formula or serovar name
     description: Taxonomic information about the spike-in organism(s) at the serovar
       or serotype level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
@@ -12814,7 +13329,9 @@ slots:
     multivalued: true
   spikein_strain:
     annotations:
-      Expected_value: NCIT:C14250 or NCBI taxid or text
+      Expected_value:
+        tag: Expected_value
+        value: NCIT:C14250 or NCBI taxid or text
     description: Taxonomic information about the spike-in organism(s) at the strain
       level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
@@ -12878,8 +13395,8 @@ slots:
   standing_water_regm:
     description: Treatment involving an exposure to standing water during a plant's
       life span, types can be flood water or standing water, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted, and
-      the start and end time of the entire treatment; can include multiple regimens
+      how many times the treatment was repeated, how long each treatment lasted,
+      and the start and end time of the entire treatment; can include multiple regimens
     title: standing water regimen
     examples:
       - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -12887,11 +13404,13 @@ slots:
       - regimen
       - water
     slot_uri: MIXS:0001069
-    multivalued: true
     range: string
+    multivalued: true
   ster_meth_samp_room:
     annotations:
-      Expected_value: ENVO:01001026
+      Expected_value:
+        tag: Expected_value
+        value: ENVO:01001026
     description: The method used to sterilize the sampling room. This field accepts
       terms listed under electromagnetic radiation (http://purl.obolibrary.org/obo/ENVO_01001026).
       If the proper descriptor is not listed, please use text to describe the sampling
@@ -12907,7 +13426,9 @@ slots:
     multivalued: true
   store_cond:
     annotations:
-      Expected_value: storage condition type;duration
+      Expected_value:
+        tag: Expected_value
+        value: storage condition type;duration
     description: Explain how and for how long the soil sample was stored before DNA
       extraction (fresh/frozen/other)
     title: storage conditions
@@ -12920,8 +13441,10 @@ slots:
     slot_uri: MIXS:0000327
   study_complt_stat:
     annotations:
-      Expected_value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
-        up (4)other-specify
+      Expected_value:
+        tag: Expected_value
+        value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
+          up (4)other-specify
     description: Specification of study completion status, if no the reason should
       be specified
     title: study completion status
@@ -12934,13 +13457,15 @@ slots:
     slot_uri: MIXS:0000898
   study_design:
     annotations:
-      Expected_value: OBI:0500000
+      Expected_value:
+        tag: Expected_value
+        value: OBI:0500000
     description: A plan specification comprised of protocols (which may specify how
       and what kinds of data will be gathered) that are executed as part of an investigation
       and is realized during a study design execution. This field accepts terms under
       study design (http://purl.obolibrary.org/obo/OBI_0500000). If the proper descriptor
-      is not listed please use text to describe the study design. Multiple terms can
-      be separated by pipes
+      is not listed please use text to describe the study design. Multiple terms
+      can be separated by pipes
     title: study design
     examples:
       - value: in vitro design [OBI:0001285]
@@ -12949,9 +13474,11 @@ slots:
     multivalued: true
   study_inc_dur:
     annotations:
-      Preferred_unit: hours or days
-    description: Sample incubation duration if unpublished or unvalidated method is
-      used. Indicate the timepoint written in ISO 8601 format
+      Preferred_unit:
+        tag: Preferred_unit
+        value: hours or days
+    description: Sample incubation duration if unpublished or unvalidated method
+      is used. Indicate the timepoint written in ISO 8601 format
     title: study incubation duration
     examples:
       - value: PT24H
@@ -12968,7 +13495,9 @@ slots:
       partial_match: true
   study_inc_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Sample incubation temperature if unpublished or unvalidated method
       is used
     title: study incubation temperature
@@ -12980,14 +13509,16 @@ slots:
     slot_uri: MIXS:0001238
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   study_timecourse:
     annotations:
-      Preferred_unit: dpi
+      Preferred_unit:
+        tag: Preferred_unit
+        value: dpi
     description: For time-course research studies involving samples of the food commodity,
       indicate the total duration of the time-course study
     title: time-course duration
@@ -13000,20 +13531,22 @@ slots:
     slot_uri: MIXS:0001239
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   study_tmnt:
     annotations:
-      Expected_value: MCO:0000866
+      Expected_value:
+        tag: Expected_value
+        value: MCO:0000866
     description: A process in which the act is intended to modify or alter some other
       material entity.  From the study design, each treatment is comprised of one
       level of one or multiple factors. This field accepts terms listed under treatment
       (http://purl.obolibrary.org/obo/MCO_0000866). If the proper descriptor is not
-      listed please use text to describe the study treatment. Multiple terms can be
-      separated by one or more pipes
+      listed please use text to describe the study treatment. Multiple terms can
+      be separated by one or more pipes
     title: study treatment
     examples:
       - value: Factor A|spike-in|levels high, medium, low
@@ -13024,8 +13557,10 @@ slots:
     multivalued: true
   subspecf_gen_lin:
     annotations:
-      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
-        e.g. serovar, biotype, ecotype, variety, cultivar
+      Expected_value:
+        tag: Expected_value
+        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
+          e.g. serovar, biotype, ecotype, variety, cultivar
     description: Information about the genetic distinctness of the sequenced organism
       below the subspecies level, e.g., serovar, serotype, biotype, ecotype, or any
       relevant genetic typing schemes like Group I plasmid. Subspecies should not
@@ -13049,11 +13584,13 @@ slots:
     keywords:
       - type
     slot_uri: MIXS:0000767
-    multivalued: true
     range: SubstructureTypeEnum
+    multivalued: true
   sulfate:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: Concentration of sulfate in the sample
     title: sulfate
     examples:
@@ -13063,14 +13600,16 @@ slots:
     slot_uri: MIXS:0000423
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sulfate_fw:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Original sulfate concentration in the hydrocarbon resource
     title: sulfate in formation water
     keywords:
@@ -13079,14 +13618,16 @@ slots:
     slot_uri: MIXS:0000407
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sulfide:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: Concentration of sulfide in the sample
     title: sulfide
     examples:
@@ -13096,7 +13637,7 @@ slots:
     slot_uri: MIXS:0000424
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13107,12 +13648,14 @@ slots:
     examples:
       - value: radon
     slot_uri: MIXS:0000759
-    multivalued: true
     range: SurfAirContEnum
     recommended: true
+    multivalued: true
   surf_humidity:
     annotations:
-      Preferred_unit: percentage
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percentage
     description: 'Surfaces: water activity as a function of air and material moisture'
     title: surface humidity
     comments:
@@ -13126,7 +13669,7 @@ slots:
     range: float
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13143,7 +13686,9 @@ slots:
     range: SurfMaterialEnum
   surf_moisture:
     annotations:
-      Preferred_unit: parts per million, gram per cubic meter, gram per square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: parts per million, gram per cubic meter, gram per square meter
     description: Water held on a surface
     title: surface moisture
     examples:
@@ -13155,7 +13700,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13174,7 +13719,9 @@ slots:
     recommended: true
   surf_temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Temperature of the surface at the time of sampling
     title: surface temperature
     examples:
@@ -13186,14 +13733,16 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   suspend_part_matter:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Concentration of suspended particulate matter
     title: suspended particulate matter
     examples:
@@ -13205,16 +13754,20 @@ slots:
     slot_uri: MIXS:0000741
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   suspend_solids:
     annotations:
-      Expected_value: suspended solid name;measurement value
-      Preferred_unit: gram, microgram, milligram per liter, mole per liter, gram per liter,
-        part per million
+      Expected_value:
+        tag: Expected_value
+        value: suspended solid name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram, microgram, milligram per liter, mole per liter, gram per liter,
+          part per million
     description: Concentration of substances including a wide variety of material,
       such as silt, decaying plant and animal matter; can include multiple substances
     title: suspended solids
@@ -13226,7 +13779,9 @@ slots:
     multivalued: true
   sym_life_cycle_type:
     annotations:
-      Expected_value: type of life cycle of the symbiotic organism (host of the samples)
+      Expected_value:
+        tag: Expected_value
+        value: type of life cycle of the symbiotic organism (host of the samples)
     description: Type of life cycle of the symbiotic host species (the thing being
       sampled). Simple life cycles occur within a single host, complex ones within
       multiple different hosts over the course of their normal life cycle
@@ -13257,7 +13812,9 @@ slots:
     recommended: true
   tan:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: 'Total Acid Number  (TAN) is a measurement of acidity that is determined
       by the amount of  potassium hydroxide  in milligrams that is needed to neutralize
       the acids in one gram of oil.  It is an important quality measurement of  crude
@@ -13270,7 +13827,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13329,7 +13886,9 @@ slots:
     range: TaxIdentEnum
   temp:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: Temperature of the sample at the time of sampling
     title: temperature
     examples:
@@ -13341,14 +13900,16 @@ slots:
     slot_uri: MIXS:0000113
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   temp_out:
     annotations:
-      Preferred_unit: degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
     description: The recorded temperature value at sampling time outside
     title: temperature outside house
     examples:
@@ -13359,21 +13920,23 @@ slots:
     slot_uri: MIXS:0000197
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tertiary_treatment:
     annotations:
-      Expected_value: tertiary treatment type
+      Expected_value:
+        tag: Expected_value
+        value: tertiary treatment type
     description: The process providing a final treatment stage to raise the effluent
       quality before it is discharged to the receiving environment
     title: tertiary treatment
     keywords:
       - treatment
-    range: string
     slot_uri: MIXS:0000352
+    range: string
   tidal_stage:
     description: Stage of tide
     title: tidal stage
@@ -13389,8 +13952,8 @@ slots:
     keywords:
       - history
     slot_uri: MIXS:0001081
-    multivalued: true
     range: TillageEnum
+    multivalued: true
   time_last_toothbrush:
     description: Specification of the time since last toothbrushing
     title: time since last toothbrushing
@@ -13424,7 +13987,9 @@ slots:
       partial_match: true
   timepoint:
     annotations:
-      Preferred_unit: hours or days
+      Preferred_unit:
+        tag: Preferred_unit
+        value: hours or days
     description: Time point at which a sample or observation is made or taken from
       a biomaterial as measured from some reference point. Indicate the timepoint
       written in ISO 8601 format
@@ -13450,21 +14015,23 @@ slots:
       - growth
     slot_uri: MIXS:0001070
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   toluene:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of toluene in the sample
     title: toluene
     slot_uri: MIXS:0000154
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13478,14 +14045,16 @@ slots:
     slot_uri: MIXS:0000525
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_depth_water_col:
     annotations:
-      Preferred_unit: meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: Measurement of total depth of water column
     title: total depth of water column
     examples:
@@ -13497,14 +14066,16 @@ slots:
     slot_uri: MIXS:0000634
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_diss_nitro:
     annotations:
-      Preferred_unit: microgram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter
     description: 'Total dissolved nitrogen concentration, reported as nitrogen, measured
       by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen'
     title: total dissolved nitrogen
@@ -13517,14 +14088,16 @@ slots:
     slot_uri: MIXS:0000744
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_inorg_nitro:
     annotations:
-      Preferred_unit: microgram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter
     description: Total inorganic nitrogen content
     title: total inorganic nitrogen
     examples:
@@ -13536,14 +14109,16 @@ slots:
     slot_uri: MIXS:0000745
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_iron:
     annotations:
-      Preferred_unit: milligram per liter, milligram per kilogram
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, milligram per kilogram
     description: Concentration of total iron in the sample
     title: total iron
     keywords:
@@ -13552,14 +14127,16 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_nitro:
     annotations:
-      Preferred_unit: microgram per liter, micromole per liter, milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, micromole per liter, milligram per liter
     description: 'Total nitrogen concentration of water samples, calculated by: total
       nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured
       without filtering, reported as nitrogen'
@@ -13573,7 +14150,7 @@ slots:
     slot_uri: MIXS:0000102
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13607,7 +14184,7 @@ slots:
     slot_uri: MIXS:0000530
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13631,7 +14208,9 @@ slots:
       partial_match: true
   tot_org_carb:
     annotations:
-      Preferred_unit: gram Carbon per kilogram sample material
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram Carbon per kilogram sample material
     description: Total organic carbon content
     title: total organic carbon
     examples:
@@ -13643,14 +14222,16 @@ slots:
     slot_uri: MIXS:0000533
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_part_carb:
     annotations:
-      Preferred_unit: microgram per liter, micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, micromole per liter
     description: Total particulate carbon content
     title: total particulate carbon
     examples:
@@ -13663,14 +14244,16 @@ slots:
     slot_uri: MIXS:0000747
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_phosp:
     annotations:
-      Preferred_unit: micromole per liter, milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: micromole per liter, milligram per liter, parts per million
     description: 'Total phosphorus concentration in the sample, calculated by: total
       phosphorus = total dissolved phosphorus + particulate phosphorus'
     title: total phosphorus
@@ -13682,14 +14265,16 @@ slots:
     slot_uri: MIXS:0000117
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_phosphate:
     annotations:
-      Preferred_unit: microgram per liter, micromole per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per liter, micromole per liter
     description: Total amount or concentration of phosphate
     title: total phosphate
     keywords:
@@ -13698,14 +14283,16 @@ slots:
     slot_uri: MIXS:0000689
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_sulfur:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of total sulfur in the sample
     title: total sulfur
     keywords:
@@ -13715,7 +14302,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13752,14 +14339,16 @@ slots:
     range: TrainStopLocEnum
   travel_out_six_month:
     annotations:
-      Expected_value: country name
+      Expected_value:
+        tag: Expected_value
+        value: country name
     description: Specification of the countries travelled in the last six months;
       can include multiple travels
     title: travel outside the country in last six months
     keywords:
       - months
-    range: string
     slot_uri: MIXS:0000268
+    range: string
     multivalued: true
   trna_ext_software:
     description: Tools used for tRNA identification
@@ -13779,7 +14368,9 @@ slots:
       partial_match: true
   trnas:
     annotations:
-      Expected_value: value from 0-21
+      Expected_value:
+        tag: Expected_value
+        value: value from 0-21
     description: The total number of tRNAs identified from the SAG or MAG
     title: number of standard tRNAs extracted
     examples:
@@ -13803,22 +14394,24 @@ slots:
     slot_uri: MIXS:0000032
     range: TrophicLevelEnum
   turbidity:
-    description: Measure of the amount of cloudiness or haziness in water caused by
-      individual particles
+    description: Measure of the amount of cloudiness or haziness in water caused
+      by individual particles
     title: turbidity
     examples:
       - value: 0.3 nephelometric turbidity units
     slot_uri: MIXS:0000191
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tvdss_of_hcr_press:
     annotations:
-      Preferred_unit: meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where
       the original pressure was measured (e.g. 1578 m)
     title: depth (TVDSS) of hydrocarbon resource pressure
@@ -13830,14 +14423,16 @@ slots:
     slot_uri: MIXS:0000397
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tvdss_of_hcr_temp:
     annotations:
-      Preferred_unit: meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: meter
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where
       the original temperature was measured (e.g. 1345 m)
     title: depth (TVDSS) of hydrocarbon resource temperature
@@ -13849,7 +14444,7 @@ slots:
     slot_uri: MIXS:0000394
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13896,7 +14491,9 @@ slots:
     range: UrineCollectMethEnum
   urobiom_sex:
     annotations:
-      Expected_value: sex of the symbiotic organism (host of the samples); enumeration
+      Expected_value:
+        tag: Expected_value
+        value: sex of the symbiotic organism (host of the samples); enumeration
     description: Physical sex of the host
     title: host sex
     keywords:
@@ -13913,8 +14510,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000289
-    multivalued: true
     range: string
+    multivalued: true
   urogenit_tract_disor:
     description: History of urogenital tract disorders; can include multiple disorders.
       The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
@@ -13923,11 +14520,13 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000278
-    multivalued: true
     range: string
+    multivalued: true
   ventilation_rate:
     annotations:
-      Preferred_unit: cubic meter per minute, liters per second
+      Preferred_unit:
+        tag: Preferred_unit
+        value: cubic meter per minute, liters per second
     description: Ventilation rate of the system in the sampled premises
     title: ventilation rate
     examples:
@@ -13937,40 +14536,46 @@ slots:
     slot_uri: MIXS:0000114
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ventilation_type:
     annotations:
-      Expected_value: ventilation type name
+      Expected_value:
+        tag: Expected_value
+        value: ventilation type name
     description: Ventilation system used in the sampled premises
     title: ventilation type
     examples:
       - value: Operable windows
     keywords:
       - type
-    range: string
     slot_uri: MIXS:0000756
+    range: string
     multivalued: true
   vfa:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of Volatile Fatty Acids in the sample
     title: volatile fatty acids
     slot_uri: MIXS:0000152
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   vfa_fw:
     annotations:
-      Preferred_unit: milligram per liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter
     description: Original volatile fatty acid concentration in the hydrocarbon resource
     title: vfa in formation water
     keywords:
@@ -13978,14 +14583,16 @@ slots:
     slot_uri: MIXS:0000408
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   vir_ident_software:
     annotations:
-      Expected_value: software name, version and relevant parameters
+      Expected_value:
+        tag: Expected_value
+        value: software name, version and relevant parameters
     description: Tool(s) used for the identification of UViG as a viral genome, software
       or protocol name including version number, parameters, and cutoffs used
     title: viral identification software
@@ -14003,13 +14610,17 @@ slots:
     title: virus enrichment approach
     examples:
       - value: filtration
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation +
+          DNAse
       - value: FeCl Precipitation
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation +
+          DNAse
       - value: ultracentrifugation
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation +
+          DNAse
       - value: DNAse
-        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation +
+          DNAse
     in_subset:
       - nucleic acid sequence source
     keywords:
@@ -14018,7 +14629,9 @@ slots:
     range: VirusEnrichApprEnum
   vis_media:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: The building visual media
     title: visual media
     examples:
@@ -14028,17 +14641,25 @@ slots:
     slot_uri: MIXS:0000840
   viscosity:
     annotations:
-      Expected_value: measurement value;measurement value
-      Preferred_unit: cP at degree Celsius
-    description: A measure of oil's resistance  to gradual deformation by  shear stress  or  tensile
-      stress (e.g. 3.5 cp; 100   C)
+      Expected_value:
+        tag: Expected_value
+        value: measurement value;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: cP at degree Celsius
+    description: A measure of oil's resistance  to gradual deformation by  shear
+      stress  or  tensile stress (e.g. 3.5 cp; 100   C)
     title: viscosity
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000126
   volatile_org_comp:
     annotations:
-      Expected_value: volatile organic compound name;measurement value
-      Preferred_unit: microgram per cubic meter, parts per million, nanogram per liter
+      Expected_value:
+        tag: Expected_value
+        value: volatile organic compound name;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: microgram per cubic meter, parts per million, nanogram per liter
     description: Concentration of carbon-based chemicals that easily evaporate at
       room temperature; can report multiple volatile organic compounds by entering
       numeric values preceded by name of compound
@@ -14052,7 +14673,9 @@ slots:
     multivalued: true
   wall_area:
     annotations:
-      Preferred_unit: square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square meter
     description: The total area of the sampled room's walls
     title: wall area
     keywords:
@@ -14061,7 +14684,7 @@ slots:
     slot_uri: MIXS:0000198
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14089,7 +14712,9 @@ slots:
     range: WallFinishMatEnum
   wall_height:
     annotations:
-      Preferred_unit: centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: centimeter
     description: The average height of the walls in the sampled room
     title: wall height
     keywords:
@@ -14098,7 +14723,7 @@ slots:
     slot_uri: MIXS:0000221
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14136,7 +14761,9 @@ slots:
     range: CeilingWallTextureEnum
   wall_thermal_mass:
     annotations:
-      Preferred_unit: joule per degree Celsius
+      Preferred_unit:
+        tag: Preferred_unit
+        value: joule per degree Celsius
     description: The ability of the wall to provide inertia against temperature fluctuations.
       Generally this means concrete or concrete block that is either exposed or covered
       only with paint
@@ -14147,7 +14774,7 @@ slots:
     slot_uri: MIXS:0000222
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14163,14 +14790,16 @@ slots:
     range: MoldVisibilityEnum
   wastewater_type:
     annotations:
-      Expected_value: wastewater type name
+      Expected_value:
+        tag: Expected_value
+        value: wastewater type name
     description: The origin of wastewater such as human waste, rainfall, storm drains,
       etc
     title: wastewater type
     keywords:
       - type
-    range: string
     slot_uri: MIXS:0000353
+    range: string
   water_cont_soil_meth:
     description: Reference or method used in determining the water content of soil
     title: water content method
@@ -14187,7 +14816,9 @@ slots:
       partial_match: true
   water_content:
     annotations:
-      Preferred_unit: gram per gram or cubic centimeter per cubic centimeter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: gram per gram or cubic centimeter per cubic centimeter
     description: Water content measurement
     title: water content
     keywords:
@@ -14196,14 +14827,16 @@ slots:
     slot_uri: MIXS:0000185
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_current:
     annotations:
-      Preferred_unit: cubic meter per second, knots
+      Preferred_unit:
+        tag: Preferred_unit
+        value: cubic meter per second, knots
     description: Measurement of magnitude and direction of flow within a fluid
     title: water current
     examples:
@@ -14213,14 +14846,16 @@ slots:
     slot_uri: MIXS:0000203
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_cut:
     annotations:
-      Preferred_unit: percent
+      Preferred_unit:
+        tag: Preferred_unit
+        value: percent
     description: Current amount of water (%) in a produced fluid stream; or the average
       of the combined streams
     title: water cut
@@ -14234,14 +14869,16 @@ slots:
     range: string
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_feat_size:
     annotations:
-      Preferred_unit: square meter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: square meter
     description: The size of the water feature
     title: water feature size
     keywords:
@@ -14251,7 +14888,7 @@ slots:
     slot_uri: MIXS:0000223
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14269,8 +14906,12 @@ slots:
     range: WaterFeatTypeEnum
   water_frequency:
     annotations:
-      Expected_value: rate
-      Preferred_unit: per day, per week, per month
+      Expected_value:
+        tag: Expected_value
+        value: rate
+      Preferred_unit:
+        tag: Preferred_unit
+        value: per day, per week, per month
     description: Number of water delivery events within a given period of time
     title: water delivery frequency
     examples:
@@ -14292,7 +14933,9 @@ slots:
     range: float
   water_prod_rate:
     annotations:
-      Preferred_unit: cubic meter per day
+      Preferred_unit:
+        tag: Preferred_unit
+        value: cubic meter per day
     description: Water production rates per well (e.g. 987 m3 / day)
     title: water production rate
     keywords:
@@ -14303,14 +14946,16 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_source_adjac:
     annotations:
-      Expected_value: ENVO_01001110 or ENVO_00000070
+      Expected_value:
+        tag: Expected_value
+        value: ENVO_01001110 or ENVO_00000070
     description: Description of the environmental features that are adjacent to the
       farm water source. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110)
       and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple
@@ -14324,12 +14969,14 @@ slots:
       - feature
       - source
       - water
-    range: string
     slot_uri: MIXS:0001122
+    range: string
     multivalued: true
   water_source_shared:
     annotations:
-      Expected_value: enumeration
+      Expected_value:
+        tag: Expected_value
+        value: enumeration
     description: Other users sharing access to the same water source. Multiple terms
       can be separated by one or more pipes
     title: water source shared
@@ -14338,16 +14985,19 @@ slots:
     keywords:
       - source
       - water
-    string_serialization: '[multiple users, agricutural|multiple users, other|no sharing]'
+    string_serialization: '[multiple users, agricutural|multiple users, other|no
+      sharing]'
     slot_uri: MIXS:0001176
     multivalued: true
   water_temp_regm:
     annotations:
-      Preferred_unit: degree Celsius
-    description: Information about treatment involving an exposure to water with varying
-      degree of temperature, treatment regimen including how many times the treatment
-      was repeated, how long each treatment lasted, and the start and end time of
-      the entire treatment; can include multiple regimens
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degree Celsius
+    description: Information about treatment involving an exposure to water with
+      varying degree of temperature, treatment regimen including how many times the
+      treatment was repeated, how long each treatment lasted, and the start and end
+      time of the entire treatment; can include multiple regimens
     title: water temperature regimen
     examples:
       - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -14356,15 +15006,17 @@ slots:
       - temperature
       - water
     slot_uri: MIXS:0000590
-    multivalued: true
     range: string
+    multivalued: true
   watering_regm:
     annotations:
-      Preferred_unit: milliliter, liter
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milliliter, liter
     description: Information about treatment involving an exposure to watering frequencies,
-      treatment regimen including how many times the treatment was repeated, how long
-      each treatment lasted, and the start and end time of the entire treatment; can
-      include multiple regimens
+      treatment regimen including how many times the treatment was repeated, how
+      long each treatment lasted, and the start and end time of the entire treatment;
+      can include multiple regimens
     title: watering regimen
     examples:
       - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -14372,8 +15024,8 @@ slots:
       - regimen
       - water
     slot_uri: MIXS:0000591
-    multivalued: true
     range: string
+    multivalued: true
   weekday:
     description: The day of the week when sampling occurred
     title: weekday
@@ -14383,8 +15035,12 @@ slots:
     range: WeekdayEnum
   weight_loss_3_month:
     annotations:
-      Expected_value: weight loss specification;measurement value
-      Preferred_unit: kilogram, gram
+      Expected_value:
+        tag: Expected_value
+        value: weight loss specification;measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: kilogram, gram
     description: Specification of weight loss in the last three months, if yes should
       be further specified to include amount of weight loss
     title: weight loss in last three months
@@ -14406,7 +15062,9 @@ slots:
     range: WgaAmpApprEnum
   wga_amp_kit:
     annotations:
-      Expected_value: kit name
+      Expected_value:
+        tag: Expected_value
+        value: kit name
     description: Kit used to amplify genomic DNA in preparation for sequencing
     title: WGA amplification kit
     examples:
@@ -14415,13 +15073,14 @@ slots:
       - sequencing
     keywords:
       - kit
-    range: string
     slot_uri: MIXS:0000006
+    range: string
   win:
-    description: 'A unique identifier of a well or wellbore. This is part of the Global
-      Framework for Well Identification initiative which is compiled by the Professional
-      Petroleum Data Management Association (PPDM) in an effort to improve well identification
-      systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)'
+    description: 'A unique identifier of a well or wellbore. This is part of the
+      Global Framework for Well Identification initiative which is compiled by the
+      Professional Petroleum Data Management Association (PPDM) in an effort to improve
+      well identification systems. (Supporting information: https://ppdm.org/ and
+      http://dl.ppdm.org/dl/690)'
     title: well identification number
     keywords:
       - identifier
@@ -14431,7 +15090,9 @@ slots:
     recommended: true
   wind_direction:
     annotations:
-      Preferred_unit: degrees or cardinal direction
+      Preferred_unit:
+        tag: Preferred_unit
+        value: degrees or cardinal direction
     description: Wind direction is the direction from which a wind originates
     title: wind direction
     keywords:
@@ -14448,7 +15109,7 @@ slots:
     slot_uri: MIXS:0000118
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14511,8 +15172,12 @@ slots:
     range: integer
   window_size:
     annotations:
-      Expected_value: measurement value
-      Preferred_unit: inch, meter
+      Expected_value:
+        tag: Expected_value
+        value: measurement value
+      Preferred_unit:
+        tag: Preferred_unit
+        value: inch, meter
     description: The window's length and width
     title: window area/size
     keywords:
@@ -14588,14 +15253,16 @@ slots:
       partial_match: true
   xylene:
     annotations:
-      Preferred_unit: milligram per liter, parts per million
+      Preferred_unit:
+        tag: Preferred_unit
+        value: milligram per liter, parts per million
     description: Concentration of xylene in the sample
     title: xylene
     slot_uri: MIXS:0000156
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+      *.*$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -15986,12 +16653,21 @@ classes:
         recommended: true
     class_uri: MIXS:0010012
   Agriculture:
-    description: >-
-      A collection of terms appropriate when sequencing samples obtained in an agricultural environment. 
-      Suitable to capture metadata appropriate to enhance crop productivity and agroecosystem health 
-      with the aim to facilitate research of agricultural microbiomes and their relationships to plant productivity 
-      and sustainable crop production from diverse crop management contexts.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Agricultural Microbiomes Research Coordination Network, model cropping
+          and plant systems focused on agricultural plant and soil microbe; microbiome
+          studies in agricultural sites; long-term ecological research in croplands;
+          eDNA in manure samples; describing agricultural microbiome studies
+    description: A collection of terms appropriate when sequencing samples obtained
+      in an agricultural environment.  Suitable to capture metadata appropriate to
+      enhance crop productivity and agroecosystem health  with the aim to facilitate
+      research of agricultural microbiomes and their relationships to plant productivity  and
+      sustainable crop production from diverse crop management contexts.
     title: agriculture
+    aliases:
+      - MIxS-Ag (agriculture)
     is_a: Extension
     slots:
       - plant_growth_med
@@ -16398,14 +17074,16 @@ classes:
         string_serialization: '{float} {unit};{period};{interval};{period}'
         recommended: true
     class_uri: MIXS:0016018
-    aliases:
-      - MIxS-Ag (agriculture)
-    annotations:
-      use_cases: Agricultural Microbiomes Research Coordination Network, model cropping and plant systems focused on agricultural plant and soil microbe; microbiome studies in agricultural sites; long-term ecological research in croplands; eDNA in manure samples; describing agricultural microbiome studies
   Air:
-    description: >-
-      A collection of terms appropriate when collecting and sequencing samples obtained from a gaseous environment.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: bioaerosol samples, pathogen load in urban air, aerosols
+    description: A collection of terms appropriate when collecting and sequencing
+      samples obtained from a gaseous environment.
     title: air
+    aliases:
+      - MIxS-air
     is_a: Extension
     slots:
       - samp_name
@@ -16458,16 +17136,19 @@ classes:
         examples:
           - value: 21 kilometer per hour
     class_uri: MIXS:0016000
-    aliases:
-      - MIxS-air
-    annotations:
-      use_cases: bioaerosol samples, pathogen load in urban air, aerosols
   BuiltEnvironment:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples obtained in the 
-      built-up environment, which includes terms for surface material, humidity, temperature, moisture and 
-      occupancy type along with specific metadata terms describing the indoor air, building and sample properties.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: microbiology studies of the built environment, NASA space station
+          sampling, MetaSUB transit system sampling, home, hospitals, office buildings
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples obtained in the  built-up environment, which includes terms for surface
+      material, humidity, temperature, moisture and  occupancy type along with specific
+      metadata terms describing the indoor air, building and sample properties.
     title: built environment
+    aliases:
+      - MIxS-BE (built environment)
     is_a: Extension
     slots:
       - samp_name
@@ -16657,19 +17338,20 @@ classes:
       ventilation_type:
         required: true
     class_uri: MIXS:0016001
-    aliases:
-      - MIxS-BE (built environment)
-    annotations:
-      use_cases: microbiology studies of the built environment, NASA space station sampling, MetaSUB transit system sampling, home, hospitals, office buildings
   FoodAnimalAndAnimalFeed:
-    description: >-
-      A collection of terms appropriate when collecting samples and performing sequencing of samples 
-      obtained from farm animals and their feed.
-    comments:
-      - This extension is intended to work alongside the other food extensions
-        (farm environment, food production facility, and human foods) for capturing contextual data
-        across the food supply-chain environment.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of farm animals, their feed, and pet food.
+    description: A collection of terms appropriate when collecting samples and performing
+      sequencing of samples  obtained from farm animals and their feed.
     title: food-animal and animal feed
+    comments:
+      - This extension is intended to work alongside the other food extensions (farm
+        environment, food production facility, and human foods) for capturing contextual
+        data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food (animal and animal feed)
     is_a: Extension
     slots:
       - samp_name
@@ -16807,19 +17489,22 @@ classes:
       samp_purpose:
         required: true
     class_uri: MIXS:0016019
-    aliases:
-      - MIxS-Food (animal and animal feed)
-    annotations:
-      use_cases: Microbiome of farm animals, their feed, and pet food.
   FoodFarmEnvironment:
-    description: >-
-      A collection of terms appropriate when collecting samples and performing sequencing of samples 
-      obtained from the farm environment, including soil, manure, and food harvesting equipment.
-    comments:
-      - This extension is intended to work alongside the other food extensions
-        (animals and animal feed, food production facility, and human foods)
-        for capturing contextual data across the food supply-chain environment.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of farm and field crops as well as environmental samples
+          including irrigation, soil amendments, and farm equipment.
+    description: A collection of terms appropriate when collecting samples and performing
+      sequencing of samples  obtained from the farm environment, including soil,
+      manure, and food harvesting equipment.
     title: food-farm environment
+    comments:
+      - This extension is intended to work alongside the other food extensions (animals
+        and animal feed, food production facility, and human foods) for capturing
+        contextual data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food (farm environment)
     is_a: Extension
     slots:
       - samp_name
@@ -17037,19 +17722,20 @@ classes:
         examples:
           - value: 1.6 kilometers per hour
     class_uri: MIXS:0016020
-    aliases:
-      - MIxS-Food (farm environment)
-    annotations:
-      use_cases: Microbiome of farm and field crops as well as environmental samples including irrigation, soil amendments, and farm equipment.
   FoodFoodProductionFacility:
-    description: >-
-      A collection of terms appropriate when collecting samples and performing sequencing of samples 
-      obtained from food production facilities.
-    comments:
-      - This extension is intended to work alongside the other food extensions
-        (animals and animal feed, farm environment, and human foods)
-        for capturing contextual data across the food supply-chain environment.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of food production facilities/factories
+    description: A collection of terms appropriate when collecting samples and performing
+      sequencing of samples  obtained from food production facilities.
     title: food-food production facility
+    comments:
+      - This extension is intended to work alongside the other food extensions (animals
+        and animal feed, farm environment, and human foods) for capturing contextual
+        data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food(food production facility)
     is_a: Extension
     slots:
       - samp_name
@@ -17195,19 +17881,20 @@ classes:
       samp_stor_media:
         required: true
     class_uri: MIXS:0016021
-    aliases:
-      - MIxS-Food(food production facility)
-    annotations:
-      use_cases: Microbiome of food production facilities/factories
   FoodHumanFoods:
-    description: >-
-      A collection of terms appropriate when collecting samples and performing sequencing of samples 
-      obtained from human food products.
-    comments:
-      - This extension is intended to work alongside the other food extensions
-        (animals and animal feed, farm environment, and food production facilities)
-        for capturing contextual data across the food supply-chain environment.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: Microbiome of foods intended for human consumption.
+    description: A collection of terms appropriate when collecting samples and performing
+      sequencing of samples  obtained from human food products.
     title: food-human foods
+    comments:
+      - This extension is intended to work alongside the other food extensions (animals
+        and animal feed, farm environment, and food production facilities) for capturing
+        contextual data across the food supply-chain environment.
+    aliases:
+      - MIxS-Food (human foods)
     is_a: Extension
     slots:
       - samp_name
@@ -17345,24 +18032,28 @@ classes:
         examples:
           - value: environmental swab sampling
     class_uri: MIXS:0016022
-    aliases:
-      - MIxS-Food (human foods)
-    annotations:
-      use_cases: Microbiome of foods intended for human consumption.
   HostAssociated:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a non-human host, to examine the host-associated microbiome or genome.
-    comments:
-      - This is a very broad package, intended to capture many kinds of sequences derived
-        from the bodies of or derived from an organism. Where possible, please use a more specific package.
-        For example, consider using food-animal and animal feed extension for sampling of farm animals reared for consumption.
-        For human stool microbiomes, consider MIxS-human-gut.
-        Incidental associations of environmental material with an organism may also be better served by other packages.
-        For example, nucleic acids derived from soil that was sampled from the hoof of a cow may be better described
-        by terms from the soil extension;
-        however, soil embedded in a wound on a cow’s leg would be best described by terms in this extension
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: elephant fecal matter or cat oral cavity
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a non-human host, to examine the host-associated microbiome
+      or genome.
     title: host-associated
+    comments:
+      - This is a very broad package, intended to capture many kinds of sequences
+        derived from the bodies of or derived from an organism. Where possible, please
+        use a more specific package. For example, consider using food-animal and
+        animal feed extension for sampling of farm animals reared for consumption.
+        For human stool microbiomes, consider MIxS-human-gut. Incidental associations
+        of environmental material with an organism may also be better served by other
+        packages. For example, nucleic acids derived from soil that was sampled from
+        the hoof of a cow may be better described by terms from the soil extension;
+        however, soil embedded in a wound on a cow’s leg would be best described
+        by terms in this extension
+    aliases:
+      - MIxS-host-associated
     is_a: Extension
     slots:
       - samp_name
@@ -17480,18 +18171,19 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016002
-    aliases:
-      - MIxS-host-associated
-    annotations:
-      use_cases: elephant fecal matter or cat oral cavity
   HumanAssociated:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a person to examine their human-associated microbiome or genome, 
-      that does not have a specific extension (e.g., skin, gut, vaginal).
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: blood samples or biopsy samples.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a person to examine their human-associated microbiome
+      or genome,  that does not have a specific extension (e.g., skin, gut, vaginal).
+    title: human-associated
     comments:
       - For stool samples use MIxS-human-gut extension.
-    title: human-associated
+    aliases:
+      - MIxS-human-associated
     is_a: Extension
     slots:
       - samp_name
@@ -17591,15 +18283,17 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016003
-    aliases:
-      - MIxS-human-associated
-    annotations:
-      use_cases: blood samples or biopsy samples.
   HumanGut:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a person to examine their gut-associated microbiome.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: human stool or fecal samples, or samples collected directly from the
+          gut.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a person to examine their gut-associated microbiome.
     title: human-gut
+    aliases:
+      - MIxS-human-gut
     is_a: Extension
     slots:
       - samp_name
@@ -17683,15 +18377,17 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016004
-    aliases:
-      - MIxS-human-gut
-    annotations:
-      use_cases: human stool or fecal samples, or samples collected directly from the gut.
   HumanOral:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a person to examine their oral-associated microbiome.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: mouth swab sampling, dental microbiome samples, microbiome of oral
+          swabs, nasal, mouth, throat, teeth, tongue microbiome studies
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a person to examine their oral-associated microbiome.
     title: human-oral
+    aliases:
+      - MIxS-human-oral
     is_a: Extension
     slots:
       - samp_name
@@ -17774,16 +18470,16 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016005
-    aliases:
-      - MIxS-human-oral
-
-    annotations:
-      use_cases: mouth swab sampling, dental microbiome samples, microbiome of oral swabs, nasal, mouth, throat, teeth, tongue microbiome studies
   HumanSkin:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a person to examine their skin-associated microbiome.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: swab samples taken on a person’s skin surface.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a person to examine their skin-associated microbiome.
     title: human-skin
+    aliases:
+      - MIxS-human-skin
     is_a: Extension
     slots:
       - samp_name
@@ -17867,15 +18563,16 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016006
-    aliases:
-      - MIxS-human-skin
-    annotations:
-      use_cases: swab samples taken on a person’s skin surface.
   HumanVaginal:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a person to examine their vaginal-associated microbiome.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: vaginal swabbing
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a person to examine their vaginal-associated microbiome.
     title: human-vaginal
+    aliases:
+      - MIxS-human-vaginal
     is_a: Extension
     slots:
       - samp_name
@@ -17966,15 +18663,19 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016007
-    aliases:
-      - MIxS-human-vaginal
-    annotations:
-      use_cases: vaginal swabbing
   HydrocarbonResourcesCores:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from environments pertaining to hydrocarbon resources, specifically core samples.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: The microbial characterization of hydrocarbon occurrences, defined
+          as the natural and artificial environmental features that are rich in hydrocarbons,
+          from hydrocarbon rich formations, such as reservoir cores.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from environments pertaining to hydrocarbon resources, specifically
+      core samples.
     title: hydrocarbon resources-cores
+    aliases:
+      - MIxS-HCR (hydrocarbon resources-cores)
     is_a: Extension
     slots:
       - samp_name
@@ -18092,15 +18793,19 @@ classes:
       vfa_fw:
         required: true
     class_uri: MIXS:0016015
-    aliases:
-      - MIxS-HCR (hydrocarbon resources-cores)
-    annotations:
-      use_cases: The microbial characterization of hydrocarbon occurrences, defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon rich formations, such as reservoir cores.
   HydrocarbonResourcesFluidsSwabs:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from environments pertaining to hydrocarbon resources, specifically run-off liquids samples and swabs.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: The microbial characterization of hydrocarbon occurrences,  defined
+          as the natural and artificial environmental features that are rich in hydrocarbons,
+          from hydrocarbon resource fluids.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from environments pertaining to hydrocarbon resources, specifically
+      run-off liquids samples and swabs.
     title: hydrocarbon resources-fluids/swabs
+    aliases:
+      - MIxS-HCR (hydrocarbon resources-fluids/swabs)
     is_a: Extension
     slots:
       - samp_name
@@ -18222,15 +18927,16 @@ classes:
       vfa_fw:
         recommended: true
     class_uri: MIXS:0016016
-    aliases:
-      - MIxS-HCR (hydrocarbon resources-fluids/swabs)
-    annotations:
-      use_cases: The microbial characterization of hydrocarbon occurrences,  defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon resource fluids.
   MicrobialMatBiofilm:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from biofilm environments including microbial mats.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: samples from microbial mats at cold seeps
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from biofilm environments including microbial mats.
     title: microbial mat/biofilm
+    aliases:
+      - MIxS-microbial mat/biofilm
     is_a: Extension
     slots:
       - samp_name
@@ -18313,15 +19019,13 @@ classes:
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016008
-    aliases:
-      - MIxS-microbial mat/biofilm
-    annotations:
-      use_cases: samples from microbial mats at cold seeps
   MiscellaneousNaturalOrArtificialEnvironment:
-    description: >-
-      A collection of generic terms appropriate when collecting and sequencing samples 
-      obtained from environments, where there is no specific extension already available.
+    description: A collection of generic terms appropriate when collecting and sequencing
+      samples  obtained from environments, where there is no specific extension already
+      available.
     title: miscellaneous natural or artificial environment
+    aliases:
+      - MIxS-miscellaneous natural or artificial environment
     is_a: Extension
     slots:
       - samp_name
@@ -18383,13 +19087,17 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016009
-    aliases:
-      - MIxS-miscellaneous natural or artificial environment
   PlantAssociated:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a plant to examine it’s plant-associated microbiome.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: plant surface swabs, root soil or rhizosphere, cultivated plants,
+          plant phenotyping
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from a plant to examine it’s plant-associated microbiome.
     title: plant-associated
+    aliases:
+      - MIxS-plant-associated
     is_a: Extension
     slots:
       - samp_name
@@ -18536,17 +19244,19 @@ classes:
       watering_regm:
         string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     class_uri: MIXS:0016010
-    aliases:
-      - MIxS-plant-associated
-    annotations:
-      use_cases: plant surface swabs, root soil or rhizosphere, cultivated plants, plant phenotyping
   Sediment:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from the sedimentary area of aquatic environments.
-    comments:
-      - Sedimentary layers in terrestrial environments will probably be better served by the soil extension.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: river bed or sea floor.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from the sedimentary area of aquatic environments.
     title: sediment
+    comments:
+      - Sedimentary layers in terrestrial environments will probably be better served
+        by the soil extension.
+    aliases:
+      - MIxS-sediment
     is_a: Extension
     slots:
       - samp_name
@@ -18635,17 +19345,19 @@ classes:
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016011
-    aliases:
-      - MIxS-sediment
-    annotations:
-      use_cases: river bed or sea floor.
   Soil:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from the uppermost layer of Earth's crust, contributed by the Terragenome Consortium.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: soil collection, island microbiome sampling, farm land or forest floor.
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from the uppermost layer of Earth's crust, contributed by
+      the Terragenome Consortium.
+    title: soil
     see_also:
       - https://www.fao.org/agriculture/crops/thematic-sitemap/theme/spi/soil-biodiversity/research-into-soil-biodiversity/the-terragenome-project/en/
-    title: soil
+    aliases:
+      - MIxS-soil
     is_a: Extension
     slots:
       - samp_name
@@ -18723,15 +19435,17 @@ classes:
       water_content:
         string_serialization: '{float}'
     class_uri: MIXS:0016012
-    aliases:
-      - MIxS-soil
-    annotations:
-      use_cases: soil collection, island microbiome sampling, farm land or forest floor.
   SymbiontAssociated:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from an organism that lives in close association with any other organism(s).
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: the microbiome sequence of a flea sampled from a farm animal
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from an organism that lives in close association with any
+      other organism(s).
     title: symbiont-associated
+    aliases:
+      - MIxS-SA (symbiont-associated)
     is_a: Extension
     slots:
       - samp_name
@@ -18845,15 +19559,16 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016023
-    aliases:
-      - MIxS-SA (symbiont-associated)
-    annotations:
-      use_cases: the microbiome sequence of a flea sampled from a farm animal
   WastewaterSludge:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from any solid, semisolid or liquid waste.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: sewerage or industrial wastewater
+    description: A collection of terms appropriate when collecting samples and sequencing
+      samples  obtained from any solid, semisolid or liquid waste.
     title: wastewater/sludge
+    aliases:
+      - MIxS-wastewater/sludge
     is_a: Extension
     slots:
       - samp_name
@@ -18905,15 +19620,18 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016013
-    aliases:
-      - MIxS-wastewater/sludge
-    annotations:
-      use_cases: sewerage or industrial wastewater
   Water:
-    description: >-
-      A collection of terms appropriate when collecting samples and sequencing water samples 
-      obtained from any aquatic environment.
+    annotations:
+      use_cases:
+        tag: use_cases
+        value: sea or river water, global ocean sampling day
+    description: A collection of terms appropriate when collecting samples and sequencing
+      water samples  obtained from any aquatic environment.
     title: water
+    see_also:
+      - https://www.vliz.be/projects/assembleplus/research/ocean-sampling-day-2018.html
+    aliases:
+      - MIxS-water
     is_a: Extension
     slots:
       - samp_name
@@ -19012,18 +19730,14 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016014
-    aliases:
-      - MIxS-water
-    annotations:
-      use_cases: sea or river water, global ocean sampling day
-    see_also:
-      - https://www.vliz.be/projects/assembleplus/research/ocean-sampling-day-2018.html
   Checklist:
     description: A collection of metadata terms (slots) to minimally describe the
-      sampling and sequencing method of a specimen used to generate a nucleotide sequence.
+      sampling and sequencing method of a specimen used to generate a nucleotide
+      sequence.
   Extension:
-    description: A collection of recommended metadata terms (slots) developed by community
-      experts, describing the specific context under which a sample was collected.
+    description: A collection of recommended metadata terms (slots) developed by
+      community experts, describing the specific context under which a sample was
+      collected.
     aliases:
       - EnvironmentalPackage
   MixsCompliantData:
@@ -20544,7 +21258,8 @@ classes:
       - Mimag
     class_uri: MIXS:0010011_0016003
   MimagHumanGut:
-    description: MIxS Data that comply with the Mimag checklist and the HumanGut Extension
+    description: MIxS Data that comply with the Mimag checklist and the HumanGut
+      Extension
     title: Mimag combined with HumanGut
     in_subset:
       - combination_classes
@@ -20633,7 +21348,8 @@ classes:
       - Mimag
     class_uri: MIXS:0010011_0016010
   MimagSediment:
-    description: MIxS Data that comply with the Mimag checklist and the Sediment Extension
+    description: MIxS Data that comply with the Mimag checklist and the Sediment
+      Extension
     title: Mimag combined with Sediment
     in_subset:
       - combination_classes
@@ -20898,7 +21614,8 @@ classes:
       - MimarksC
     class_uri: MIXS:0010009_0016013
   MimarksCWater:
-    description: MIxS Data that comply with the MimarksC checklist and the Water Extension
+    description: MIxS Data that comply with the MimarksC checklist and the Water
+      Extension
     title: MimarksC combined with Water
     in_subset:
       - combination_classes
@@ -21125,7 +21842,8 @@ classes:
       - MimarksS
     class_uri: MIXS:0010008_0016013
   MimarksSWater:
-    description: MIxS Data that comply with the MimarksS checklist and the Water Extension
+    description: MIxS Data that comply with the MimarksS checklist and the Water
+      Extension
     title: MimarksS combined with Water
     in_subset:
       - combination_classes
@@ -21232,7 +21950,8 @@ classes:
       - Mims
     class_uri: MIXS:0010007_0016004
   MimsHumanOral:
-    description: MIxS Data that comply with the Mims checklist and the HumanOral Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanOral
+      Extension
     title: Mims combined with HumanOral
     in_subset:
       - combination_classes
@@ -21241,7 +21960,8 @@ classes:
       - Mims
     class_uri: MIXS:0010007_0016005
   MimsHumanSkin:
-    description: MIxS Data that comply with the Mims checklist and the HumanSkin Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanSkin
+      Extension
     title: Mims combined with HumanSkin
     in_subset:
       - combination_classes
@@ -21446,7 +22166,8 @@ classes:
       - Misag
     class_uri: MIXS:0010010_0016003
   MisagHumanGut:
-    description: MIxS Data that comply with the Misag checklist and the HumanGut Extension
+    description: MIxS Data that comply with the Misag checklist and the HumanGut
+      Extension
     title: Misag combined with HumanGut
     in_subset:
       - combination_classes
@@ -21535,7 +22256,8 @@ classes:
       - Misag
     class_uri: MIXS:0010010_0016010
   MisagSediment:
-    description: MIxS Data that comply with the Misag checklist and the Sediment Extension
+    description: MIxS Data that comply with the Misag checklist and the Sediment
+      Extension
     title: Misag combined with Sediment
     in_subset:
       - combination_classes
@@ -21809,10 +22531,11 @@ classes:
       - Miuvig
     class_uri: MIXS:0010012_0016014
 settings:
-  agrochemical_name: ".*"
+  agrochemical_name: .*
   amount: '[-+]?[0-9]*\.?[0-9]+'
-  add_recov_methods: 'Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer Addition|Surfactant Addition|Not Applicable|other'
-  DOI: '^doi:10.\d{2,9}/.*$'
+  add_recov_methods: Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer
+    Addition|Surfactant Addition|Not Applicable|other
+  DOI: ^doi:10.\d{2,9}/.*$
   NCBItaxon_id: NCBITaxon:\d+
   PMID: ^PMID:\d+$
   URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$
@@ -21821,15 +22544,15 @@ settings:
   adapter_B_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
   ambiguous_nucleotides: '[ACGTRKSYMWBHDVN]+'
   country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  date_time_stamp: '(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$'
+  date_time_stamp: (\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$
   duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
   float: '[-+]?[0-9]*\.?[0-9]+'
   integer: '[1-9][0-9]*'
   lat: (-?((?:[0-8]?[0-9](?:\.\d{0,8})?)|90))
   lon: -?[0-9]+(?:\.[0-9]{0,8})?$|^-?(1[0-7]{1,2})
-  name: '.*'
+  name: .*
   parameters: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  particulate_matter_name: '.*'
+  particulate_matter_name: .*
   region: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   room_name: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   room_number: '[1-9][0-9]*'
@@ -21839,6 +22562,6 @@ settings:
   storage_condition_type: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   termID: '[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'
   termLabel: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  text: '.*'
+  text: .*
   unit: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   version: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -29,6 +29,7 @@ subsets:
   investigation: {}
 enums:
   BiolStatEnum:
+    description: Permissible values, used by term biol_stat
     permissible_values:
       breeder's line: {}
       clonal selection: {}
@@ -39,6 +40,7 @@ enums:
       semi-natural: {}
       wild: {}
   AssemblyQualEnum:
+    description: Permissible values, used by term assembly_qual
     permissible_values:
       Finished genome: {}
       High-quality draft genome: {}
@@ -46,26 +48,31 @@ enums:
       Low-quality draft genome: {}
       Genome fragment(s): {}
   AeroStrucEnum:
+    description: Permissible values, used by term aero_struc
     permissible_values:
       glider: {}
       plane: {}
   AnimalBodyCondEnum:
+    description: Permissible values, used by term animal_body_cond
     permissible_values:
       normal: {}
       over conditioned: {}
       under conditioned: {}
   AnimalSexEnum:
+    description: Permissible values, used by term animal_sex
     permissible_values:
       castrated female: {}
       castrated male: {}
       intact female: {}
       intact male: {}
   ArchStrucEnum:
+    description: Permissible values, used by term arch_struc
     permissible_values:
       building: {}
       home: {}
       shed: {}
   BinParamEnum:
+    description: Permissible values, used by term bin_param
     permissible_values:
       codon usage: {}
       combination: {}
@@ -73,6 +80,7 @@ enums:
       homology search: {}
       kmer: {}
   BioticRelationshipEnum:
+    description: Permissible values, used by term biotic_relationship
     permissible_values:
       commensalism: {}
       free living: {}
@@ -80,12 +88,14 @@ enums:
       parasitism: {}
       symbiotic: {}
   BuildingSettingEnum:
+    description: Permissible values, used by term building_setting
     permissible_values:
       exurban: {}
       rural: {}
       suburban: {}
       urban: {}
   BuildDocsEnum:
+    description: Permissible values, used by term build_docs
     permissible_values:
       building information model: {}
       commissioning report: {}
@@ -101,6 +111,7 @@ enums:
       ventilation system: {}
       windows: {}
   BuildOccupTypeEnum:
+    description: Permissible values, used by term build_occup_type
     permissible_values:
       airport: {}
       commercial: {}
@@ -116,10 +127,12 @@ enums:
       sports complex: {}
       wood framed: {}
   BuiltStrucSetEnum:
+    description: Permissible values, used by term built_struc_set
     permissible_values:
       rural: {}
       urban: {}
   CeilFinishMatEnum:
+    description: Permissible values, used by term ceil_finish_mat
     permissible_values:
       PVC: {}
       drywall: {}
@@ -132,10 +145,12 @@ enums:
       tiles: {}
       wood: {}
   CeilStrucEnum:
+    description: Permissible values, used by term ceil_struc
     permissible_values:
       concrete: {}
       wood frame: {}
   CeilTypeEnum:
+    description: Permissible values, used by term ceil_type
     permissible_values:
       barrel-shaped: {}
       cathedral: {}
@@ -145,15 +160,18 @@ enums:
       dropped: {}
       stretched: {}
   ComplApprEnum:
+    description: Permissible values, used by term compl_appr
     permissible_values:
       marker gene: {}
       other: {}
       reference based: {}
   ContamScreenInputEnum:
+    description: Permissible values, used by term contam_screen_input
     permissible_values:
       contigs: {}
       reads: {}
   CultResultEnum:
+    description: Permissible values, used by term cult_result
     permissible_values:
       absent: {}
       active: {}
@@ -164,6 +182,7 @@ enums:
       present: {}
       'yes': {}
   DeposEnvEnum:
+    description: Permissible values, used by term depos_env
     permissible_values:
       Continental - Aeolian: {}
       Continental - Alluvial: {}
@@ -182,22 +201,26 @@ enums:
       Transitional - Tidal: {}
       other: {}
   DominantHandEnum:
+    description: Permissible values, used by term dominant_hand
     permissible_values:
       ambidextrous: {}
       left: {}
       right: {}
   DoorCompTypeEnum:
+    description: Permissible values, used by term door_comp_type
     permissible_values:
       metal covered: {}
       revolving: {}
       sliding: {}
       telescopic: {}
   DoorDirectEnum:
+    description: Permissible values, used by term door_direct
     permissible_values:
       inward: {}
       outward: {}
       sideways: {}
   DoorMatEnum:
+    description: Permissible values, used by term door_mat
     permissible_values:
       aluminum: {}
       cellular PVC: {}
@@ -210,6 +233,7 @@ enums:
       wood: {}
       wood/plastic composite: {}
   DoorMoveEnum:
+    description: Permissible values, used by term door_move
     permissible_values:
       collapsible: {}
       folding: {}
@@ -218,11 +242,13 @@ enums:
       sliding: {}
       swinging: {}
   DoorTypeEnum:
+    description: Permissible values, used by term door_type
     permissible_values:
       composite: {}
       metal: {}
       wooden: {}
   DoorTypeMetalEnum:
+    description: Permissible values, used by term door_type_metal
     permissible_values:
       collapsible: {}
       corrugated steel: {}
@@ -230,6 +256,7 @@ enums:
       rolling shutters: {}
       steel plate: {}
   DrainageClassEnum:
+    description: Permissible values, used by term drainage_class
     permissible_values:
       excessively drained: {}
       moderately well: {}
@@ -238,6 +265,7 @@ enums:
       very poorly: {}
       well: {}
   DrawingsEnum:
+    description: Permissible values, used by term drawings
     permissible_values:
       as built: {}
       bid: {}
@@ -248,6 +276,7 @@ enums:
       operation: {}
       sketch: {}
   ExtrWeatherEventEnum:
+    description: Permissible values, used by term extr_weather_event
     permissible_values:
       drought: {}
       dust storm: {}
@@ -259,6 +288,7 @@ enums:
       high precipitation: {}
       high winds: {}
   FacilityTypeEnum:
+    description: Permissible values, used by term facility_type
     permissible_values:
       ambient storage: {}
       caterer-catering point: {}
@@ -272,6 +302,7 @@ enums:
       refrigerated storage: {}
       storage: {}
   FaoClassEnum:
+    description: Permissible values, used by term fao_class
     permissible_values:
       Acrisols: {}
       Alisols: {}
@@ -318,6 +349,7 @@ enums:
       Yermosols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
   FarmWaterSourceEnum:
+    description: Permissible values, used by term farm_water_source
     permissible_values:
       brackish: {}
       canal: {}
@@ -338,6 +370,7 @@ enums:
       stream: {}
       well: {}
   FilterTypeEnum:
+    description: Permissible values, used by term filter_type
     permissible_values:
       HEPA: {}
       chemical air filter: {}
@@ -346,10 +379,12 @@ enums:
       low-MERV pleated media: {}
       particulate air filter: {}
   FireplaceTypeEnum:
+    description: Permissible values, used by term fireplace_type
     permissible_values:
       gas burning: {}
       wood burning: {}
   FloorStrucEnum:
+    description: Permissible values, used by term floor_struc
     permissible_values:
       balcony: {}
       concrete: {}
@@ -359,6 +394,7 @@ enums:
       sprung floor: {}
       wood-framed: {}
   FloorWaterMoldEnum:
+    description: Permissible values, used by term floor_water_mold
     permissible_values:
       bulging walls: {}
       ceiling discoloration: {}
@@ -370,6 +406,7 @@ enums:
       water stains: {}
       wet floor: {}
   FoodCleanProcEnum:
+    description: Permissible values, used by term food_clean_proc
     permissible_values:
       drum and drain: {}
       manual spinner: {}
@@ -379,6 +416,7 @@ enums:
       scrubbed with hand: {}
       soaking: {}
   FoodTraceListEnum:
+    description: Permissible values, used by term food_trace_list
     permissible_values:
       cheeses-other than hard cheeses: {}
       crustaceans: {}
@@ -397,6 +435,7 @@ enums:
       tomatoes: {}
       tropical tree fruits: {}
   FreqCleanEnum:
+    description: Permissible values, used by term freq_clean
     permissible_values:
       Annually: {}
       Daily: {}
@@ -405,11 +444,13 @@ enums:
       Weekly: {}
       other: {}
   FurnitureEnum:
+    description: Permissible values, used by term furniture
     permissible_values:
       cabinet: {}
       chair: {}
       desks: {}
   GenderRestroomEnum:
+    description: Permissible values, used by term gender_restroom
     permissible_values:
       all gender: {}
       female: {}
@@ -418,18 +459,21 @@ enums:
       male and female: {}
       unisex: {}
   GrowthHabitEnum:
+    description: Permissible values, used by term growth_habit
     permissible_values:
       erect: {}
       prostrate: {}
       semi-erect: {}
       spreading: {}
   HandidnessEnum:
+    description: Permissible values, used by term handidness
     permissible_values:
       ambidexterity: {}
       left handedness: {}
       mixed-handedness: {}
       right handedness: {}
   HcrEnum:
+    description: Permissible values, used by term hcr
     permissible_values:
       Coalbed: {}
       Gas Reservoir: {}
@@ -440,6 +484,7 @@ enums:
       Tight Oil Reservoir: {}
       other: {}
   HcProducedEnum:
+    description: Permissible values, used by term hc_produced
     permissible_values:
       Bitumen: {}
       Coalbed Methane: {}
@@ -448,6 +493,7 @@ enums:
       Oil: {}
       other: {}
   HeatCoolTypeEnum:
+    description: Permissible values, used by term heat_cool_type
     permissible_values:
       forced air system: {}
       heat pump: {}
@@ -455,19 +501,23 @@ enums:
       steam forced heat: {}
       wood stove: {}
   HeatSysDelivMethEnum:
+    description: Permissible values, used by term heat_sys_deliv_meth
     permissible_values:
       conductive: {}
       radiant: {}
   HostCellularLocEnum:
+    description: Permissible values, used by term host_cellular_loc
     permissible_values:
       extracellular: {}
       intracellular: {}
       not determined: {}
   HostDependenceEnum:
+    description: Permissible values, used by term host_dependence
     permissible_values:
       facultative: {}
       obligate: {}
   HostPredApprEnum:
+    description: Permissible values, used by term host_pred_appr
     permissible_values:
       CRISPR spacer match: {}
       co-occurrence: {}
@@ -477,12 +527,14 @@ enums:
       other: {}
       provirus: {}
   HostSpecificityEnum:
+    description: Permissible values, used by term host_specificity
     permissible_values:
       family-specific: {}
       generalist: {}
       genus-specific: {}
       species-specific: {}
   IndoorSpaceEnum:
+    description: Permissible values, used by term indoor_space
     permissible_values:
       bathroom: {}
       bedroom: {}
@@ -493,6 +545,7 @@ enums:
       locker room: {}
       office: {}
   IndoorSurfEnum:
+    description: Permissible values, used by term indoor_surf
     permissible_values:
       cabinet: {}
       ceiling: {}
@@ -503,12 +556,14 @@ enums:
       wall: {}
       window: {}
   LibLayoutEnum:
+    description: Permissible values, used by term lib_layout
     permissible_values:
       other: {}
       paired: {}
       single: {}
       vector: {}
   LightTypeEnum:
+    description: Permissible values, used by term light_type
     permissible_values:
       desk lamp: {}
       electric light: {}
@@ -516,6 +571,7 @@ enums:
       natural light: {}
       none: {}
   LithologyEnum:
+    description: Permissible values, used by term lithology
     permissible_values:
       Basement: {}
       Chalk: {}
@@ -531,12 +587,14 @@ enums:
       Volcanic: {}
       other: {}
   MagCovSoftwareEnum:
+    description: Permissible values, used by term mag_cov_software
     permissible_values:
       bbmap: {}
       bowtie: {}
       bwa: {}
       other: {}
   MechStrucEnum:
+    description: Permissible values, used by term mech_struc
     permissible_values:
       boat: {}
       bus: {}
@@ -548,6 +606,7 @@ enums:
       subway: {}
       train: {}
   ModeTransmissionEnum:
+    description: Permissible values, used by term mode_transmission
     permissible_values:
       horizontal:castrator: {}
       horizontal:directly transmitted: {}
@@ -557,6 +616,7 @@ enums:
       horizontal:vector transmitted: {}
       vertical: {}
   NegContTypeEnum:
+    description: Permissible values, used by term neg_cont_type
     permissible_values:
       DNA-free PCR mix: {}
       distilled water: {}
@@ -566,17 +626,20 @@ enums:
       sterile swab: {}
       sterile syringe: {}
   OccupDocumentEnum:
+    description: Permissible values, used by term occup_document
     permissible_values:
       automated count: {}
       estimate: {}
       manual count: {}
       videos: {}
   OxyStatSampEnum:
+    description: Permissible values, used by term oxy_stat_samp
     permissible_values:
       aerobic: {}
       anaerobic: {}
       other: {}
   PlantReprodCropEnum:
+    description: Permissible values, used by term plant_reprod_crop
     permissible_values:
       plant cutting: {}
       pregerminated seed: {}
@@ -585,6 +648,7 @@ enums:
       seedling: {}
       whole mature plant: {}
   PlantSexEnum:
+    description: Permissible values, used by term plant_sex
     permissible_values:
       Androdioecious: {}
       Androecious: {}
@@ -616,11 +680,13 @@ enums:
       Trioecious: {}
       Unisexual: {}
   PredGenomeStrucEnum:
+    description: Permissible values, used by term pred_genome_struc
     permissible_values:
       non-segmented: {}
       segmented: {}
       undetermined: {}
   ProfilePositionEnum:
+    description: Permissible values, used by term profile_position
     permissible_values:
       backslope: {}
       footslope: {}
@@ -628,17 +694,20 @@ enums:
       summit: {}
       toeslope: {}
   QuadPosEnum:
+    description: Permissible values, used by term quad_pos
     permissible_values:
       East side: {}
       North side: {}
       South side: {}
       West side: {}
   RelSampLocEnum:
+    description: Permissible values, used by term rel_samp_loc
     permissible_values:
       center of car: {}
       edge of car: {}
       under a seat: {}
   RelToOxygenEnum:
+    description: Permissible values, used by term rel_to_oxygen
     permissible_values:
       aerobe: {}
       anaerobe: {}
@@ -648,6 +717,7 @@ enums:
       obligate aerobe: {}
       obligate anaerobe: {}
   RoomCondtEnum:
+    description: Permissible values, used by term room_condt
     permissible_values:
       damaged: {}
       needs repair: {}
@@ -656,6 +726,7 @@ enums:
       visible signs of mold/mildew: {}
       visible wear: {}
   RoomConnectedEnum:
+    description: Permissible values, used by term room_connected
     permissible_values:
       attic: {}
       bathroom: {}
@@ -669,11 +740,13 @@ enums:
       office: {}
       stairwell: {}
   RoomLocEnum:
+    description: Permissible values, used by term room_loc
     permissible_values:
       corner room: {}
       exterior wall: {}
       interior room: {}
   RoomSampPosEnum:
+    description: Permissible values, used by term room_samp_pos
     permissible_values:
       center: {}
       east corner: {}
@@ -685,11 +758,13 @@ enums:
       southwest corner: {}
       west corner: {}
   RouteTransmissionEnum:
+    description: Permissible values, used by term route_transmission
     permissible_values:
       environmental:faecal-oral: {}
       transplacental: {}
       vector-borne:vector penetration: {}
   SampCaptStatusEnum:
+    description: Permissible values, used by term samp_capt_status
     permissible_values:
       active surveillance in response to an outbreak: {}
       active surveillance not initiated by an outbreak: {}
@@ -697,6 +772,7 @@ enums:
       market sample: {}
       other: {}
   SampCollectPointEnum:
+    description: Permissible values, used by term samp_collect_point
     permissible_values:
       drilling rig: {}
       other: {}
@@ -706,6 +782,7 @@ enums:
       well: {}
       wellhead: {}
   SampDisStageEnum:
+    description: Permissible values, used by term samp_dis_stage
     permissible_values:
       dissemination: {}
       growth and reproduction: {}
@@ -714,6 +791,7 @@ enums:
       other: {}
       penetration: {}
   SampLocConditionEnum:
+    description: Permissible values, used by term samp_loc_condition
     permissible_values:
       damaged: {}
       new: {}
@@ -721,6 +799,7 @@ enums:
       visible signs of mold-mildew: {}
       visible weariness repair: {}
   SampSubtypeEnum:
+    description: Permissible values, used by term samp_subtype
     permissible_values:
       biofilm: {}
       not applicable: {}
@@ -728,11 +807,13 @@ enums:
       other: {}
       water phase: {}
   SampSurfMoistureEnum:
+    description: Permissible values, used by term samp_surf_moisture
     permissible_values:
       intermittent moisture: {}
       not present: {}
       submerged: {}
   SampTransportContEnum:
+    description: Permissible values, used by term samp_transport_cont
     permissible_values:
       bottle: {}
       cooler: {}
@@ -740,6 +821,7 @@ enums:
       plastic vial: {}
       vendor supplied container: {}
   SampWeatherEnum:
+    description: Permissible values, used by term samp_weather
     permissible_values:
       clear sky: {}
       cloudy: {}
@@ -751,32 +833,38 @@ enums:
       sunny: {}
       windy: {}
   ScLysisApproachEnum:
+    description: Permissible values, used by term sc_lysis_approach
     permissible_values:
       chemical: {}
       combination: {}
       enzymatic: {}
       physical: {}
   SeasonUseEnum:
+    description: Permissible values, used by term season_use
     permissible_values:
       Fall: {}
       Spring: {}
       Summer: {}
       Winter: {}
   SedimentTypeEnum:
+    description: Permissible values, used by term sediment_type
     permissible_values:
       biogenous: {}
       cosmogenous: {}
       hydrogenous: {}
       lithogenous: {}
   SeqQualityCheckEnum:
+    description: Permissible values, used by term seq_quality_check
     permissible_values:
       manually edited: {}
       none: {}
   ShadingDeviceLocEnum:
+    description: Permissible values, used by term shading_device_loc
     permissible_values:
       exterior: {}
       interior: {}
   ShadingDeviceTypeEnum:
+    description: Permissible values, used by term shading_device_type
     permissible_values:
       bahama shutters: {}
       exterior roll blind: {}
@@ -791,6 +879,8 @@ enums:
       trellis: {}
       venetian awning: {}
   CompassDirections8Enum:
+    description: 'Permissible values, used by 6 terms: door_loc, ext_wall_orient,
+      ext_window_orient, heat_deliv_loc, wall_loc, window_loc'
     permissible_values:
       east: {}
       north: {}
@@ -801,10 +891,14 @@ enums:
       southwest: {}
       west: {}
   MoldVisibilityEnum:
+    description: 'Permissible values, used by 5 terms: ceil_water_mold, door_water_mold,
+      shad_dev_water_mold, wall_water_mold, window_water_mold'
     permissible_values:
       no presence of mold visible: {}
       presence of mold visible: {}
   DamagedRupturedEnum:
+    description: 'Permissible values, used by 3 terms: door_cond, shading_device_cond,
+      window_cond'
     permissible_values:
       damaged: {}
       needs repair: {}
@@ -812,6 +906,7 @@ enums:
       rupture: {}
       visible wear: {}
   DamagedEnum:
+    description: 'Permissible values, used by 3 terms: ceil_cond, floor_cond, int_wall_cond'
     permissible_values:
       damaged: {}
       needs repair: {}
@@ -819,6 +914,7 @@ enums:
       rupture: {}
       visible wear: {}
   CeilingWallTextureEnum:
+    description: 'Permissible values, used by 2 terms: ceil_texture, wall_texture'
     permissible_values:
       Santa-Fe texture: {}
       crows feet: {}
@@ -834,6 +930,7 @@ enums:
       stomp knockdown: {}
       swirl: {}
   GeolAgeEnum:
+    description: 'Permissible values, used by 2 terms: hcr_geol_age, sr_geol_age'
     permissible_values:
       Archean: {}
       Cambrian: {}
@@ -854,6 +951,7 @@ enums:
       Triassic: {}
       other: {}
   SoilHorizonEnum:
+    description: Permissible values, used by term soil_horizon
     permissible_values:
       A horizon: {}
       B horizon: {}
@@ -863,6 +961,7 @@ enums:
       Permafrost: {}
       R layer: {}
   SoilTextureClassEnum:
+    description: Permissible values, used by term soil_texture_class
     permissible_values:
       clay: {}
       clay loam: {}
@@ -877,6 +976,7 @@ enums:
       silty clay: {}
       silty clay loam: {}
   SortTechEnum:
+    description: Permissible values, used by term sort_tech
     permissible_values:
       flow cytometric cell sorting: {}
       lazer-tweezing: {}
@@ -885,10 +985,12 @@ enums:
       optical manipulation: {}
       other: {}
   SpaceTypStateEnum:
+    description: Permissible values, used by term space_typ_state
     permissible_values:
       typically occupied: {}
       typically unoccupied: {}
   SpecificEnum:
+    description: Permissible values, used by term specific
     permissible_values:
       as built: {}
       bid: {}
@@ -897,6 +999,7 @@ enums:
       operation: {}
       photos: {}
   SrDepEnvEnum:
+    description: Permissible values, used by term sr_dep_env
     permissible_values:
       Fluvioldeltaic: {}
       Fluviomarine: {}
@@ -904,6 +1007,7 @@ enums:
       Marine: {}
       other: {}
   SrKerogTypeEnum:
+    description: Permissible values, used by term sr_kerog_type
     permissible_values:
       Type I: {}
       Type II: {}
@@ -911,6 +1015,7 @@ enums:
       Type IV: {}
       other: {}
   SrLithologyEnum:
+    description: Permissible values, used by term sr_lithology
     permissible_values:
       Biosilicieous: {}
       Carbonate: {}
@@ -918,11 +1023,13 @@ enums:
       Coal: {}
       other: {}
   SubstructureTypeEnum:
+    description: Permissible values, used by term substructure_type
     permissible_values:
       basement: {}
       crawlspace: {}
       slab on grade: {}
   SurfAirContEnum:
+    description: Permissible values, used by term surf_air_cont
     permissible_values:
       biocides: {}
       biological contaminants: {}
@@ -933,6 +1040,7 @@ enums:
       radon: {}
       volatile organic compounds: {}
   SurfMaterialEnum:
+    description: Permissible values, used by term surf_material
     permissible_values:
       adobe: {}
       carpet: {}
@@ -950,6 +1058,7 @@ enums:
       vinyl: {}
       wood: {}
   SymbiontHostRoleEnum:
+    description: Permissible values, used by term symbiont_host_role
     permissible_values:
       accidental: {}
       dead-end: {}
@@ -959,21 +1068,25 @@ enums:
       reservoir: {}
       single host: {}
   SymLifeCycleTypeEnum:
+    description: Permissible values, used by term sym_life_cycle_type
     permissible_values:
       complex life cycle: {}
       simple life cycle: {}
   TaxIdentEnum:
+    description: Permissible values, used by term tax_ident
     permissible_values:
       16S rRNA gene: {}
       multi-marker approach: {}
       other: {}
   TidalStageEnum:
+    description: Permissible values, used by term tidal_stage
     permissible_values:
       ebb tide: {}
       flood tide: {}
       high tide: {}
       low tide: {}
   TillageEnum:
+    description: Permissible values, used by term tillage
     permissible_values:
       chisel: {}
       cutting disc: {}
@@ -985,11 +1098,13 @@ enums:
       tined: {}
       zonal tillage: {}
   TrainLineEnum:
+    description: Permissible values, used by term train_line
     permissible_values:
       green: {}
       orange: {}
       red: {}
   TrainStatLocEnum:
+    description: Permissible values, used by term train_stat_loc
     permissible_values:
       forest hills: {}
       riverside: {}
@@ -997,11 +1112,13 @@ enums:
       south station amtrak: {}
       south station underground: {}
   TrainStopLocEnum:
+    description: Permissible values, used by term train_stop_loc
     permissible_values:
       downtown: {}
       end: {}
       mid: {}
   TrophicLevelEnum:
+    description: Permissible values, used by term trophic_level
     permissible_values:
       autotroph: {}
       carboxydotroph: {}
@@ -1035,21 +1152,25 @@ enums:
       photosynthetic: {}
       phototroph: {}
   TypeOfSymbiosisEnum:
+    description: Permissible values, used by term type_of_symbiosis
     permissible_values:
       commensalistic: {}
       mutualistic: {}
       parasitic: {}
   UrineCollectMethEnum:
+    description: Permissible values, used by term urine_collect_meth
     permissible_values:
       catheter: {}
       clean catch: {}
   UrobiomSexEnum:
+    description: Permissible values, used by term urobiom_sex
     permissible_values:
       female: {}
       hermaphrodite: {}
       male: {}
       neuter: {}
   VirusEnrichApprEnum:
+    description: Permissible values, used by term virus_enrich_appr
     permissible_values:
       CsCl density gradient: {}
       DNAse: {}
@@ -1064,6 +1185,7 @@ enums:
       ultracentrifugation: {}
       ultrafiltration: {}
   WallConstTypeEnum:
+    description: Permissible values, used by term wall_const_type
     permissible_values:
       fire resistive: {}
       frame construction: {}
@@ -1072,6 +1194,7 @@ enums:
       masonry noncombustible: {}
       modified fire resistive: {}
   WallFinishMatEnum:
+    description: Permissible values, used by term wall_finish_mat
     permissible_values:
       acoustical treatment: {}
       gypsum board: {}
@@ -1085,6 +1208,7 @@ enums:
       veneer plaster: {}
       wood: {}
   WallSurfTreatmentEnum:
+    description: Permissible values, used by term wall_surf_treatment
     permissible_values:
       fabric: {}
       no treatment: {}
@@ -1093,6 +1217,7 @@ enums:
       stucco: {}
       wall paper: {}
   WaterFeatTypeEnum:
+    description: Permissible values, used by term water_feat_type
     permissible_values:
       fountain: {}
       pool: {}
@@ -1100,6 +1225,7 @@ enums:
       stream: {}
       waterfall: {}
   WeekdayEnum:
+    description: Permissible values, used by term weekday
     permissible_values:
       Friday: {}
       Monday: {}
@@ -1109,20 +1235,24 @@ enums:
       Tuesday: {}
       Wednesday: {}
   WgaAmpApprEnum:
+    description: Permissible values, used by term wga_amp_appr
     permissible_values:
       mda based: {}
       pcr based: {}
   WindowCoverEnum:
+    description: Permissible values, used by term window_cover
     permissible_values:
       blinds: {}
       curtains: {}
       none: {}
   WindowHorizPosEnum:
+    description: Permissible values, used by term window_horiz_pos
     permissible_values:
       left: {}
       middle: {}
       right: {}
   WindowMatEnum:
+    description: Permissible values, used by term window_mat
     permissible_values:
       clad: {}
       fiberglass: {}
@@ -1130,15 +1260,18 @@ enums:
       vinyl: {}
       wood: {}
   WindowStatusEnum:
+    description: Permissible values, used by term window_status
     permissible_values:
       closed: {}
       open: {}
   WindowTypeEnum:
+    description: Permissible values, used by term window_type
     permissible_values:
       fixed window: {}
       horizontal sash window: {}
       single-hung sash window: {}
   WindowVertPosEnum:
+    description: Permissible values, used by term window_vert_pos
     permissible_values:
       bottom: {}
       high: {}

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -1,11 +1,7 @@
 ---
 name: mixs
-description: 'This file contains a YAML-formatted specification of the Minimum Information
-  about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/).
-  This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/)
-  for use by anyone handling data or information about biological sequences. This
-  file is also used as an authoritative ''source of truth'' to generate downstream
-  GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project'
+description: >-
+  This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project
 comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
@@ -22,316 +18,285 @@ prefixes:
 default_prefix: MIXS
 default_range: string
 subsets:
-  combination_classes: {}
-  sequencing: {}
-  environment: {}
-  nucleic acid sequence source: {}
-  investigation: {}
+  combination_classes:
+  sequencing:
+  environment:
+  nucleic acid sequence source:
+  investigation:
 enums:
   BiolStatEnum:
-    description: Permissible values, used by term biol_stat
     permissible_values:
-      breeder's line: {}
-      clonal selection: {}
-      hybrid: {}
-      inbred line: {}
-      mutant: {}
-      natural: {}
-      semi-natural: {}
-      wild: {}
+      breeder's line:
+      clonal selection:
+      hybrid:
+      inbred line:
+      mutant:
+      natural:
+      semi-natural:
+      wild:
   AssemblyQualEnum:
-    description: Permissible values, used by term assembly_qual
     permissible_values:
-      Finished genome: {}
-      High-quality draft genome: {}
-      Medium-quality draft genome: {}
-      Low-quality draft genome: {}
-      Genome fragment(s): {}
+      Finished genome:
+      High-quality draft genome:
+      Medium-quality draft genome:
+      Low-quality draft genome:
+      Genome fragment(s):
   AeroStrucEnum:
-    description: Permissible values, used by term aero_struc
     permissible_values:
-      glider: {}
-      plane: {}
+      glider:
+      plane:
   AnimalBodyCondEnum:
-    description: Permissible values, used by term animal_body_cond
     permissible_values:
-      normal: {}
-      over conditioned: {}
-      under conditioned: {}
+      normal:
+      over conditioned:
+      under conditioned:
   AnimalSexEnum:
-    description: Permissible values, used by term animal_sex
     permissible_values:
-      castrated female: {}
-      castrated male: {}
-      intact female: {}
-      intact male: {}
+      castrated female:
+      castrated male:
+      intact female:
+      intact male:
   ArchStrucEnum:
-    description: Permissible values, used by term arch_struc
     permissible_values:
-      building: {}
-      home: {}
-      shed: {}
+      building:
+      home:
+      shed:
   BinParamEnum:
-    description: Permissible values, used by term bin_param
     permissible_values:
-      codon usage: {}
-      combination: {}
-      coverage: {}
-      homology search: {}
-      kmer: {}
+      codon usage:
+      combination:
+      coverage:
+      homology search:
+      kmer:
   BioticRelationshipEnum:
-    description: Permissible values, used by term biotic_relationship
     permissible_values:
-      commensalism: {}
-      free living: {}
-      mutualism: {}
-      parasitism: {}
-      symbiotic: {}
+      commensalism:
+      free living:
+      mutualism:
+      parasitism:
+      symbiotic:
   BuildingSettingEnum:
-    description: Permissible values, used by term building_setting
     permissible_values:
-      exurban: {}
-      rural: {}
-      suburban: {}
-      urban: {}
+      exurban:
+      rural:
+      suburban:
+      urban:
   BuildDocsEnum:
-    description: Permissible values, used by term build_docs
     permissible_values:
-      building information model: {}
-      commissioning report: {}
-      complaint logs: {}
-      contract administration: {}
-      cost estimate: {}
-      janitorial schedules or logs: {}
-      maintenance plans: {}
-      schedule: {}
-      sections: {}
-      shop drawings: {}
-      submittals: {}
-      ventilation system: {}
-      windows: {}
+      building information model:
+      commissioning report:
+      complaint logs:
+      contract administration:
+      cost estimate:
+      janitorial schedules or logs:
+      maintenance plans:
+      schedule:
+      sections:
+      shop drawings:
+      submittals:
+      ventilation system:
+      windows:
   BuildOccupTypeEnum:
-    description: Permissible values, used by term build_occup_type
     permissible_values:
-      airport: {}
-      commercial: {}
-      health care: {}
-      high rise: {}
-      low rise: {}
-      market: {}
-      office: {}
-      residence: {}
-      residential: {}
-      restaurant: {}
-      school: {}
-      sports complex: {}
-      wood framed: {}
+      airport:
+      commercial:
+      health care:
+      high rise:
+      low rise:
+      market:
+      office:
+      residence:
+      residential:
+      restaurant:
+      school:
+      sports complex:
+      wood framed:
   BuiltStrucSetEnum:
-    description: Permissible values, used by term built_struc_set
     permissible_values:
-      rural: {}
-      urban: {}
+      rural:
+      urban:
   CeilFinishMatEnum:
-    description: Permissible values, used by term ceil_finish_mat
     permissible_values:
-      PVC: {}
-      drywall: {}
-      fiberglass: {}
-      metal: {}
-      mineral fibre: {}
-      mineral wool/calcium silicate: {}
-      plasterboard: {}
-      stucco: {}
-      tiles: {}
-      wood: {}
+      PVC:
+      drywall:
+      fiberglass:
+      metal:
+      mineral fibre:
+      mineral wool/calcium silicate:
+      plasterboard:
+      stucco:
+      tiles:
+      wood:
   CeilStrucEnum:
-    description: Permissible values, used by term ceil_struc
     permissible_values:
-      concrete: {}
-      wood frame: {}
+      concrete:
+      wood frame:
   CeilTypeEnum:
-    description: Permissible values, used by term ceil_type
     permissible_values:
-      barrel-shaped: {}
-      cathedral: {}
-      coffered: {}
-      concave: {}
-      cove: {}
-      dropped: {}
-      stretched: {}
+      barrel-shaped:
+      cathedral:
+      coffered:
+      concave:
+      cove:
+      dropped:
+      stretched:
   ComplApprEnum:
-    description: Permissible values, used by term compl_appr
     permissible_values:
-      marker gene: {}
-      other: {}
-      reference based: {}
+      marker gene:
+      other:
+      reference based:
   ContamScreenInputEnum:
-    description: Permissible values, used by term contam_screen_input
     permissible_values:
-      contigs: {}
-      reads: {}
+      contigs:
+      reads:
   CultResultEnum:
-    description: Permissible values, used by term cult_result
     permissible_values:
-      absent: {}
-      active: {}
-      inactive: {}
-      negative: {}
-      'no': {}
-      positive: {}
-      present: {}
-      'yes': {}
+      absent:
+      active:
+      inactive:
+      negative:
+      'no':
+      positive:
+      present:
+      'yes':
   DeposEnvEnum:
-    description: Permissible values, used by term depos_env
     permissible_values:
-      Continental - Aeolian: {}
-      Continental - Alluvial: {}
-      Continental - Fluvial: {}
-      Continental - Lacustrine: {}
-      Marine - Deep: {}
-      Marine - Reef: {}
-      Marine - Shallow: {}
-      Other - Evaporite: {}
-      Other - Glacial: {}
-      Other - Volcanic: {}
-      Transitional - Beach: {}
-      Transitional - Deltaic: {}
-      Transitional - Lagoonal: {}
-      Transitional - Lake: {}
-      Transitional - Tidal: {}
-      other: {}
+      Continental - Aeolian:
+      Continental - Alluvial:
+      Continental - Fluvial:
+      Continental - Lacustrine:
+      Marine - Deep:
+      Marine - Reef:
+      Marine - Shallow:
+      Other - Evaporite:
+      Other - Glacial:
+      Other - Volcanic:
+      Transitional - Beach:
+      Transitional - Deltaic:
+      Transitional - Lagoonal:
+      Transitional - Lake:
+      Transitional - Tidal:
+      other:
   DominantHandEnum:
-    description: Permissible values, used by term dominant_hand
     permissible_values:
-      ambidextrous: {}
-      left: {}
-      right: {}
+      ambidextrous:
+      left:
+      right:
   DoorCompTypeEnum:
-    description: Permissible values, used by term door_comp_type
     permissible_values:
-      metal covered: {}
-      revolving: {}
-      sliding: {}
-      telescopic: {}
+      metal covered:
+      revolving:
+      sliding:
+      telescopic:
   DoorDirectEnum:
-    description: Permissible values, used by term door_direct
     permissible_values:
-      inward: {}
-      outward: {}
-      sideways: {}
+      inward:
+      outward:
+      sideways:
   DoorMatEnum:
-    description: Permissible values, used by term door_mat
     permissible_values:
-      aluminum: {}
-      cellular PVC: {}
-      engineered plastic: {}
-      fiberboard: {}
-      fiberglass: {}
-      metal: {}
-      thermoplastic alloy: {}
-      vinyl: {}
-      wood: {}
-      wood/plastic composite: {}
+      aluminum:
+      cellular PVC:
+      engineered plastic:
+      fiberboard:
+      fiberglass:
+      metal:
+      thermoplastic alloy:
+      vinyl:
+      wood:
+      wood/plastic composite:
   DoorMoveEnum:
-    description: Permissible values, used by term door_move
     permissible_values:
-      collapsible: {}
-      folding: {}
-      revolving: {}
-      rolling shutter: {}
-      sliding: {}
-      swinging: {}
+      collapsible:
+      folding:
+      revolving:
+      rolling shutter:
+      sliding:
+      swinging:
   DoorTypeEnum:
-    description: Permissible values, used by term door_type
     permissible_values:
-      composite: {}
-      metal: {}
-      wooden: {}
+      composite:
+      metal:
+      wooden:
   DoorTypeMetalEnum:
-    description: Permissible values, used by term door_type_metal
     permissible_values:
-      collapsible: {}
-      corrugated steel: {}
-      hollow: {}
-      rolling shutters: {}
-      steel plate: {}
+      collapsible:
+      corrugated steel:
+      hollow:
+      rolling shutters:
+      steel plate:
   DrainageClassEnum:
-    description: Permissible values, used by term drainage_class
     permissible_values:
-      excessively drained: {}
-      moderately well: {}
-      poorly: {}
-      somewhat poorly: {}
-      very poorly: {}
-      well: {}
+      excessively drained:
+      moderately well:
+      poorly:
+      somewhat poorly:
+      very poorly:
+      well:
   DrawingsEnum:
-    description: Permissible values, used by term drawings
     permissible_values:
-      as built: {}
-      bid: {}
-      building navigation map: {}
-      construction: {}
-      design: {}
-      diagram: {}
-      operation: {}
-      sketch: {}
+      as built:
+      bid:
+      building navigation map:
+      construction:
+      design:
+      diagram:
+      operation:
+      sketch:
   ExtrWeatherEventEnum:
-    description: Permissible values, used by term extr_weather_event
     permissible_values:
-      drought: {}
-      dust storm: {}
-      extreme cold: {}
-      extreme heat: {}
-      flood: {}
-      frost: {}
-      hail: {}
-      high precipitation: {}
-      high winds: {}
+      drought:
+      dust storm:
+      extreme cold:
+      extreme heat:
+      flood:
+      frost:
+      hail:
+      high precipitation:
+      high winds:
   FacilityTypeEnum:
-    description: Permissible values, used by term facility_type
     permissible_values:
-      ambient storage: {}
-      caterer-catering point: {}
-      distribution: {}
-      frozen storage: {}
-      importer-broker: {}
-      interstate conveyance: {}
-      labeler-relabeler: {}
-      manufacturing-processing: {}
-      packaging: {}
-      refrigerated storage: {}
-      storage: {}
+      ambient storage:
+      caterer-catering point:
+      distribution:
+      frozen storage:
+      importer-broker:
+      interstate conveyance:
+      labeler-relabeler:
+      manufacturing-processing:
+      packaging:
+      refrigerated storage:
+      storage:
   FaoClassEnum:
-    description: Permissible values, used by term fao_class
     permissible_values:
-      Acrisols: {}
-      Alisols: {}
-      Andosols: {}
-      Anthrosols: {}
-      Arenosols: {}
-      Calcisols: {}
-      Cambisols: {}
-      Chernozems: {}
-      Cryosols: {}
-      Durisols: {}
-      Ferralsols: {}
-      Fluvisols: {}
-      Gleysols: {}
+      Acrisols:
+      Alisols:
+      Andosols:
+      Anthrosols:
+      Arenosols:
+      Calcisols:
+      Cambisols:
+      Chernozems:
+      Cryosols:
+      Durisols:
+      Ferralsols:
+      Fluvisols:
+      Gleysols:
       Greyzems:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
-      Gypsisols: {}
-      Histosols: {}
-      Kastanozems: {}
+      Gypsisols:
+      Histosols:
+      Kastanozems:
       Lithosols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
-      Leptosols: {}
-      Lixisols: {}
-      Luvisols: {}
-      Nitosols: {}
-      Phaeozems: {}
-      Planosols: {}
-      Plinthosols: {}
-      Podzols: {}
+      Leptosols:
+      Lixisols:
+      Luvisols:
+      Nitosols:
+      Phaeozems:
+      Planosols:
+      Plinthosols:
+      Podzols:
       Podzoluvisols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
       Rankers:
@@ -340,967 +305,868 @@ enums:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
       Rendzinas:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
-      Solonchaks: {}
-      Solonetz: {}
-      Stagnosols: {}
-      Technosols: {}
-      Umbrisols: {}
-      Vertisols: {}
+      Solonchaks:
+      Solonetz:
+      Stagnosols:
+      Technosols:
+      Umbrisols:
+      Vertisols:
       Yermosols:
         deprecated: true, value no longer recognized by FAO, https://github.com/GenomicsStandardsConsortium/mixs/issues/696
   FarmWaterSourceEnum:
-    description: Permissible values, used by term farm_water_source
     permissible_values:
-      brackish: {}
-      canal: {}
-      collected rainwater: {}
-      ditch: {}
-      estuary: {}
-      freshwater: {}
-      lake: {}
-      manmade: {}
-      melt pond: {}
-      municipal: {}
-      natural: {}
-      pond: {}
-      reservior: {}
-      river: {}
-      saline: {}
-      storage tank: {}
-      stream: {}
-      well: {}
+      brackish:
+      canal:
+      collected rainwater:
+      ditch:
+      estuary:
+      freshwater:
+      lake:
+      manmade:
+      melt pond:
+      municipal:
+      natural:
+      pond:
+      reservior:
+      river:
+      saline:
+      storage tank:
+      stream:
+      well:
   FilterTypeEnum:
-    description: Permissible values, used by term filter_type
     permissible_values:
-      HEPA: {}
-      chemical air filter: {}
-      electrostatic: {}
-      gas-phase or ultraviolet air treatments: {}
-      low-MERV pleated media: {}
-      particulate air filter: {}
+      HEPA:
+      chemical air filter:
+      electrostatic:
+      gas-phase or ultraviolet air treatments:
+      low-MERV pleated media:
+      particulate air filter:
   FireplaceTypeEnum:
-    description: Permissible values, used by term fireplace_type
     permissible_values:
-      gas burning: {}
-      wood burning: {}
+      gas burning:
+      wood burning:
   FloorStrucEnum:
-    description: Permissible values, used by term floor_struc
     permissible_values:
-      balcony: {}
-      concrete: {}
-      floating floor: {}
-      glass floor: {}
-      raised floor: {}
-      sprung floor: {}
-      wood-framed: {}
+      balcony:
+      concrete:
+      floating floor:
+      glass floor:
+      raised floor:
+      sprung floor:
+      wood-framed:
   FloorWaterMoldEnum:
-    description: Permissible values, used by term floor_water_mold
     permissible_values:
-      bulging walls: {}
-      ceiling discoloration: {}
-      condensation: {}
-      floor discoloration: {}
-      mold odor: {}
-      peeling paint or wallpaper: {}
-      wall discoloration: {}
-      water stains: {}
-      wet floor: {}
+      bulging walls:
+      ceiling discoloration:
+      condensation:
+      floor discoloration:
+      mold odor:
+      peeling paint or wallpaper:
+      wall discoloration:
+      water stains:
+      wet floor:
   FoodCleanProcEnum:
-    description: Permissible values, used by term food_clean_proc
     permissible_values:
-      drum and drain: {}
-      manual spinner: {}
-      rinsed with sanitizer solution: {}
-      rinsed with water: {}
-      scrubbed with brush: {}
-      scrubbed with hand: {}
-      soaking: {}
+      drum and drain:
+      manual spinner:
+      rinsed with sanitizer solution:
+      rinsed with water:
+      scrubbed with brush:
+      scrubbed with hand:
+      soaking:
   FoodTraceListEnum:
-    description: Permissible values, used by term food_trace_list
     permissible_values:
-      cheeses-other than hard cheeses: {}
-      crustaceans: {}
-      cucumbers: {}
-      finfish-including smoked finfish: {}
-      fruits and vegetables-fresh cut: {}
-      herbs-fresh: {}
-      leafy greens-including fresh cut leafy greens: {}
-      melons: {}
-      mollusks-bivalves: {}
-      nut butter: {}
-      peppers: {}
-      ready to eat deli salads: {}
-      shell eggs: {}
-      sprouts: {}
-      tomatoes: {}
-      tropical tree fruits: {}
+      cheeses-other than hard cheeses:
+      crustaceans:
+      cucumbers:
+      finfish-including smoked finfish:
+      fruits and vegetables-fresh cut:
+      herbs-fresh:
+      leafy greens-including fresh cut leafy greens:
+      melons:
+      mollusks-bivalves:
+      nut butter:
+      peppers:
+      ready to eat deli salads:
+      shell eggs:
+      sprouts:
+      tomatoes:
+      tropical tree fruits:
   FreqCleanEnum:
-    description: Permissible values, used by term freq_clean
     permissible_values:
-      Annually: {}
-      Daily: {}
-      Monthly: {}
-      Quarterly: {}
-      Weekly: {}
-      other: {}
+      Annually:
+      Daily:
+      Monthly:
+      Quarterly:
+      Weekly:
+      other:
   FurnitureEnum:
-    description: Permissible values, used by term furniture
     permissible_values:
-      cabinet: {}
-      chair: {}
-      desks: {}
+      cabinet:
+      chair:
+      desks:
   GenderRestroomEnum:
-    description: Permissible values, used by term gender_restroom
     permissible_values:
-      all gender: {}
-      female: {}
-      gender neutral: {}
-      male: {}
-      male and female: {}
-      unisex: {}
+      all gender:
+      female:
+      gender neutral:
+      male:
+      male and female:
+      unisex:
   GrowthHabitEnum:
-    description: Permissible values, used by term growth_habit
     permissible_values:
-      erect: {}
-      prostrate: {}
-      semi-erect: {}
-      spreading: {}
+      erect:
+      prostrate:
+      semi-erect:
+      spreading:
   HandidnessEnum:
-    description: Permissible values, used by term handidness
     permissible_values:
-      ambidexterity: {}
-      left handedness: {}
-      mixed-handedness: {}
-      right handedness: {}
+      ambidexterity:
+      left handedness:
+      mixed-handedness:
+      right handedness:
   HcrEnum:
-    description: Permissible values, used by term hcr
     permissible_values:
-      Coalbed: {}
-      Gas Reservoir: {}
-      Oil Reservoir: {}
-      Oil Sand: {}
-      Shale: {}
-      Tight Gas Reservoir: {}
-      Tight Oil Reservoir: {}
-      other: {}
+      Coalbed:
+      Gas Reservoir:
+      Oil Reservoir:
+      Oil Sand:
+      Shale:
+      Tight Gas Reservoir:
+      Tight Oil Reservoir:
+      other:
   HcProducedEnum:
-    description: Permissible values, used by term hc_produced
     permissible_values:
-      Bitumen: {}
-      Coalbed Methane: {}
-      Gas: {}
-      Gas-Condensate: {}
-      Oil: {}
-      other: {}
+      Bitumen:
+      Coalbed Methane:
+      Gas:
+      Gas-Condensate:
+      Oil:
+      other:
   HeatCoolTypeEnum:
-    description: Permissible values, used by term heat_cool_type
     permissible_values:
-      forced air system: {}
-      heat pump: {}
-      radiant system: {}
-      steam forced heat: {}
-      wood stove: {}
+      forced air system:
+      heat pump:
+      radiant system:
+      steam forced heat:
+      wood stove:
   HeatSysDelivMethEnum:
-    description: Permissible values, used by term heat_sys_deliv_meth
     permissible_values:
-      conductive: {}
-      radiant: {}
+      conductive:
+      radiant:
   HostCellularLocEnum:
-    description: Permissible values, used by term host_cellular_loc
     permissible_values:
-      extracellular: {}
-      intracellular: {}
-      not determined: {}
+      extracellular:
+      intracellular:
+      not determined:
   HostDependenceEnum:
-    description: Permissible values, used by term host_dependence
     permissible_values:
-      facultative: {}
-      obligate: {}
+      facultative:
+      obligate:
   HostPredApprEnum:
-    description: Permissible values, used by term host_pred_appr
     permissible_values:
-      CRISPR spacer match: {}
-      co-occurrence: {}
-      combination: {}
-      host sequence similarity: {}
-      kmer similarity: {}
-      other: {}
-      provirus: {}
+      CRISPR spacer match:
+      co-occurrence:
+      combination:
+      host sequence similarity:
+      kmer similarity:
+      other:
+      provirus:
   HostSpecificityEnum:
-    description: Permissible values, used by term host_specificity
     permissible_values:
-      family-specific: {}
-      generalist: {}
-      genus-specific: {}
-      species-specific: {}
+      family-specific:
+      generalist:
+      genus-specific:
+      species-specific:
   IndoorSpaceEnum:
-    description: Permissible values, used by term indoor_space
     permissible_values:
-      bathroom: {}
-      bedroom: {}
-      elevator: {}
-      foyer: {}
-      hallway: {}
-      kitchen: {}
-      locker room: {}
-      office: {}
+      bathroom:
+      bedroom:
+      elevator:
+      foyer:
+      hallway:
+      kitchen:
+      locker room:
+      office:
   IndoorSurfEnum:
-    description: Permissible values, used by term indoor_surf
     permissible_values:
-      cabinet: {}
-      ceiling: {}
-      counter top: {}
-      door: {}
-      shelving: {}
-      vent cover: {}
-      wall: {}
-      window: {}
+      cabinet:
+      ceiling:
+      counter top:
+      door:
+      shelving:
+      vent cover:
+      wall:
+      window:
   LibLayoutEnum:
-    description: Permissible values, used by term lib_layout
     permissible_values:
-      other: {}
-      paired: {}
-      single: {}
-      vector: {}
+      other:
+      paired:
+      single:
+      vector:
   LightTypeEnum:
-    description: Permissible values, used by term light_type
     permissible_values:
-      desk lamp: {}
-      electric light: {}
-      fluorescent lights: {}
-      natural light: {}
-      none: {}
+      desk lamp:
+      electric light:
+      fluorescent lights:
+      natural light:
+      none:
   LithologyEnum:
-    description: Permissible values, used by term lithology
     permissible_values:
-      Basement: {}
-      Chalk: {}
-      Chert: {}
-      Coal: {}
-      Conglomerate: {}
-      Diatomite: {}
-      Dolomite: {}
-      Limestone: {}
-      Sandstone: {}
-      Shale: {}
-      Siltstone: {}
-      Volcanic: {}
-      other: {}
+      Basement:
+      Chalk:
+      Chert:
+      Coal:
+      Conglomerate:
+      Diatomite:
+      Dolomite:
+      Limestone:
+      Sandstone:
+      Shale:
+      Siltstone:
+      Volcanic:
+      other:
   MagCovSoftwareEnum:
-    description: Permissible values, used by term mag_cov_software
     permissible_values:
-      bbmap: {}
-      bowtie: {}
-      bwa: {}
-      other: {}
+      bbmap:
+      bowtie:
+      bwa:
+      other:
   MechStrucEnum:
-    description: Permissible values, used by term mech_struc
     permissible_values:
-      boat: {}
-      bus: {}
-      car: {}
-      carriage: {}
-      coach: {}
-      elevator: {}
-      escalator: {}
-      subway: {}
-      train: {}
+      boat:
+      bus:
+      car:
+      carriage:
+      coach:
+      elevator:
+      escalator:
+      subway:
+      train:
   ModeTransmissionEnum:
-    description: Permissible values, used by term mode_transmission
     permissible_values:
-      horizontal:castrator: {}
-      horizontal:directly transmitted: {}
-      horizontal:micropredator: {}
-      horizontal:parasitoid: {}
-      horizontal:trophically transmitted: {}
-      horizontal:vector transmitted: {}
-      vertical: {}
+      horizontal:castrator:
+      horizontal:directly transmitted:
+      horizontal:micropredator:
+      horizontal:parasitoid:
+      horizontal:trophically transmitted:
+      horizontal:vector transmitted:
+      vertical:
   NegContTypeEnum:
-    description: Permissible values, used by term neg_cont_type
     permissible_values:
-      DNA-free PCR mix: {}
-      distilled water: {}
-      empty collection device: {}
-      empty collection tube: {}
-      phosphate buffer: {}
-      sterile swab: {}
-      sterile syringe: {}
+      DNA-free PCR mix:
+      distilled water:
+      empty collection device:
+      empty collection tube:
+      phosphate buffer:
+      sterile swab:
+      sterile syringe:
   OccupDocumentEnum:
-    description: Permissible values, used by term occup_document
     permissible_values:
-      automated count: {}
-      estimate: {}
-      manual count: {}
-      videos: {}
+      automated count:
+      estimate:
+      manual count:
+      videos:
   OxyStatSampEnum:
-    description: Permissible values, used by term oxy_stat_samp
     permissible_values:
-      aerobic: {}
-      anaerobic: {}
-      other: {}
+      aerobic:
+      anaerobic:
+      other:
   PlantReprodCropEnum:
-    description: Permissible values, used by term plant_reprod_crop
     permissible_values:
-      plant cutting: {}
-      pregerminated seed: {}
-      ratoon: {}
-      seed: {}
-      seedling: {}
-      whole mature plant: {}
+      plant cutting:
+      pregerminated seed:
+      ratoon:
+      seed:
+      seedling:
+      whole mature plant:
   PlantSexEnum:
-    description: Permissible values, used by term plant_sex
     permissible_values:
-      Androdioecious: {}
-      Androecious: {}
-      Androgynomonoecious: {}
-      Androgynous: {}
-      Andromonoecious: {}
-      Bisexual: {}
-      Dichogamous: {}
-      Diclinous: {}
-      Dioecious: {}
-      Gynodioecious: {}
-      Gynoecious: {}
-      Gynomonoecious: {}
-      Hermaphroditic: {}
-      Imperfect: {}
-      Monoclinous: {}
-      Monoecious: {}
-      Perfect: {}
-      Polygamodioecious: {}
-      Polygamomonoecious: {}
-      Polygamous: {}
-      Protandrous: {}
-      Protogynous: {}
-      Subandroecious: {}
-      Subdioecious: {}
-      Subgynoecious: {}
-      Synoecious: {}
-      Trimonoecious: {}
-      Trioecious: {}
-      Unisexual: {}
+      Androdioecious:
+      Androecious:
+      Androgynomonoecious:
+      Androgynous:
+      Andromonoecious:
+      Bisexual:
+      Dichogamous:
+      Diclinous:
+      Dioecious:
+      Gynodioecious:
+      Gynoecious:
+      Gynomonoecious:
+      Hermaphroditic:
+      Imperfect:
+      Monoclinous:
+      Monoecious:
+      Perfect:
+      Polygamodioecious:
+      Polygamomonoecious:
+      Polygamous:
+      Protandrous:
+      Protogynous:
+      Subandroecious:
+      Subdioecious:
+      Subgynoecious:
+      Synoecious:
+      Trimonoecious:
+      Trioecious:
+      Unisexual:
   PredGenomeStrucEnum:
-    description: Permissible values, used by term pred_genome_struc
     permissible_values:
-      non-segmented: {}
-      segmented: {}
-      undetermined: {}
+      non-segmented:
+      segmented:
+      undetermined:
   ProfilePositionEnum:
-    description: Permissible values, used by term profile_position
     permissible_values:
-      backslope: {}
-      footslope: {}
-      shoulder: {}
-      summit: {}
-      toeslope: {}
+      backslope:
+      footslope:
+      shoulder:
+      summit:
+      toeslope:
   QuadPosEnum:
-    description: Permissible values, used by term quad_pos
     permissible_values:
-      East side: {}
-      North side: {}
-      South side: {}
-      West side: {}
+      East side:
+      North side:
+      South side:
+      West side:
   RelSampLocEnum:
-    description: Permissible values, used by term rel_samp_loc
     permissible_values:
-      center of car: {}
-      edge of car: {}
-      under a seat: {}
+      center of car:
+      edge of car:
+      under a seat:
   RelToOxygenEnum:
-    description: Permissible values, used by term rel_to_oxygen
     permissible_values:
-      aerobe: {}
-      anaerobe: {}
-      facultative: {}
-      microaerophilic: {}
-      microanaerobe: {}
-      obligate aerobe: {}
-      obligate anaerobe: {}
+      aerobe:
+      anaerobe:
+      facultative:
+      microaerophilic:
+      microanaerobe:
+      obligate aerobe:
+      obligate anaerobe:
   RoomCondtEnum:
-    description: Permissible values, used by term room_condt
     permissible_values:
-      damaged: {}
-      needs repair: {}
-      new: {}
-      rupture: {}
-      visible signs of mold/mildew: {}
-      visible wear: {}
+      damaged:
+      needs repair:
+      new:
+      rupture:
+      visible signs of mold/mildew:
+      visible wear:
   RoomConnectedEnum:
-    description: Permissible values, used by term room_connected
     permissible_values:
-      attic: {}
-      bathroom: {}
-      closet: {}
-      conference room: {}
-      elevator: {}
-      examining room: {}
-      hallway: {}
-      kitchen: {}
-      mail room: {}
-      office: {}
-      stairwell: {}
+      attic:
+      bathroom:
+      closet:
+      conference room:
+      elevator:
+      examining room:
+      hallway:
+      kitchen:
+      mail room:
+      office:
+      stairwell:
   RoomLocEnum:
-    description: Permissible values, used by term room_loc
     permissible_values:
-      corner room: {}
-      exterior wall: {}
-      interior room: {}
+      corner room:
+      exterior wall:
+      interior room:
   RoomSampPosEnum:
-    description: Permissible values, used by term room_samp_pos
     permissible_values:
-      center: {}
-      east corner: {}
-      north corner: {}
-      northeast corner: {}
-      northwest corner: {}
-      south corner: {}
-      southeast corner: {}
-      southwest corner: {}
-      west corner: {}
+      center:
+      east corner:
+      north corner:
+      northeast corner:
+      northwest corner:
+      south corner:
+      southeast corner:
+      southwest corner:
+      west corner:
   RouteTransmissionEnum:
-    description: Permissible values, used by term route_transmission
     permissible_values:
-      environmental:faecal-oral: {}
-      transplacental: {}
-      vector-borne:vector penetration: {}
+      environmental:faecal-oral:
+      transplacental:
+      vector-borne:vector penetration:
   SampCaptStatusEnum:
-    description: Permissible values, used by term samp_capt_status
     permissible_values:
-      active surveillance in response to an outbreak: {}
-      active surveillance not initiated by an outbreak: {}
-      farm sample: {}
-      market sample: {}
-      other: {}
+      active surveillance in response to an outbreak:
+      active surveillance not initiated by an outbreak:
+      farm sample:
+      market sample:
+      other:
   SampCollectPointEnum:
-    description: Permissible values, used by term samp_collect_point
     permissible_values:
-      drilling rig: {}
-      other: {}
-      separator: {}
-      storage tank: {}
-      test well: {}
-      well: {}
-      wellhead: {}
+      drilling rig:
+      other:
+      separator:
+      storage tank:
+      test well:
+      well:
+      wellhead:
   SampDisStageEnum:
-    description: Permissible values, used by term samp_dis_stage
     permissible_values:
-      dissemination: {}
-      growth and reproduction: {}
-      infection: {}
-      inoculation: {}
-      other: {}
-      penetration: {}
+      dissemination:
+      growth and reproduction:
+      infection:
+      inoculation:
+      other:
+      penetration:
   SampLocConditionEnum:
-    description: Permissible values, used by term samp_loc_condition
     permissible_values:
-      damaged: {}
-      new: {}
-      rupture: {}
-      visible signs of mold-mildew: {}
-      visible weariness repair: {}
+      damaged:
+      new:
+      rupture:
+      visible signs of mold-mildew:
+      visible weariness repair:
   SampSubtypeEnum:
-    description: Permissible values, used by term samp_subtype
     permissible_values:
-      biofilm: {}
-      not applicable: {}
-      oil phase: {}
-      other: {}
-      water phase: {}
+      biofilm:
+      not applicable:
+      oil phase:
+      other:
+      water phase:
   SampSurfMoistureEnum:
-    description: Permissible values, used by term samp_surf_moisture
     permissible_values:
-      intermittent moisture: {}
-      not present: {}
-      submerged: {}
+      intermittent moisture:
+      not present:
+      submerged:
   SampTransportContEnum:
-    description: Permissible values, used by term samp_transport_cont
     permissible_values:
-      bottle: {}
-      cooler: {}
-      glass vial: {}
-      plastic vial: {}
-      vendor supplied container: {}
+      bottle:
+      cooler:
+      glass vial:
+      plastic vial:
+      vendor supplied container:
   SampWeatherEnum:
-    description: Permissible values, used by term samp_weather
     permissible_values:
-      clear sky: {}
-      cloudy: {}
-      foggy: {}
-      hail: {}
-      rain: {}
-      sleet: {}
-      snow: {}
-      sunny: {}
-      windy: {}
+      clear sky:
+      cloudy:
+      foggy:
+      hail:
+      rain:
+      sleet:
+      snow:
+      sunny:
+      windy:
   ScLysisApproachEnum:
-    description: Permissible values, used by term sc_lysis_approach
     permissible_values:
-      chemical: {}
-      combination: {}
-      enzymatic: {}
-      physical: {}
+      chemical:
+      combination:
+      enzymatic:
+      physical:
   SeasonUseEnum:
-    description: Permissible values, used by term season_use
     permissible_values:
-      Fall: {}
-      Spring: {}
-      Summer: {}
-      Winter: {}
+      Fall:
+      Spring:
+      Summer:
+      Winter:
   SedimentTypeEnum:
-    description: Permissible values, used by term sediment_type
     permissible_values:
-      biogenous: {}
-      cosmogenous: {}
-      hydrogenous: {}
-      lithogenous: {}
+      biogenous:
+      cosmogenous:
+      hydrogenous:
+      lithogenous:
   SeqQualityCheckEnum:
-    description: Permissible values, used by term seq_quality_check
     permissible_values:
-      manually edited: {}
-      none: {}
+      manually edited:
+      none:
   ShadingDeviceLocEnum:
-    description: Permissible values, used by term shading_device_loc
     permissible_values:
-      exterior: {}
-      interior: {}
+      exterior:
+      interior:
   ShadingDeviceTypeEnum:
-    description: Permissible values, used by term shading_device_type
     permissible_values:
-      bahama shutters: {}
-      exterior roll blind: {}
-      gambrel awning: {}
-      hood awning: {}
-      porchroller awning: {}
-      sarasota shutters: {}
-      slatted aluminum: {}
-      solid aluminum awning: {}
-      sun screen: {}
-      tree: {}
-      trellis: {}
-      venetian awning: {}
+      bahama shutters:
+      exterior roll blind:
+      gambrel awning:
+      hood awning:
+      porchroller awning:
+      sarasota shutters:
+      slatted aluminum:
+      solid aluminum awning:
+      sun screen:
+      tree:
+      trellis:
+      venetian awning:
   CompassDirections8Enum:
-    description: 'Permissible values, used by 6 terms: door_loc, ext_wall_orient,
-      ext_window_orient, heat_deliv_loc, wall_loc, window_loc'
     permissible_values:
-      east: {}
-      north: {}
-      northeast: {}
-      northwest: {}
-      south: {}
-      southeast: {}
-      southwest: {}
-      west: {}
+      east:
+      north:
+      northeast:
+      northwest:
+      south:
+      southeast:
+      southwest:
+      west:
   MoldVisibilityEnum:
-    description: 'Permissible values, used by 5 terms: ceil_water_mold, door_water_mold,
-      shad_dev_water_mold, wall_water_mold, window_water_mold'
     permissible_values:
-      no presence of mold visible: {}
-      presence of mold visible: {}
+      no presence of mold visible:
+      presence of mold visible:
   DamagedRupturedEnum:
-    description: 'Permissible values, used by 3 terms: door_cond, shading_device_cond,
-      window_cond'
     permissible_values:
-      damaged: {}
-      needs repair: {}
-      new: {}
-      rupture: {}
-      visible wear: {}
+      damaged:
+      needs repair:
+      new:
+      rupture:
+      visible wear:
   DamagedEnum:
-    description: 'Permissible values, used by 3 terms: ceil_cond, floor_cond, int_wall_cond'
     permissible_values:
-      damaged: {}
-      needs repair: {}
-      new: {}
-      rupture: {}
-      visible wear: {}
+      damaged:
+      needs repair:
+      new:
+      rupture:
+      visible wear:
   CeilingWallTextureEnum:
-    description: 'Permissible values, used by 2 terms: ceil_texture, wall_texture'
     permissible_values:
-      Santa-Fe texture: {}
-      crows feet: {}
-      crows-foot stomp: {}
-      double skip: {}
-      hawk and trowel: {}
-      knockdown: {}
-      orange peel: {}
-      popcorn: {}
-      rosebud stomp: {}
-      skip trowel: {}
-      smooth: {}
-      stomp knockdown: {}
-      swirl: {}
+      Santa-Fe texture:
+      crows feet:
+      crows-foot stomp:
+      double skip:
+      hawk and trowel:
+      knockdown:
+      orange peel:
+      popcorn:
+      rosebud stomp:
+      skip trowel:
+      smooth:
+      stomp knockdown:
+      swirl:
   GeolAgeEnum:
-    description: 'Permissible values, used by 2 terms: hcr_geol_age, sr_geol_age'
     permissible_values:
-      Archean: {}
-      Cambrian: {}
-      Carboniferous: {}
-      Cenozoic: {}
-      Cretaceous: {}
-      Devonian: {}
-      Jurassic: {}
-      Mesozoic: {}
-      Neogene: {}
-      Ordovician: {}
-      Paleogene: {}
-      Paleozoic: {}
-      Permian: {}
-      Precambrian: {}
-      Proterozoic: {}
-      Silurian: {}
-      Triassic: {}
-      other: {}
+      Archean:
+      Cambrian:
+      Carboniferous:
+      Cenozoic:
+      Cretaceous:
+      Devonian:
+      Jurassic:
+      Mesozoic:
+      Neogene:
+      Ordovician:
+      Paleogene:
+      Paleozoic:
+      Permian:
+      Precambrian:
+      Proterozoic:
+      Silurian:
+      Triassic:
+      other:
   SoilHorizonEnum:
-    description: Permissible values, used by term soil_horizon
     permissible_values:
-      A horizon: {}
-      B horizon: {}
-      C horizon: {}
-      E horizon: {}
-      O horizon: {}
-      Permafrost: {}
-      R layer: {}
+      A horizon:
+      B horizon:
+      C horizon:
+      E horizon:
+      O horizon:
+      Permafrost:
+      R layer:
   SoilTextureClassEnum:
-    description: Permissible values, used by term soil_texture_class
     permissible_values:
-      clay: {}
-      clay loam: {}
-      loam: {}
-      loamy sand: {}
-      sand: {}
-      sandy clay: {}
-      sandy clay loam: {}
-      sandy loam: {}
-      silt: {}
-      silt loam: {}
-      silty clay: {}
-      silty clay loam: {}
+      clay:
+      clay loam:
+      loam:
+      loamy sand:
+      sand:
+      sandy clay:
+      sandy clay loam:
+      sandy loam:
+      silt:
+      silt loam:
+      silty clay:
+      silty clay loam:
   SortTechEnum:
-    description: Permissible values, used by term sort_tech
     permissible_values:
-      flow cytometric cell sorting: {}
-      lazer-tweezing: {}
-      microfluidics: {}
-      micromanipulation: {}
-      optical manipulation: {}
-      other: {}
+      flow cytometric cell sorting:
+      lazer-tweezing:
+      microfluidics:
+      micromanipulation:
+      optical manipulation:
+      other:
   SpaceTypStateEnum:
-    description: Permissible values, used by term space_typ_state
     permissible_values:
-      typically occupied: {}
-      typically unoccupied: {}
+      typically occupied:
+      typically unoccupied:
   SpecificEnum:
-    description: Permissible values, used by term specific
     permissible_values:
-      as built: {}
-      bid: {}
-      construction: {}
-      design: {}
-      operation: {}
-      photos: {}
+      as built:
+      bid:
+      construction:
+      design:
+      operation:
+      photos:
   SrDepEnvEnum:
-    description: Permissible values, used by term sr_dep_env
     permissible_values:
-      Fluvioldeltaic: {}
-      Fluviomarine: {}
-      Lacustine: {}
-      Marine: {}
-      other: {}
+      Fluvioldeltaic:
+      Fluviomarine:
+      Lacustine:
+      Marine:
+      other:
   SrKerogTypeEnum:
-    description: Permissible values, used by term sr_kerog_type
     permissible_values:
-      Type I: {}
-      Type II: {}
-      Type III: {}
-      Type IV: {}
-      other: {}
+      Type I:
+      Type II:
+      Type III:
+      Type IV:
+      other:
   SrLithologyEnum:
-    description: Permissible values, used by term sr_lithology
     permissible_values:
-      Biosilicieous: {}
-      Carbonate: {}
-      Clastic: {}
-      Coal: {}
-      other: {}
+      Biosilicieous:
+      Carbonate:
+      Clastic:
+      Coal:
+      other:
   SubstructureTypeEnum:
-    description: Permissible values, used by term substructure_type
     permissible_values:
-      basement: {}
-      crawlspace: {}
-      slab on grade: {}
+      basement:
+      crawlspace:
+      slab on grade:
   SurfAirContEnum:
-    description: Permissible values, used by term surf_air_cont
     permissible_values:
-      biocides: {}
-      biological contaminants: {}
-      dust: {}
-      nutrients: {}
-      organic matter: {}
-      particulate matter: {}
-      radon: {}
-      volatile organic compounds: {}
+      biocides:
+      biological contaminants:
+      dust:
+      nutrients:
+      organic matter:
+      particulate matter:
+      radon:
+      volatile organic compounds:
   SurfMaterialEnum:
-    description: Permissible values, used by term surf_material
     permissible_values:
-      adobe: {}
-      carpet: {}
-      cinder blocks: {}
-      concrete: {}
-      glass: {}
-      hay bales: {}
-      metal: {}
-      paint: {}
-      plastic: {}
-      stainless steel: {}
-      stone: {}
-      stucco: {}
-      tile: {}
-      vinyl: {}
-      wood: {}
+      adobe:
+      carpet:
+      cinder blocks:
+      concrete:
+      glass:
+      hay bales:
+      metal:
+      paint:
+      plastic:
+      stainless steel:
+      stone:
+      stucco:
+      tile:
+      vinyl:
+      wood:
   SymbiontHostRoleEnum:
-    description: Permissible values, used by term symbiont_host_role
     permissible_values:
-      accidental: {}
-      dead-end: {}
-      definitive: {}
-      intermediate: {}
-      paratenic: {}
-      reservoir: {}
-      single host: {}
+      accidental:
+      dead-end:
+      definitive:
+      intermediate:
+      paratenic:
+      reservoir:
+      single host:
   SymLifeCycleTypeEnum:
-    description: Permissible values, used by term sym_life_cycle_type
     permissible_values:
-      complex life cycle: {}
-      simple life cycle: {}
+      complex life cycle:
+      simple life cycle:
   TaxIdentEnum:
-    description: Permissible values, used by term tax_ident
     permissible_values:
-      16S rRNA gene: {}
-      multi-marker approach: {}
-      other: {}
+      16S rRNA gene:
+      multi-marker approach:
+      other:
   TidalStageEnum:
-    description: Permissible values, used by term tidal_stage
     permissible_values:
-      ebb tide: {}
-      flood tide: {}
-      high tide: {}
-      low tide: {}
+      ebb tide:
+      flood tide:
+      high tide:
+      low tide:
   TillageEnum:
-    description: Permissible values, used by term tillage
     permissible_values:
-      chisel: {}
-      cutting disc: {}
-      disc plough: {}
-      drill: {}
-      mouldboard: {}
-      ridge till: {}
-      strip tillage: {}
-      tined: {}
-      zonal tillage: {}
+      chisel:
+      cutting disc:
+      disc plough:
+      drill:
+      mouldboard:
+      ridge till:
+      strip tillage:
+      tined:
+      zonal tillage:
   TrainLineEnum:
-    description: Permissible values, used by term train_line
     permissible_values:
-      green: {}
-      orange: {}
-      red: {}
+      green:
+      orange:
+      red:
   TrainStatLocEnum:
-    description: Permissible values, used by term train_stat_loc
     permissible_values:
-      forest hills: {}
-      riverside: {}
-      south station above ground: {}
-      south station amtrak: {}
-      south station underground: {}
+      forest hills:
+      riverside:
+      south station above ground:
+      south station amtrak:
+      south station underground:
   TrainStopLocEnum:
-    description: Permissible values, used by term train_stop_loc
     permissible_values:
-      downtown: {}
-      end: {}
-      mid: {}
+      downtown:
+      end:
+      mid:
   TrophicLevelEnum:
-    description: Permissible values, used by term trophic_level
     permissible_values:
-      autotroph: {}
-      carboxydotroph: {}
-      chemoautolithotroph: {}
-      chemoautotroph: {}
-      chemoheterotroph: {}
-      chemolithoautotroph: {}
-      chemolithotroph: {}
-      chemoorganoheterotroph: {}
-      chemoorganotroph: {}
-      chemosynthetic: {}
-      chemotroph: {}
-      copiotroph: {}
-      diazotroph: {}
-      facultative: {}
-      heterotroph: {}
-      lithoautotroph: {}
-      lithoheterotroph: {}
-      lithotroph: {}
-      methanotroph: {}
-      methylotroph: {}
-      mixotroph: {}
-      obligate: {}
-      oligotroph: {}
-      organoheterotroph: {}
-      organotroph: {}
-      photoautotroph: {}
-      photoheterotroph: {}
-      photolithoautotroph: {}
-      photolithotroph: {}
-      photosynthetic: {}
-      phototroph: {}
+      autotroph:
+      carboxydotroph:
+      chemoautolithotroph:
+      chemoautotroph:
+      chemoheterotroph:
+      chemolithoautotroph:
+      chemolithotroph:
+      chemoorganoheterotroph:
+      chemoorganotroph:
+      chemosynthetic:
+      chemotroph:
+      copiotroph:
+      diazotroph:
+      facultative:
+      heterotroph:
+      lithoautotroph:
+      lithoheterotroph:
+      lithotroph:
+      methanotroph:
+      methylotroph:
+      mixotroph:
+      obligate:
+      oligotroph:
+      organoheterotroph:
+      organotroph:
+      photoautotroph:
+      photoheterotroph:
+      photolithoautotroph:
+      photolithotroph:
+      photosynthetic:
+      phototroph:
   TypeOfSymbiosisEnum:
-    description: Permissible values, used by term type_of_symbiosis
     permissible_values:
-      commensalistic: {}
-      mutualistic: {}
-      parasitic: {}
+      commensalistic:
+      mutualistic:
+      parasitic:
   UrineCollectMethEnum:
-    description: Permissible values, used by term urine_collect_meth
     permissible_values:
-      catheter: {}
-      clean catch: {}
+      catheter:
+      clean catch:
   UrobiomSexEnum:
-    description: Permissible values, used by term urobiom_sex
     permissible_values:
-      female: {}
-      hermaphrodite: {}
-      male: {}
-      neuter: {}
+      female:
+      hermaphrodite:
+      male:
+      neuter:
   VirusEnrichApprEnum:
-    description: Permissible values, used by term virus_enrich_appr
     permissible_values:
-      CsCl density gradient: {}
-      DNAse: {}
-      FeCl Precipitation: {}
-      PEG Precipitation: {}
-      RNAse: {}
-      centrifugation: {}
-      filtration: {}
-      none: {}
-      other: {}
-      targeted sequence capture: {}
-      ultracentrifugation: {}
-      ultrafiltration: {}
+      CsCl density gradient:
+      DNAse:
+      FeCl Precipitation:
+      PEG Precipitation:
+      RNAse:
+      centrifugation:
+      filtration:
+      none:
+      other:
+      targeted sequence capture:
+      ultracentrifugation:
+      ultrafiltration:
   WallConstTypeEnum:
-    description: Permissible values, used by term wall_const_type
     permissible_values:
-      fire resistive: {}
-      frame construction: {}
-      joisted masonry: {}
-      light noncombustible: {}
-      masonry noncombustible: {}
-      modified fire resistive: {}
+      fire resistive:
+      frame construction:
+      joisted masonry:
+      light noncombustible:
+      masonry noncombustible:
+      modified fire resistive:
   WallFinishMatEnum:
-    description: Permissible values, used by term wall_finish_mat
     permissible_values:
-      acoustical treatment: {}
-      gypsum board: {}
-      gypsum plaster: {}
-      masonry: {}
-      metal: {}
-      plaster: {}
-      stone facing: {}
-      terrazzo: {}
-      tile: {}
-      veneer plaster: {}
-      wood: {}
+      acoustical treatment:
+      gypsum board:
+      gypsum plaster:
+      masonry:
+      metal:
+      plaster:
+      stone facing:
+      terrazzo:
+      tile:
+      veneer plaster:
+      wood:
   WallSurfTreatmentEnum:
-    description: Permissible values, used by term wall_surf_treatment
     permissible_values:
-      fabric: {}
-      no treatment: {}
-      painted: {}
-      paneling: {}
-      stucco: {}
-      wall paper: {}
+      fabric:
+      no treatment:
+      painted:
+      paneling:
+      stucco:
+      wall paper:
   WaterFeatTypeEnum:
-    description: Permissible values, used by term water_feat_type
     permissible_values:
-      fountain: {}
-      pool: {}
-      standing feature: {}
-      stream: {}
-      waterfall: {}
+      fountain:
+      pool:
+      standing feature:
+      stream:
+      waterfall:
   WeekdayEnum:
-    description: Permissible values, used by term weekday
     permissible_values:
-      Friday: {}
-      Monday: {}
-      Saturday: {}
-      Sunday: {}
-      Thursday: {}
-      Tuesday: {}
-      Wednesday: {}
+      Friday:
+      Monday:
+      Saturday:
+      Sunday:
+      Thursday:
+      Tuesday:
+      Wednesday:
   WgaAmpApprEnum:
-    description: Permissible values, used by term wga_amp_appr
     permissible_values:
-      mda based: {}
-      pcr based: {}
+      mda based:
+      pcr based:
   WindowCoverEnum:
-    description: Permissible values, used by term window_cover
     permissible_values:
-      blinds: {}
-      curtains: {}
-      none: {}
+      blinds:
+      curtains:
+      none:
   WindowHorizPosEnum:
-    description: Permissible values, used by term window_horiz_pos
     permissible_values:
-      left: {}
-      middle: {}
-      right: {}
+      left:
+      middle:
+      right:
   WindowMatEnum:
-    description: Permissible values, used by term window_mat
     permissible_values:
-      clad: {}
-      fiberglass: {}
-      metal: {}
-      vinyl: {}
-      wood: {}
+      clad:
+      fiberglass:
+      metal:
+      vinyl:
+      wood:
   WindowStatusEnum:
-    description: Permissible values, used by term window_status
     permissible_values:
-      closed: {}
-      open: {}
+      closed:
+      open:
   WindowTypeEnum:
-    description: Permissible values, used by term window_type
     permissible_values:
-      fixed window: {}
-      horizontal sash window: {}
-      single-hung sash window: {}
+      fixed window:
+      horizontal sash window:
+      single-hung sash window:
   WindowVertPosEnum:
-    description: Permissible values, used by term window_vert_pos
     permissible_values:
-      bottom: {}
-      high: {}
-      low: {}
-      middle: {}
-      top: {}
+      bottom:
+      high:
+      low:
+      middle:
+      top:
 slots:
   migs_ba_data:
     description: Data that comply with checklist MigsBa
     title: MigsBa data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_data
-    range: MigsBa
     multivalued: true
+    range: MigsBa
     inlined: true
     inlined_as_list: true
   agriculture_data:
     description: Data that comply with Extension Agriculture
     title: Agriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:agriculture_data
-    range: Agriculture
     multivalued: true
+    range: Agriculture
     inlined: true
     inlined_as_list: true
   migs_ba_agriculture_data:
     description: Data that comply with MigsBa combined with Agriculture
     title: MigsBaAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_agriculture_data
-    range: MigsBaAgriculture
     multivalued: true
+    range: MigsBaAgriculture
     inlined: true
     inlined_as_list: true
   air_data:
@@ -1308,273 +1174,307 @@ slots:
     title: Air data
     keywords:
       - air
+    domain: MixsCompliantData
     slot_uri: MIXS:air_data
-    range: Air
     multivalued: true
+    range: Air
     inlined: true
     inlined_as_list: true
   migs_ba_air_data:
     description: Data that comply with MigsBa combined with Air
     title: MigsBaAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_air_data
-    range: MigsBaAir
     multivalued: true
+    range: MigsBaAir
     inlined: true
     inlined_as_list: true
   built_environment_data:
     description: Data that comply with Extension BuiltEnvironment
     title: BuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:built_environment_data
-    range: BuiltEnvironment
     multivalued: true
+    range: BuiltEnvironment
     inlined: true
     inlined_as_list: true
   migs_ba_built_environment_data:
     description: Data that comply with MigsBa combined with BuiltEnvironment
     title: MigsBaBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_built_environment_data
-    range: MigsBaBuiltEnvironment
     multivalued: true
+    range: MigsBaBuiltEnvironment
     inlined: true
     inlined_as_list: true
   food_animal_and_animal_feed_data:
     description: Data that comply with Extension FoodAnimalAndAnimalFeed
     title: FoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:food_animal_and_animal_feed_data
-    range: FoodAnimalAndAnimalFeed
     multivalued: true
+    range: FoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   migs_ba_food_animal_and_animal_feed_data:
     description: Data that comply with MigsBa combined with FoodAnimalAndAnimalFeed
     title: MigsBaFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_animal_and_animal_feed_data
-    range: MigsBaFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MigsBaFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   food_farm_environment_data:
     description: Data that comply with Extension FoodFarmEnvironment
     title: FoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:food_farm_environment_data
-    range: FoodFarmEnvironment
     multivalued: true
+    range: FoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   migs_ba_food_farm_environment_data:
     description: Data that comply with MigsBa combined with FoodFarmEnvironment
     title: MigsBaFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_farm_environment_data
-    range: MigsBaFoodFarmEnvironment
     multivalued: true
+    range: MigsBaFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   food_food_production_facility_data:
     description: Data that comply with Extension FoodFoodProductionFacility
     title: FoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:food_food_production_facility_data
-    range: FoodFoodProductionFacility
     multivalued: true
+    range: FoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   migs_ba_food_food_production_facility_data:
     description: Data that comply with MigsBa combined with FoodFoodProductionFacility
     title: MigsBaFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_food_production_facility_data
-    range: MigsBaFoodFoodProductionFacility
     multivalued: true
+    range: MigsBaFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   food_human_foods_data:
     description: Data that comply with Extension FoodHumanFoods
     title: FoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:food_human_foods_data
-    range: FoodHumanFoods
     multivalued: true
+    range: FoodHumanFoods
     inlined: true
     inlined_as_list: true
   migs_ba_food_human_foods_data:
     description: Data that comply with MigsBa combined with FoodHumanFoods
     title: MigsBaFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_food_human_foods_data
-    range: MigsBaFoodHumanFoods
     multivalued: true
+    range: MigsBaFoodHumanFoods
     inlined: true
     inlined_as_list: true
   host_associated_data:
     description: Data that comply with Extension HostAssociated
     title: HostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:host_associated_data
-    range: HostAssociated
     multivalued: true
+    range: HostAssociated
     inlined: true
     inlined_as_list: true
   migs_ba_host_associated_data:
     description: Data that comply with MigsBa combined with HostAssociated
     title: MigsBaHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_host_associated_data
-    range: MigsBaHostAssociated
     multivalued: true
+    range: MigsBaHostAssociated
     inlined: true
     inlined_as_list: true
   human_associated_data:
     description: Data that comply with Extension HumanAssociated
     title: HumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:human_associated_data
-    range: HumanAssociated
     multivalued: true
+    range: HumanAssociated
     inlined: true
     inlined_as_list: true
   migs_ba_human_associated_data:
     description: Data that comply with MigsBa combined with HumanAssociated
     title: MigsBaHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_associated_data
-    range: MigsBaHumanAssociated
     multivalued: true
+    range: MigsBaHumanAssociated
     inlined: true
     inlined_as_list: true
   human_gut_data:
     description: Data that comply with Extension HumanGut
     title: HumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:human_gut_data
-    range: HumanGut
     multivalued: true
+    range: HumanGut
     inlined: true
     inlined_as_list: true
   migs_ba_human_gut_data:
     description: Data that comply with MigsBa combined with HumanGut
     title: MigsBaHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_gut_data
-    range: MigsBaHumanGut
     multivalued: true
+    range: MigsBaHumanGut
     inlined: true
     inlined_as_list: true
   human_oral_data:
     description: Data that comply with Extension HumanOral
     title: HumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:human_oral_data
-    range: HumanOral
     multivalued: true
+    range: HumanOral
     inlined: true
     inlined_as_list: true
   migs_ba_human_oral_data:
     description: Data that comply with MigsBa combined with HumanOral
     title: MigsBaHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_oral_data
-    range: MigsBaHumanOral
     multivalued: true
+    range: MigsBaHumanOral
     inlined: true
     inlined_as_list: true
   human_skin_data:
     description: Data that comply with Extension HumanSkin
     title: HumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:human_skin_data
-    range: HumanSkin
     multivalued: true
+    range: HumanSkin
     inlined: true
     inlined_as_list: true
   migs_ba_human_skin_data:
     description: Data that comply with MigsBa combined with HumanSkin
     title: MigsBaHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_skin_data
-    range: MigsBaHumanSkin
     multivalued: true
+    range: MigsBaHumanSkin
     inlined: true
     inlined_as_list: true
   human_vaginal_data:
     description: Data that comply with Extension HumanVaginal
     title: HumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:human_vaginal_data
-    range: HumanVaginal
     multivalued: true
+    range: HumanVaginal
     inlined: true
     inlined_as_list: true
   migs_ba_human_vaginal_data:
     description: Data that comply with MigsBa combined with HumanVaginal
     title: MigsBaHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_human_vaginal_data
-    range: MigsBaHumanVaginal
     multivalued: true
+    range: MigsBaHumanVaginal
     inlined: true
     inlined_as_list: true
   hydrocarbon_resources_cores_data:
     description: Data that comply with Extension HydrocarbonResourcesCores
     title: HydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:hydrocarbon_resources_cores_data
-    range: HydrocarbonResourcesCores
     multivalued: true
+    range: HydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   migs_ba_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsBa combined with HydrocarbonResourcesCores
     title: MigsBaHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_hydrocarbon_resources_cores_data
-    range: MigsBaHydrocarbonResourcesCores
     multivalued: true
+    range: MigsBaHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Extension HydrocarbonResourcesFluidsSwabs
     title: HydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:hydrocarbon_resources_fluids_swabs_data
-    range: HydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: HydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   migs_ba_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsBa combined with HydrocarbonResourcesFluidsSwabs
     title: MigsBaHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_hydrocarbon_resources_fluids_swabs_data
-    range: MigsBaHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MigsBaHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   microbial_mat_biofilm_data:
     description: Data that comply with Extension MicrobialMatBiofilm
     title: MicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:microbial_mat_biofilm_data
-    range: MicrobialMatBiofilm
     multivalued: true
+    range: MicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   migs_ba_microbial_mat_biofilm_data:
     description: Data that comply with MigsBa combined with MicrobialMatBiofilm
     title: MigsBaMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_microbial_mat_biofilm_data
-    range: MigsBaMicrobialMatBiofilm
     multivalued: true
+    range: MigsBaMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Extension MiscellaneousNaturalOrArtificialEnvironment
     title: MiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:miscellaneous_natural_or_artificial_environment_data
-    range: MiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   migs_ba_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsBa combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsBaMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_miscellaneous_natural_or_artificial_environment_data
-    range: MigsBaMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MigsBaMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   plant_associated_data:
     description: Data that comply with Extension PlantAssociated
     title: PlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:plant_associated_data
-    range: PlantAssociated
     multivalued: true
+    range: PlantAssociated
     inlined: true
     inlined_as_list: true
   migs_ba_plant_associated_data:
     description: Data that comply with MigsBa combined with PlantAssociated
     title: MigsBaPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_plant_associated_data
-    range: MigsBaPlantAssociated
     multivalued: true
+    range: MigsBaPlantAssociated
     inlined: true
     inlined_as_list: true
   sediment_data:
@@ -1582,17 +1482,19 @@ slots:
     title: Sediment data
     keywords:
       - sediment
+    domain: MixsCompliantData
     slot_uri: MIXS:sediment_data
-    range: Sediment
     multivalued: true
+    range: Sediment
     inlined: true
     inlined_as_list: true
   migs_ba_sediment_data:
     description: Data that comply with MigsBa combined with Sediment
     title: MigsBaSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_sediment_data
-    range: MigsBaSediment
     multivalued: true
+    range: MigsBaSediment
     inlined: true
     inlined_as_list: true
   soil_data:
@@ -1600,49 +1502,55 @@ slots:
     title: Soil data
     keywords:
       - soil
+    domain: MixsCompliantData
     slot_uri: MIXS:soil_data
-    range: Soil
     multivalued: true
+    range: Soil
     inlined: true
     inlined_as_list: true
   migs_ba_soil_data:
     description: Data that comply with MigsBa combined with Soil
     title: MigsBaSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_soil_data
-    range: MigsBaSoil
     multivalued: true
+    range: MigsBaSoil
     inlined: true
     inlined_as_list: true
   symbiont_associated_data:
     description: Data that comply with Extension SymbiontAssociated
     title: SymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:symbiont_associated_data
-    range: SymbiontAssociated
     multivalued: true
+    range: SymbiontAssociated
     inlined: true
     inlined_as_list: true
   migs_ba_symbiont_associated_data:
     description: Data that comply with MigsBa combined with SymbiontAssociated
     title: MigsBaSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_symbiont_associated_data
-    range: MigsBaSymbiontAssociated
     multivalued: true
+    range: MigsBaSymbiontAssociated
     inlined: true
     inlined_as_list: true
   wastewater_sludge_data:
     description: Data that comply with Extension WastewaterSludge
     title: WastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:wastewater_sludge_data
-    range: WastewaterSludge
     multivalued: true
+    range: WastewaterSludge
     inlined: true
     inlined_as_list: true
   migs_ba_wastewater_sludge_data:
     description: Data that comply with MigsBa combined with WastewaterSludge
     title: MigsBaWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_wastewater_sludge_data
-    range: MigsBaWastewaterSludge
     multivalued: true
+    range: MigsBaWastewaterSludge
     inlined: true
     inlined_as_list: true
   water_data:
@@ -1650,1937 +1558,2179 @@ slots:
     title: Water data
     keywords:
       - water
+    domain: MixsCompliantData
     slot_uri: MIXS:water_data
-    range: Water
     multivalued: true
+    range: Water
     inlined: true
     inlined_as_list: true
   migs_ba_water_data:
     description: Data that comply with MigsBa combined with Water
     title: MigsBaWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_ba_water_data
-    range: MigsBaWater
     multivalued: true
+    range: MigsBaWater
     inlined: true
     inlined_as_list: true
   migs_eu_data:
     description: Data that comply with checklist MigsEu
     title: MigsEu data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_data
-    range: MigsEu
     multivalued: true
+    range: MigsEu
     inlined: true
     inlined_as_list: true
   migs_eu_agriculture_data:
     description: Data that comply with MigsEu combined with Agriculture
     title: MigsEuAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_agriculture_data
-    range: MigsEuAgriculture
     multivalued: true
+    range: MigsEuAgriculture
     inlined: true
     inlined_as_list: true
   migs_eu_air_data:
     description: Data that comply with MigsEu combined with Air
     title: MigsEuAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_air_data
-    range: MigsEuAir
     multivalued: true
+    range: MigsEuAir
     inlined: true
     inlined_as_list: true
   migs_eu_built_environment_data:
     description: Data that comply with MigsEu combined with BuiltEnvironment
     title: MigsEuBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_built_environment_data
-    range: MigsEuBuiltEnvironment
     multivalued: true
+    range: MigsEuBuiltEnvironment
     inlined: true
     inlined_as_list: true
   migs_eu_food_animal_and_animal_feed_data:
     description: Data that comply with MigsEu combined with FoodAnimalAndAnimalFeed
     title: MigsEuFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_animal_and_animal_feed_data
-    range: MigsEuFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MigsEuFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   migs_eu_food_farm_environment_data:
     description: Data that comply with MigsEu combined with FoodFarmEnvironment
     title: MigsEuFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_farm_environment_data
-    range: MigsEuFoodFarmEnvironment
     multivalued: true
+    range: MigsEuFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   migs_eu_food_food_production_facility_data:
     description: Data that comply with MigsEu combined with FoodFoodProductionFacility
     title: MigsEuFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_food_production_facility_data
-    range: MigsEuFoodFoodProductionFacility
     multivalued: true
+    range: MigsEuFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   migs_eu_food_human_foods_data:
     description: Data that comply with MigsEu combined with FoodHumanFoods
     title: MigsEuFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_food_human_foods_data
-    range: MigsEuFoodHumanFoods
     multivalued: true
+    range: MigsEuFoodHumanFoods
     inlined: true
     inlined_as_list: true
   migs_eu_host_associated_data:
     description: Data that comply with MigsEu combined with HostAssociated
     title: MigsEuHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_host_associated_data
-    range: MigsEuHostAssociated
     multivalued: true
+    range: MigsEuHostAssociated
     inlined: true
     inlined_as_list: true
   migs_eu_human_associated_data:
     description: Data that comply with MigsEu combined with HumanAssociated
     title: MigsEuHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_associated_data
-    range: MigsEuHumanAssociated
     multivalued: true
+    range: MigsEuHumanAssociated
     inlined: true
     inlined_as_list: true
   migs_eu_human_gut_data:
     description: Data that comply with MigsEu combined with HumanGut
     title: MigsEuHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_gut_data
-    range: MigsEuHumanGut
     multivalued: true
+    range: MigsEuHumanGut
     inlined: true
     inlined_as_list: true
   migs_eu_human_oral_data:
     description: Data that comply with MigsEu combined with HumanOral
     title: MigsEuHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_oral_data
-    range: MigsEuHumanOral
     multivalued: true
+    range: MigsEuHumanOral
     inlined: true
     inlined_as_list: true
   migs_eu_human_skin_data:
     description: Data that comply with MigsEu combined with HumanSkin
     title: MigsEuHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_skin_data
-    range: MigsEuHumanSkin
     multivalued: true
+    range: MigsEuHumanSkin
     inlined: true
     inlined_as_list: true
   migs_eu_human_vaginal_data:
     description: Data that comply with MigsEu combined with HumanVaginal
     title: MigsEuHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_human_vaginal_data
-    range: MigsEuHumanVaginal
     multivalued: true
+    range: MigsEuHumanVaginal
     inlined: true
     inlined_as_list: true
   migs_eu_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsEu combined with HydrocarbonResourcesCores
     title: MigsEuHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_hydrocarbon_resources_cores_data
-    range: MigsEuHydrocarbonResourcesCores
     multivalued: true
+    range: MigsEuHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   migs_eu_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsEu combined with HydrocarbonResourcesFluidsSwabs
     title: MigsEuHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_hydrocarbon_resources_fluids_swabs_data
-    range: MigsEuHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MigsEuHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   migs_eu_microbial_mat_biofilm_data:
     description: Data that comply with MigsEu combined with MicrobialMatBiofilm
     title: MigsEuMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_microbial_mat_biofilm_data
-    range: MigsEuMicrobialMatBiofilm
     multivalued: true
+    range: MigsEuMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   migs_eu_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsEu combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsEuMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_miscellaneous_natural_or_artificial_environment_data
-    range: MigsEuMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MigsEuMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   migs_eu_plant_associated_data:
     description: Data that comply with MigsEu combined with PlantAssociated
     title: MigsEuPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_plant_associated_data
-    range: MigsEuPlantAssociated
     multivalued: true
+    range: MigsEuPlantAssociated
     inlined: true
     inlined_as_list: true
   migs_eu_sediment_data:
     description: Data that comply with MigsEu combined with Sediment
     title: MigsEuSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_sediment_data
-    range: MigsEuSediment
     multivalued: true
+    range: MigsEuSediment
     inlined: true
     inlined_as_list: true
   migs_eu_soil_data:
     description: Data that comply with MigsEu combined with Soil
     title: MigsEuSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_soil_data
-    range: MigsEuSoil
     multivalued: true
+    range: MigsEuSoil
     inlined: true
     inlined_as_list: true
   migs_eu_symbiont_associated_data:
     description: Data that comply with MigsEu combined with SymbiontAssociated
     title: MigsEuSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_symbiont_associated_data
-    range: MigsEuSymbiontAssociated
     multivalued: true
+    range: MigsEuSymbiontAssociated
     inlined: true
     inlined_as_list: true
   migs_eu_wastewater_sludge_data:
     description: Data that comply with MigsEu combined with WastewaterSludge
     title: MigsEuWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_wastewater_sludge_data
-    range: MigsEuWastewaterSludge
     multivalued: true
+    range: MigsEuWastewaterSludge
     inlined: true
     inlined_as_list: true
   migs_eu_water_data:
     description: Data that comply with MigsEu combined with Water
     title: MigsEuWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_eu_water_data
-    range: MigsEuWater
     multivalued: true
+    range: MigsEuWater
     inlined: true
     inlined_as_list: true
   migs_org_data:
     description: Data that comply with checklist MigsOrg
     title: MigsOrg data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_data
-    range: MigsOrg
     multivalued: true
+    range: MigsOrg
     inlined: true
     inlined_as_list: true
   migs_org_agriculture_data:
     description: Data that comply with MigsOrg combined with Agriculture
     title: MigsOrgAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_agriculture_data
-    range: MigsOrgAgriculture
     multivalued: true
+    range: MigsOrgAgriculture
     inlined: true
     inlined_as_list: true
   migs_org_air_data:
     description: Data that comply with MigsOrg combined with Air
     title: MigsOrgAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_air_data
-    range: MigsOrgAir
     multivalued: true
+    range: MigsOrgAir
     inlined: true
     inlined_as_list: true
   migs_org_built_environment_data:
     description: Data that comply with MigsOrg combined with BuiltEnvironment
     title: MigsOrgBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_built_environment_data
-    range: MigsOrgBuiltEnvironment
     multivalued: true
+    range: MigsOrgBuiltEnvironment
     inlined: true
     inlined_as_list: true
   migs_org_food_animal_and_animal_feed_data:
     description: Data that comply with MigsOrg combined with FoodAnimalAndAnimalFeed
     title: MigsOrgFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_animal_and_animal_feed_data
-    range: MigsOrgFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MigsOrgFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   migs_org_food_farm_environment_data:
     description: Data that comply with MigsOrg combined with FoodFarmEnvironment
     title: MigsOrgFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_farm_environment_data
-    range: MigsOrgFoodFarmEnvironment
     multivalued: true
+    range: MigsOrgFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   migs_org_food_food_production_facility_data:
     description: Data that comply with MigsOrg combined with FoodFoodProductionFacility
     title: MigsOrgFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_food_production_facility_data
-    range: MigsOrgFoodFoodProductionFacility
     multivalued: true
+    range: MigsOrgFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   migs_org_food_human_foods_data:
     description: Data that comply with MigsOrg combined with FoodHumanFoods
     title: MigsOrgFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_food_human_foods_data
-    range: MigsOrgFoodHumanFoods
     multivalued: true
+    range: MigsOrgFoodHumanFoods
     inlined: true
     inlined_as_list: true
   migs_org_host_associated_data:
     description: Data that comply with MigsOrg combined with HostAssociated
     title: MigsOrgHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_host_associated_data
-    range: MigsOrgHostAssociated
     multivalued: true
+    range: MigsOrgHostAssociated
     inlined: true
     inlined_as_list: true
   migs_org_human_associated_data:
     description: Data that comply with MigsOrg combined with HumanAssociated
     title: MigsOrgHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_associated_data
-    range: MigsOrgHumanAssociated
     multivalued: true
+    range: MigsOrgHumanAssociated
     inlined: true
     inlined_as_list: true
   migs_org_human_gut_data:
     description: Data that comply with MigsOrg combined with HumanGut
     title: MigsOrgHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_gut_data
-    range: MigsOrgHumanGut
     multivalued: true
+    range: MigsOrgHumanGut
     inlined: true
     inlined_as_list: true
   migs_org_human_oral_data:
     description: Data that comply with MigsOrg combined with HumanOral
     title: MigsOrgHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_oral_data
-    range: MigsOrgHumanOral
     multivalued: true
+    range: MigsOrgHumanOral
     inlined: true
     inlined_as_list: true
   migs_org_human_skin_data:
     description: Data that comply with MigsOrg combined with HumanSkin
     title: MigsOrgHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_skin_data
-    range: MigsOrgHumanSkin
     multivalued: true
+    range: MigsOrgHumanSkin
     inlined: true
     inlined_as_list: true
   migs_org_human_vaginal_data:
     description: Data that comply with MigsOrg combined with HumanVaginal
     title: MigsOrgHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_human_vaginal_data
-    range: MigsOrgHumanVaginal
     multivalued: true
+    range: MigsOrgHumanVaginal
     inlined: true
     inlined_as_list: true
   migs_org_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsOrg combined with HydrocarbonResourcesCores
     title: MigsOrgHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_hydrocarbon_resources_cores_data
-    range: MigsOrgHydrocarbonResourcesCores
     multivalued: true
+    range: MigsOrgHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   migs_org_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsOrg combined with HydrocarbonResourcesFluidsSwabs
     title: MigsOrgHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_hydrocarbon_resources_fluids_swabs_data
-    range: MigsOrgHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MigsOrgHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   migs_org_microbial_mat_biofilm_data:
     description: Data that comply with MigsOrg combined with MicrobialMatBiofilm
     title: MigsOrgMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_microbial_mat_biofilm_data
-    range: MigsOrgMicrobialMatBiofilm
     multivalued: true
+    range: MigsOrgMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   migs_org_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsOrg combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsOrgMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_miscellaneous_natural_or_artificial_environment_data
-    range: MigsOrgMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MigsOrgMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   migs_org_plant_associated_data:
     description: Data that comply with MigsOrg combined with PlantAssociated
     title: MigsOrgPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_plant_associated_data
-    range: MigsOrgPlantAssociated
     multivalued: true
+    range: MigsOrgPlantAssociated
     inlined: true
     inlined_as_list: true
   migs_org_sediment_data:
     description: Data that comply with MigsOrg combined with Sediment
     title: MigsOrgSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_sediment_data
-    range: MigsOrgSediment
     multivalued: true
+    range: MigsOrgSediment
     inlined: true
     inlined_as_list: true
   migs_org_soil_data:
     description: Data that comply with MigsOrg combined with Soil
     title: MigsOrgSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_soil_data
-    range: MigsOrgSoil
     multivalued: true
+    range: MigsOrgSoil
     inlined: true
     inlined_as_list: true
   migs_org_symbiont_associated_data:
     description: Data that comply with MigsOrg combined with SymbiontAssociated
     title: MigsOrgSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_symbiont_associated_data
-    range: MigsOrgSymbiontAssociated
     multivalued: true
+    range: MigsOrgSymbiontAssociated
     inlined: true
     inlined_as_list: true
   migs_org_wastewater_sludge_data:
     description: Data that comply with MigsOrg combined with WastewaterSludge
     title: MigsOrgWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_wastewater_sludge_data
-    range: MigsOrgWastewaterSludge
     multivalued: true
+    range: MigsOrgWastewaterSludge
     inlined: true
     inlined_as_list: true
   migs_org_water_data:
     description: Data that comply with MigsOrg combined with Water
     title: MigsOrgWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_org_water_data
-    range: MigsOrgWater
     multivalued: true
+    range: MigsOrgWater
     inlined: true
     inlined_as_list: true
   migs_pl_data:
     description: Data that comply with checklist MigsPl
     title: MigsPl data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_data
-    range: MigsPl
     multivalued: true
+    range: MigsPl
     inlined: true
     inlined_as_list: true
   migs_pl_agriculture_data:
     description: Data that comply with MigsPl combined with Agriculture
     title: MigsPlAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_agriculture_data
-    range: MigsPlAgriculture
     multivalued: true
+    range: MigsPlAgriculture
     inlined: true
     inlined_as_list: true
   migs_pl_air_data:
     description: Data that comply with MigsPl combined with Air
     title: MigsPlAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_air_data
-    range: MigsPlAir
     multivalued: true
+    range: MigsPlAir
     inlined: true
     inlined_as_list: true
   migs_pl_built_environment_data:
     description: Data that comply with MigsPl combined with BuiltEnvironment
     title: MigsPlBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_built_environment_data
-    range: MigsPlBuiltEnvironment
     multivalued: true
+    range: MigsPlBuiltEnvironment
     inlined: true
     inlined_as_list: true
   migs_pl_food_animal_and_animal_feed_data:
     description: Data that comply with MigsPl combined with FoodAnimalAndAnimalFeed
     title: MigsPlFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_animal_and_animal_feed_data
-    range: MigsPlFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MigsPlFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   migs_pl_food_farm_environment_data:
     description: Data that comply with MigsPl combined with FoodFarmEnvironment
     title: MigsPlFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_farm_environment_data
-    range: MigsPlFoodFarmEnvironment
     multivalued: true
+    range: MigsPlFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   migs_pl_food_food_production_facility_data:
     description: Data that comply with MigsPl combined with FoodFoodProductionFacility
     title: MigsPlFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_food_production_facility_data
-    range: MigsPlFoodFoodProductionFacility
     multivalued: true
+    range: MigsPlFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   migs_pl_food_human_foods_data:
     description: Data that comply with MigsPl combined with FoodHumanFoods
     title: MigsPlFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_food_human_foods_data
-    range: MigsPlFoodHumanFoods
     multivalued: true
+    range: MigsPlFoodHumanFoods
     inlined: true
     inlined_as_list: true
   migs_pl_host_associated_data:
     description: Data that comply with MigsPl combined with HostAssociated
     title: MigsPlHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_host_associated_data
-    range: MigsPlHostAssociated
     multivalued: true
+    range: MigsPlHostAssociated
     inlined: true
     inlined_as_list: true
   migs_pl_human_associated_data:
     description: Data that comply with MigsPl combined with HumanAssociated
     title: MigsPlHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_associated_data
-    range: MigsPlHumanAssociated
     multivalued: true
+    range: MigsPlHumanAssociated
     inlined: true
     inlined_as_list: true
   migs_pl_human_gut_data:
     description: Data that comply with MigsPl combined with HumanGut
     title: MigsPlHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_gut_data
-    range: MigsPlHumanGut
     multivalued: true
+    range: MigsPlHumanGut
     inlined: true
     inlined_as_list: true
   migs_pl_human_oral_data:
     description: Data that comply with MigsPl combined with HumanOral
     title: MigsPlHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_oral_data
-    range: MigsPlHumanOral
     multivalued: true
+    range: MigsPlHumanOral
     inlined: true
     inlined_as_list: true
   migs_pl_human_skin_data:
     description: Data that comply with MigsPl combined with HumanSkin
     title: MigsPlHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_skin_data
-    range: MigsPlHumanSkin
     multivalued: true
+    range: MigsPlHumanSkin
     inlined: true
     inlined_as_list: true
   migs_pl_human_vaginal_data:
     description: Data that comply with MigsPl combined with HumanVaginal
     title: MigsPlHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_human_vaginal_data
-    range: MigsPlHumanVaginal
     multivalued: true
+    range: MigsPlHumanVaginal
     inlined: true
     inlined_as_list: true
   migs_pl_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsPl combined with HydrocarbonResourcesCores
     title: MigsPlHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_hydrocarbon_resources_cores_data
-    range: MigsPlHydrocarbonResourcesCores
     multivalued: true
+    range: MigsPlHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   migs_pl_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsPl combined with HydrocarbonResourcesFluidsSwabs
     title: MigsPlHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_hydrocarbon_resources_fluids_swabs_data
-    range: MigsPlHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MigsPlHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   migs_pl_microbial_mat_biofilm_data:
     description: Data that comply with MigsPl combined with MicrobialMatBiofilm
     title: MigsPlMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_microbial_mat_biofilm_data
-    range: MigsPlMicrobialMatBiofilm
     multivalued: true
+    range: MigsPlMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   migs_pl_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsPl combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsPlMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_miscellaneous_natural_or_artificial_environment_data
-    range: MigsPlMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MigsPlMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   migs_pl_plant_associated_data:
     description: Data that comply with MigsPl combined with PlantAssociated
     title: MigsPlPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_plant_associated_data
-    range: MigsPlPlantAssociated
     multivalued: true
+    range: MigsPlPlantAssociated
     inlined: true
     inlined_as_list: true
   migs_pl_sediment_data:
     description: Data that comply with MigsPl combined with Sediment
     title: MigsPlSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_sediment_data
-    range: MigsPlSediment
     multivalued: true
+    range: MigsPlSediment
     inlined: true
     inlined_as_list: true
   migs_pl_soil_data:
     description: Data that comply with MigsPl combined with Soil
     title: MigsPlSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_soil_data
-    range: MigsPlSoil
     multivalued: true
+    range: MigsPlSoil
     inlined: true
     inlined_as_list: true
   migs_pl_symbiont_associated_data:
     description: Data that comply with MigsPl combined with SymbiontAssociated
     title: MigsPlSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_symbiont_associated_data
-    range: MigsPlSymbiontAssociated
     multivalued: true
+    range: MigsPlSymbiontAssociated
     inlined: true
     inlined_as_list: true
   migs_pl_wastewater_sludge_data:
     description: Data that comply with MigsPl combined with WastewaterSludge
     title: MigsPlWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_wastewater_sludge_data
-    range: MigsPlWastewaterSludge
     multivalued: true
+    range: MigsPlWastewaterSludge
     inlined: true
     inlined_as_list: true
   migs_pl_water_data:
     description: Data that comply with MigsPl combined with Water
     title: MigsPlWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_pl_water_data
-    range: MigsPlWater
     multivalued: true
+    range: MigsPlWater
     inlined: true
     inlined_as_list: true
   migs_vi_data:
     description: Data that comply with checklist MigsVi
     title: MigsVi data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_data
-    range: MigsVi
     multivalued: true
+    range: MigsVi
     inlined: true
     inlined_as_list: true
   migs_vi_agriculture_data:
     description: Data that comply with MigsVi combined with Agriculture
     title: MigsViAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_agriculture_data
-    range: MigsViAgriculture
     multivalued: true
+    range: MigsViAgriculture
     inlined: true
     inlined_as_list: true
   migs_vi_air_data:
     description: Data that comply with MigsVi combined with Air
     title: MigsViAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_air_data
-    range: MigsViAir
     multivalued: true
+    range: MigsViAir
     inlined: true
     inlined_as_list: true
   migs_vi_built_environment_data:
     description: Data that comply with MigsVi combined with BuiltEnvironment
     title: MigsViBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_built_environment_data
-    range: MigsViBuiltEnvironment
     multivalued: true
+    range: MigsViBuiltEnvironment
     inlined: true
     inlined_as_list: true
   migs_vi_food_animal_and_animal_feed_data:
     description: Data that comply with MigsVi combined with FoodAnimalAndAnimalFeed
     title: MigsViFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_animal_and_animal_feed_data
-    range: MigsViFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MigsViFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   migs_vi_food_farm_environment_data:
     description: Data that comply with MigsVi combined with FoodFarmEnvironment
     title: MigsViFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_farm_environment_data
-    range: MigsViFoodFarmEnvironment
     multivalued: true
+    range: MigsViFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   migs_vi_food_food_production_facility_data:
     description: Data that comply with MigsVi combined with FoodFoodProductionFacility
     title: MigsViFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_food_production_facility_data
-    range: MigsViFoodFoodProductionFacility
     multivalued: true
+    range: MigsViFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   migs_vi_food_human_foods_data:
     description: Data that comply with MigsVi combined with FoodHumanFoods
     title: MigsViFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_food_human_foods_data
-    range: MigsViFoodHumanFoods
     multivalued: true
+    range: MigsViFoodHumanFoods
     inlined: true
     inlined_as_list: true
   migs_vi_host_associated_data:
     description: Data that comply with MigsVi combined with HostAssociated
     title: MigsViHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_host_associated_data
-    range: MigsViHostAssociated
     multivalued: true
+    range: MigsViHostAssociated
     inlined: true
     inlined_as_list: true
   migs_vi_human_associated_data:
     description: Data that comply with MigsVi combined with HumanAssociated
     title: MigsViHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_associated_data
-    range: MigsViHumanAssociated
     multivalued: true
+    range: MigsViHumanAssociated
     inlined: true
     inlined_as_list: true
   migs_vi_human_gut_data:
     description: Data that comply with MigsVi combined with HumanGut
     title: MigsViHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_gut_data
-    range: MigsViHumanGut
     multivalued: true
+    range: MigsViHumanGut
     inlined: true
     inlined_as_list: true
   migs_vi_human_oral_data:
     description: Data that comply with MigsVi combined with HumanOral
     title: MigsViHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_oral_data
-    range: MigsViHumanOral
     multivalued: true
+    range: MigsViHumanOral
     inlined: true
     inlined_as_list: true
   migs_vi_human_skin_data:
     description: Data that comply with MigsVi combined with HumanSkin
     title: MigsViHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_skin_data
-    range: MigsViHumanSkin
     multivalued: true
+    range: MigsViHumanSkin
     inlined: true
     inlined_as_list: true
   migs_vi_human_vaginal_data:
     description: Data that comply with MigsVi combined with HumanVaginal
     title: MigsViHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_human_vaginal_data
-    range: MigsViHumanVaginal
     multivalued: true
+    range: MigsViHumanVaginal
     inlined: true
     inlined_as_list: true
   migs_vi_hydrocarbon_resources_cores_data:
     description: Data that comply with MigsVi combined with HydrocarbonResourcesCores
     title: MigsViHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_hydrocarbon_resources_cores_data
-    range: MigsViHydrocarbonResourcesCores
     multivalued: true
+    range: MigsViHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   migs_vi_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MigsVi combined with HydrocarbonResourcesFluidsSwabs
     title: MigsViHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_hydrocarbon_resources_fluids_swabs_data
-    range: MigsViHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MigsViHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   migs_vi_microbial_mat_biofilm_data:
     description: Data that comply with MigsVi combined with MicrobialMatBiofilm
     title: MigsViMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_microbial_mat_biofilm_data
-    range: MigsViMicrobialMatBiofilm
     multivalued: true
+    range: MigsViMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   migs_vi_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MigsVi combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MigsViMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_miscellaneous_natural_or_artificial_environment_data
-    range: MigsViMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MigsViMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   migs_vi_plant_associated_data:
     description: Data that comply with MigsVi combined with PlantAssociated
     title: MigsViPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_plant_associated_data
-    range: MigsViPlantAssociated
     multivalued: true
+    range: MigsViPlantAssociated
     inlined: true
     inlined_as_list: true
   migs_vi_sediment_data:
     description: Data that comply with MigsVi combined with Sediment
     title: MigsViSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_sediment_data
-    range: MigsViSediment
     multivalued: true
+    range: MigsViSediment
     inlined: true
     inlined_as_list: true
   migs_vi_soil_data:
     description: Data that comply with MigsVi combined with Soil
     title: MigsViSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_soil_data
-    range: MigsViSoil
     multivalued: true
+    range: MigsViSoil
     inlined: true
     inlined_as_list: true
   migs_vi_symbiont_associated_data:
     description: Data that comply with MigsVi combined with SymbiontAssociated
     title: MigsViSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_symbiont_associated_data
-    range: MigsViSymbiontAssociated
     multivalued: true
+    range: MigsViSymbiontAssociated
     inlined: true
     inlined_as_list: true
   migs_vi_wastewater_sludge_data:
     description: Data that comply with MigsVi combined with WastewaterSludge
     title: MigsViWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_wastewater_sludge_data
-    range: MigsViWastewaterSludge
     multivalued: true
+    range: MigsViWastewaterSludge
     inlined: true
     inlined_as_list: true
   migs_vi_water_data:
     description: Data that comply with MigsVi combined with Water
     title: MigsViWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:migs_vi_water_data
-    range: MigsViWater
     multivalued: true
+    range: MigsViWater
     inlined: true
     inlined_as_list: true
   mimag_data:
     description: Data that comply with checklist Mimag
     title: Mimag data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_data
-    range: Mimag
     multivalued: true
+    range: Mimag
     inlined: true
     inlined_as_list: true
   mimag_agriculture_data:
     description: Data that comply with Mimag combined with Agriculture
     title: MimagAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_agriculture_data
-    range: MimagAgriculture
     multivalued: true
+    range: MimagAgriculture
     inlined: true
     inlined_as_list: true
   mimag_air_data:
     description: Data that comply with Mimag combined with Air
     title: MimagAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_air_data
-    range: MimagAir
     multivalued: true
+    range: MimagAir
     inlined: true
     inlined_as_list: true
   mimag_built_environment_data:
     description: Data that comply with Mimag combined with BuiltEnvironment
     title: MimagBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_built_environment_data
-    range: MimagBuiltEnvironment
     multivalued: true
+    range: MimagBuiltEnvironment
     inlined: true
     inlined_as_list: true
   mimag_food_animal_and_animal_feed_data:
     description: Data that comply with Mimag combined with FoodAnimalAndAnimalFeed
     title: MimagFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_animal_and_animal_feed_data
-    range: MimagFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MimagFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   mimag_food_farm_environment_data:
     description: Data that comply with Mimag combined with FoodFarmEnvironment
     title: MimagFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_farm_environment_data
-    range: MimagFoodFarmEnvironment
     multivalued: true
+    range: MimagFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   mimag_food_food_production_facility_data:
     description: Data that comply with Mimag combined with FoodFoodProductionFacility
     title: MimagFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_food_production_facility_data
-    range: MimagFoodFoodProductionFacility
     multivalued: true
+    range: MimagFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   mimag_food_human_foods_data:
     description: Data that comply with Mimag combined with FoodHumanFoods
     title: MimagFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_food_human_foods_data
-    range: MimagFoodHumanFoods
     multivalued: true
+    range: MimagFoodHumanFoods
     inlined: true
     inlined_as_list: true
   mimag_host_associated_data:
     description: Data that comply with Mimag combined with HostAssociated
     title: MimagHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_host_associated_data
-    range: MimagHostAssociated
     multivalued: true
+    range: MimagHostAssociated
     inlined: true
     inlined_as_list: true
   mimag_human_associated_data:
     description: Data that comply with Mimag combined with HumanAssociated
     title: MimagHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_associated_data
-    range: MimagHumanAssociated
     multivalued: true
+    range: MimagHumanAssociated
     inlined: true
     inlined_as_list: true
   mimag_human_gut_data:
     description: Data that comply with Mimag combined with HumanGut
     title: MimagHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_gut_data
-    range: MimagHumanGut
     multivalued: true
+    range: MimagHumanGut
     inlined: true
     inlined_as_list: true
   mimag_human_oral_data:
     description: Data that comply with Mimag combined with HumanOral
     title: MimagHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_oral_data
-    range: MimagHumanOral
     multivalued: true
+    range: MimagHumanOral
     inlined: true
     inlined_as_list: true
   mimag_human_skin_data:
     description: Data that comply with Mimag combined with HumanSkin
     title: MimagHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_skin_data
-    range: MimagHumanSkin
     multivalued: true
+    range: MimagHumanSkin
     inlined: true
     inlined_as_list: true
   mimag_human_vaginal_data:
     description: Data that comply with Mimag combined with HumanVaginal
     title: MimagHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_human_vaginal_data
-    range: MimagHumanVaginal
     multivalued: true
+    range: MimagHumanVaginal
     inlined: true
     inlined_as_list: true
   mimag_hydrocarbon_resources_cores_data:
     description: Data that comply with Mimag combined with HydrocarbonResourcesCores
     title: MimagHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_hydrocarbon_resources_cores_data
-    range: MimagHydrocarbonResourcesCores
     multivalued: true
+    range: MimagHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   mimag_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Mimag combined with HydrocarbonResourcesFluidsSwabs
     title: MimagHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_hydrocarbon_resources_fluids_swabs_data
-    range: MimagHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MimagHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   mimag_microbial_mat_biofilm_data:
     description: Data that comply with Mimag combined with MicrobialMatBiofilm
     title: MimagMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_microbial_mat_biofilm_data
-    range: MimagMicrobialMatBiofilm
     multivalued: true
+    range: MimagMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   mimag_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Mimag combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimagMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_miscellaneous_natural_or_artificial_environment_data
-    range: MimagMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MimagMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   mimag_plant_associated_data:
     description: Data that comply with Mimag combined with PlantAssociated
     title: MimagPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_plant_associated_data
-    range: MimagPlantAssociated
     multivalued: true
+    range: MimagPlantAssociated
     inlined: true
     inlined_as_list: true
   mimag_sediment_data:
     description: Data that comply with Mimag combined with Sediment
     title: MimagSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_sediment_data
-    range: MimagSediment
     multivalued: true
+    range: MimagSediment
     inlined: true
     inlined_as_list: true
   mimag_soil_data:
     description: Data that comply with Mimag combined with Soil
     title: MimagSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_soil_data
-    range: MimagSoil
     multivalued: true
+    range: MimagSoil
     inlined: true
     inlined_as_list: true
   mimag_symbiont_associated_data:
     description: Data that comply with Mimag combined with SymbiontAssociated
     title: MimagSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_symbiont_associated_data
-    range: MimagSymbiontAssociated
     multivalued: true
+    range: MimagSymbiontAssociated
     inlined: true
     inlined_as_list: true
   mimag_wastewater_sludge_data:
     description: Data that comply with Mimag combined with WastewaterSludge
     title: MimagWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_wastewater_sludge_data
-    range: MimagWastewaterSludge
     multivalued: true
+    range: MimagWastewaterSludge
     inlined: true
     inlined_as_list: true
   mimag_water_data:
     description: Data that comply with Mimag combined with Water
     title: MimagWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimag_water_data
-    range: MimagWater
     multivalued: true
+    range: MimagWater
     inlined: true
     inlined_as_list: true
   mimarks_c_data:
     description: Data that comply with checklist MimarksC
     title: MimarksC data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_data
-    range: MimarksC
     multivalued: true
+    range: MimarksC
     inlined: true
     inlined_as_list: true
   mimarks_c_agriculture_data:
     description: Data that comply with MimarksC combined with Agriculture
     title: MimarksCAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_agriculture_data
-    range: MimarksCAgriculture
     multivalued: true
+    range: MimarksCAgriculture
     inlined: true
     inlined_as_list: true
   mimarks_c_air_data:
     description: Data that comply with MimarksC combined with Air
     title: MimarksCAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_air_data
-    range: MimarksCAir
     multivalued: true
+    range: MimarksCAir
     inlined: true
     inlined_as_list: true
   mimarks_c_built_environment_data:
     description: Data that comply with MimarksC combined with BuiltEnvironment
     title: MimarksCBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_built_environment_data
-    range: MimarksCBuiltEnvironment
     multivalued: true
+    range: MimarksCBuiltEnvironment
     inlined: true
     inlined_as_list: true
   mimarks_c_food_animal_and_animal_feed_data:
     description: Data that comply with MimarksC combined with FoodAnimalAndAnimalFeed
     title: MimarksCFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_animal_and_animal_feed_data
-    range: MimarksCFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MimarksCFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   mimarks_c_food_farm_environment_data:
     description: Data that comply with MimarksC combined with FoodFarmEnvironment
     title: MimarksCFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_farm_environment_data
-    range: MimarksCFoodFarmEnvironment
     multivalued: true
+    range: MimarksCFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   mimarks_c_food_food_production_facility_data:
     description: Data that comply with MimarksC combined with FoodFoodProductionFacility
     title: MimarksCFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_food_production_facility_data
-    range: MimarksCFoodFoodProductionFacility
     multivalued: true
+    range: MimarksCFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   mimarks_c_food_human_foods_data:
     description: Data that comply with MimarksC combined with FoodHumanFoods
     title: MimarksCFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_food_human_foods_data
-    range: MimarksCFoodHumanFoods
     multivalued: true
+    range: MimarksCFoodHumanFoods
     inlined: true
     inlined_as_list: true
   mimarks_c_host_associated_data:
     description: Data that comply with MimarksC combined with HostAssociated
     title: MimarksCHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_host_associated_data
-    range: MimarksCHostAssociated
     multivalued: true
+    range: MimarksCHostAssociated
     inlined: true
     inlined_as_list: true
   mimarks_c_human_associated_data:
     description: Data that comply with MimarksC combined with HumanAssociated
     title: MimarksCHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_associated_data
-    range: MimarksCHumanAssociated
     multivalued: true
+    range: MimarksCHumanAssociated
     inlined: true
     inlined_as_list: true
   mimarks_c_human_gut_data:
     description: Data that comply with MimarksC combined with HumanGut
     title: MimarksCHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_gut_data
-    range: MimarksCHumanGut
     multivalued: true
+    range: MimarksCHumanGut
     inlined: true
     inlined_as_list: true
   mimarks_c_human_oral_data:
     description: Data that comply with MimarksC combined with HumanOral
     title: MimarksCHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_oral_data
-    range: MimarksCHumanOral
     multivalued: true
+    range: MimarksCHumanOral
     inlined: true
     inlined_as_list: true
   mimarks_c_human_skin_data:
     description: Data that comply with MimarksC combined with HumanSkin
     title: MimarksCHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_skin_data
-    range: MimarksCHumanSkin
     multivalued: true
+    range: MimarksCHumanSkin
     inlined: true
     inlined_as_list: true
   mimarks_c_human_vaginal_data:
     description: Data that comply with MimarksC combined with HumanVaginal
     title: MimarksCHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_human_vaginal_data
-    range: MimarksCHumanVaginal
     multivalued: true
+    range: MimarksCHumanVaginal
     inlined: true
     inlined_as_list: true
   mimarks_c_hydrocarbon_resources_cores_data:
     description: Data that comply with MimarksC combined with HydrocarbonResourcesCores
     title: MimarksCHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_hydrocarbon_resources_cores_data
-    range: MimarksCHydrocarbonResourcesCores
     multivalued: true
+    range: MimarksCHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   mimarks_c_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MimarksC combined with HydrocarbonResourcesFluidsSwabs
     title: MimarksCHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_hydrocarbon_resources_fluids_swabs_data
-    range: MimarksCHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MimarksCHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   mimarks_c_microbial_mat_biofilm_data:
     description: Data that comply with MimarksC combined with MicrobialMatBiofilm
     title: MimarksCMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_microbial_mat_biofilm_data
-    range: MimarksCMicrobialMatBiofilm
     multivalued: true
+    range: MimarksCMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   mimarks_c_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MimarksC combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimarksCMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_miscellaneous_natural_or_artificial_environment_data
-    range: MimarksCMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MimarksCMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   mimarks_c_plant_associated_data:
     description: Data that comply with MimarksC combined with PlantAssociated
     title: MimarksCPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_plant_associated_data
-    range: MimarksCPlantAssociated
     multivalued: true
+    range: MimarksCPlantAssociated
     inlined: true
     inlined_as_list: true
   mimarks_c_sediment_data:
     description: Data that comply with MimarksC combined with Sediment
     title: MimarksCSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_sediment_data
-    range: MimarksCSediment
     multivalued: true
+    range: MimarksCSediment
     inlined: true
     inlined_as_list: true
   mimarks_c_soil_data:
     description: Data that comply with MimarksC combined with Soil
     title: MimarksCSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_soil_data
-    range: MimarksCSoil
     multivalued: true
+    range: MimarksCSoil
     inlined: true
     inlined_as_list: true
   mimarks_c_symbiont_associated_data:
     description: Data that comply with MimarksC combined with SymbiontAssociated
     title: MimarksCSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_symbiont_associated_data
-    range: MimarksCSymbiontAssociated
     multivalued: true
+    range: MimarksCSymbiontAssociated
     inlined: true
     inlined_as_list: true
   mimarks_c_wastewater_sludge_data:
     description: Data that comply with MimarksC combined with WastewaterSludge
     title: MimarksCWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_wastewater_sludge_data
-    range: MimarksCWastewaterSludge
     multivalued: true
+    range: MimarksCWastewaterSludge
     inlined: true
     inlined_as_list: true
   mimarks_c_water_data:
     description: Data that comply with MimarksC combined with Water
     title: MimarksCWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_c_water_data
-    range: MimarksCWater
     multivalued: true
+    range: MimarksCWater
     inlined: true
     inlined_as_list: true
   mimarks_s_data:
     description: Data that comply with checklist MimarksS
     title: MimarksS data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_data
-    range: MimarksS
     multivalued: true
+    range: MimarksS
     inlined: true
     inlined_as_list: true
   mimarks_s_agriculture_data:
     description: Data that comply with MimarksS combined with Agriculture
     title: MimarksSAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_agriculture_data
-    range: MimarksSAgriculture
     multivalued: true
+    range: MimarksSAgriculture
     inlined: true
     inlined_as_list: true
   mimarks_s_air_data:
     description: Data that comply with MimarksS combined with Air
     title: MimarksSAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_air_data
-    range: MimarksSAir
     multivalued: true
+    range: MimarksSAir
     inlined: true
     inlined_as_list: true
   mimarks_s_built_environment_data:
     description: Data that comply with MimarksS combined with BuiltEnvironment
     title: MimarksSBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_built_environment_data
-    range: MimarksSBuiltEnvironment
     multivalued: true
+    range: MimarksSBuiltEnvironment
     inlined: true
     inlined_as_list: true
   mimarks_s_food_animal_and_animal_feed_data:
     description: Data that comply with MimarksS combined with FoodAnimalAndAnimalFeed
     title: MimarksSFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_animal_and_animal_feed_data
-    range: MimarksSFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MimarksSFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   mimarks_s_food_farm_environment_data:
     description: Data that comply with MimarksS combined with FoodFarmEnvironment
     title: MimarksSFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_farm_environment_data
-    range: MimarksSFoodFarmEnvironment
     multivalued: true
+    range: MimarksSFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   mimarks_s_food_food_production_facility_data:
     description: Data that comply with MimarksS combined with FoodFoodProductionFacility
     title: MimarksSFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_food_production_facility_data
-    range: MimarksSFoodFoodProductionFacility
     multivalued: true
+    range: MimarksSFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   mimarks_s_food_human_foods_data:
     description: Data that comply with MimarksS combined with FoodHumanFoods
     title: MimarksSFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_food_human_foods_data
-    range: MimarksSFoodHumanFoods
     multivalued: true
+    range: MimarksSFoodHumanFoods
     inlined: true
     inlined_as_list: true
   mimarks_s_host_associated_data:
     description: Data that comply with MimarksS combined with HostAssociated
     title: MimarksSHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_host_associated_data
-    range: MimarksSHostAssociated
     multivalued: true
+    range: MimarksSHostAssociated
     inlined: true
     inlined_as_list: true
   mimarks_s_human_associated_data:
     description: Data that comply with MimarksS combined with HumanAssociated
     title: MimarksSHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_associated_data
-    range: MimarksSHumanAssociated
     multivalued: true
+    range: MimarksSHumanAssociated
     inlined: true
     inlined_as_list: true
   mimarks_s_human_gut_data:
     description: Data that comply with MimarksS combined with HumanGut
     title: MimarksSHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_gut_data
-    range: MimarksSHumanGut
     multivalued: true
+    range: MimarksSHumanGut
     inlined: true
     inlined_as_list: true
   mimarks_s_human_oral_data:
     description: Data that comply with MimarksS combined with HumanOral
     title: MimarksSHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_oral_data
-    range: MimarksSHumanOral
     multivalued: true
+    range: MimarksSHumanOral
     inlined: true
     inlined_as_list: true
   mimarks_s_human_skin_data:
     description: Data that comply with MimarksS combined with HumanSkin
     title: MimarksSHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_skin_data
-    range: MimarksSHumanSkin
     multivalued: true
+    range: MimarksSHumanSkin
     inlined: true
     inlined_as_list: true
   mimarks_s_human_vaginal_data:
     description: Data that comply with MimarksS combined with HumanVaginal
     title: MimarksSHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_human_vaginal_data
-    range: MimarksSHumanVaginal
     multivalued: true
+    range: MimarksSHumanVaginal
     inlined: true
     inlined_as_list: true
   mimarks_s_hydrocarbon_resources_cores_data:
     description: Data that comply with MimarksS combined with HydrocarbonResourcesCores
     title: MimarksSHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_hydrocarbon_resources_cores_data
-    range: MimarksSHydrocarbonResourcesCores
     multivalued: true
+    range: MimarksSHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   mimarks_s_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with MimarksS combined with HydrocarbonResourcesFluidsSwabs
     title: MimarksSHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_hydrocarbon_resources_fluids_swabs_data
-    range: MimarksSHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MimarksSHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   mimarks_s_microbial_mat_biofilm_data:
     description: Data that comply with MimarksS combined with MicrobialMatBiofilm
     title: MimarksSMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_microbial_mat_biofilm_data
-    range: MimarksSMicrobialMatBiofilm
     multivalued: true
+    range: MimarksSMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   mimarks_s_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with MimarksS combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimarksSMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_miscellaneous_natural_or_artificial_environment_data
-    range: MimarksSMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MimarksSMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   mimarks_s_plant_associated_data:
     description: Data that comply with MimarksS combined with PlantAssociated
     title: MimarksSPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_plant_associated_data
-    range: MimarksSPlantAssociated
     multivalued: true
+    range: MimarksSPlantAssociated
     inlined: true
     inlined_as_list: true
   mimarks_s_sediment_data:
     description: Data that comply with MimarksS combined with Sediment
     title: MimarksSSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_sediment_data
-    range: MimarksSSediment
     multivalued: true
+    range: MimarksSSediment
     inlined: true
     inlined_as_list: true
   mimarks_s_soil_data:
     description: Data that comply with MimarksS combined with Soil
     title: MimarksSSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_soil_data
-    range: MimarksSSoil
     multivalued: true
+    range: MimarksSSoil
     inlined: true
     inlined_as_list: true
   mimarks_s_symbiont_associated_data:
     description: Data that comply with MimarksS combined with SymbiontAssociated
     title: MimarksSSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_symbiont_associated_data
-    range: MimarksSSymbiontAssociated
     multivalued: true
+    range: MimarksSSymbiontAssociated
     inlined: true
     inlined_as_list: true
   mimarks_s_wastewater_sludge_data:
     description: Data that comply with MimarksS combined with WastewaterSludge
     title: MimarksSWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_wastewater_sludge_data
-    range: MimarksSWastewaterSludge
     multivalued: true
+    range: MimarksSWastewaterSludge
     inlined: true
     inlined_as_list: true
   mimarks_s_water_data:
     description: Data that comply with MimarksS combined with Water
     title: MimarksSWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:mimarks_s_water_data
-    range: MimarksSWater
     multivalued: true
+    range: MimarksSWater
     inlined: true
     inlined_as_list: true
   mims_data:
     description: Data that comply with checklist Mims
     title: Mims data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_data
-    range: Mims
     multivalued: true
+    range: Mims
     inlined: true
     inlined_as_list: true
   mims_agriculture_data:
     description: Data that comply with Mims combined with Agriculture
     title: MimsAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_agriculture_data
-    range: MimsAgriculture
     multivalued: true
+    range: MimsAgriculture
     inlined: true
     inlined_as_list: true
   mims_air_data:
     description: Data that comply with Mims combined with Air
     title: MimsAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_air_data
-    range: MimsAir
     multivalued: true
+    range: MimsAir
     inlined: true
     inlined_as_list: true
   mims_built_environment_data:
     description: Data that comply with Mims combined with BuiltEnvironment
     title: MimsBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_built_environment_data
-    range: MimsBuiltEnvironment
     multivalued: true
+    range: MimsBuiltEnvironment
     inlined: true
     inlined_as_list: true
   mims_food_animal_and_animal_feed_data:
     description: Data that comply with Mims combined with FoodAnimalAndAnimalFeed
     title: MimsFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_animal_and_animal_feed_data
-    range: MimsFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MimsFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   mims_food_farm_environment_data:
     description: Data that comply with Mims combined with FoodFarmEnvironment
     title: MimsFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_farm_environment_data
-    range: MimsFoodFarmEnvironment
     multivalued: true
+    range: MimsFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   mims_food_food_production_facility_data:
     description: Data that comply with Mims combined with FoodFoodProductionFacility
     title: MimsFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_food_production_facility_data
-    range: MimsFoodFoodProductionFacility
     multivalued: true
+    range: MimsFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   mims_food_human_foods_data:
     description: Data that comply with Mims combined with FoodHumanFoods
     title: MimsFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_food_human_foods_data
-    range: MimsFoodHumanFoods
     multivalued: true
+    range: MimsFoodHumanFoods
     inlined: true
     inlined_as_list: true
   mims_host_associated_data:
     description: Data that comply with Mims combined with HostAssociated
     title: MimsHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_host_associated_data
-    range: MimsHostAssociated
     multivalued: true
+    range: MimsHostAssociated
     inlined: true
     inlined_as_list: true
   mims_human_associated_data:
     description: Data that comply with Mims combined with HumanAssociated
     title: MimsHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_associated_data
-    range: MimsHumanAssociated
     multivalued: true
+    range: MimsHumanAssociated
     inlined: true
     inlined_as_list: true
   mims_human_gut_data:
     description: Data that comply with Mims combined with HumanGut
     title: MimsHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_gut_data
-    range: MimsHumanGut
     multivalued: true
+    range: MimsHumanGut
     inlined: true
     inlined_as_list: true
   mims_human_oral_data:
     description: Data that comply with Mims combined with HumanOral
     title: MimsHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_oral_data
-    range: MimsHumanOral
     multivalued: true
+    range: MimsHumanOral
     inlined: true
     inlined_as_list: true
   mims_human_skin_data:
     description: Data that comply with Mims combined with HumanSkin
     title: MimsHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_skin_data
-    range: MimsHumanSkin
     multivalued: true
+    range: MimsHumanSkin
     inlined: true
     inlined_as_list: true
   mims_human_vaginal_data:
     description: Data that comply with Mims combined with HumanVaginal
     title: MimsHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_human_vaginal_data
-    range: MimsHumanVaginal
     multivalued: true
+    range: MimsHumanVaginal
     inlined: true
     inlined_as_list: true
   mims_hydrocarbon_resources_cores_data:
     description: Data that comply with Mims combined with HydrocarbonResourcesCores
     title: MimsHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_hydrocarbon_resources_cores_data
-    range: MimsHydrocarbonResourcesCores
     multivalued: true
+    range: MimsHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   mims_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Mims combined with HydrocarbonResourcesFluidsSwabs
     title: MimsHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_hydrocarbon_resources_fluids_swabs_data
-    range: MimsHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MimsHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   mims_microbial_mat_biofilm_data:
     description: Data that comply with Mims combined with MicrobialMatBiofilm
     title: MimsMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_microbial_mat_biofilm_data
-    range: MimsMicrobialMatBiofilm
     multivalued: true
+    range: MimsMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   mims_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Mims combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MimsMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_miscellaneous_natural_or_artificial_environment_data
-    range: MimsMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MimsMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   mims_plant_associated_data:
     description: Data that comply with Mims combined with PlantAssociated
     title: MimsPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_plant_associated_data
-    range: MimsPlantAssociated
     multivalued: true
+    range: MimsPlantAssociated
     inlined: true
     inlined_as_list: true
   mims_sediment_data:
     description: Data that comply with Mims combined with Sediment
     title: MimsSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_sediment_data
-    range: MimsSediment
     multivalued: true
+    range: MimsSediment
     inlined: true
     inlined_as_list: true
   mims_soil_data:
     description: Data that comply with Mims combined with Soil
     title: MimsSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_soil_data
-    range: MimsSoil
     multivalued: true
+    range: MimsSoil
     inlined: true
     inlined_as_list: true
   mims_symbiont_associated_data:
     description: Data that comply with Mims combined with SymbiontAssociated
     title: MimsSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_symbiont_associated_data
-    range: MimsSymbiontAssociated
     multivalued: true
+    range: MimsSymbiontAssociated
     inlined: true
     inlined_as_list: true
   mims_wastewater_sludge_data:
     description: Data that comply with Mims combined with WastewaterSludge
     title: MimsWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_wastewater_sludge_data
-    range: MimsWastewaterSludge
     multivalued: true
+    range: MimsWastewaterSludge
     inlined: true
     inlined_as_list: true
   mims_water_data:
     description: Data that comply with Mims combined with Water
     title: MimsWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:mims_water_data
-    range: MimsWater
     multivalued: true
+    range: MimsWater
     inlined: true
     inlined_as_list: true
   misag_data:
     description: Data that comply with checklist Misag
     title: Misag data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_data
-    range: Misag
     multivalued: true
+    range: Misag
     inlined: true
     inlined_as_list: true
   misag_agriculture_data:
     description: Data that comply with Misag combined with Agriculture
     title: MisagAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_agriculture_data
-    range: MisagAgriculture
     multivalued: true
+    range: MisagAgriculture
     inlined: true
     inlined_as_list: true
   misag_air_data:
     description: Data that comply with Misag combined with Air
     title: MisagAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_air_data
-    range: MisagAir
     multivalued: true
+    range: MisagAir
     inlined: true
     inlined_as_list: true
   misag_built_environment_data:
     description: Data that comply with Misag combined with BuiltEnvironment
     title: MisagBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_built_environment_data
-    range: MisagBuiltEnvironment
     multivalued: true
+    range: MisagBuiltEnvironment
     inlined: true
     inlined_as_list: true
   misag_food_animal_and_animal_feed_data:
     description: Data that comply with Misag combined with FoodAnimalAndAnimalFeed
     title: MisagFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_animal_and_animal_feed_data
-    range: MisagFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MisagFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   misag_food_farm_environment_data:
     description: Data that comply with Misag combined with FoodFarmEnvironment
     title: MisagFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_farm_environment_data
-    range: MisagFoodFarmEnvironment
     multivalued: true
+    range: MisagFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   misag_food_food_production_facility_data:
     description: Data that comply with Misag combined with FoodFoodProductionFacility
     title: MisagFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_food_production_facility_data
-    range: MisagFoodFoodProductionFacility
     multivalued: true
+    range: MisagFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   misag_food_human_foods_data:
     description: Data that comply with Misag combined with FoodHumanFoods
     title: MisagFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_food_human_foods_data
-    range: MisagFoodHumanFoods
     multivalued: true
+    range: MisagFoodHumanFoods
     inlined: true
     inlined_as_list: true
   misag_host_associated_data:
     description: Data that comply with Misag combined with HostAssociated
     title: MisagHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_host_associated_data
-    range: MisagHostAssociated
     multivalued: true
+    range: MisagHostAssociated
     inlined: true
     inlined_as_list: true
   misag_human_associated_data:
     description: Data that comply with Misag combined with HumanAssociated
     title: MisagHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_associated_data
-    range: MisagHumanAssociated
     multivalued: true
+    range: MisagHumanAssociated
     inlined: true
     inlined_as_list: true
   misag_human_gut_data:
     description: Data that comply with Misag combined with HumanGut
     title: MisagHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_gut_data
-    range: MisagHumanGut
     multivalued: true
+    range: MisagHumanGut
     inlined: true
     inlined_as_list: true
   misag_human_oral_data:
     description: Data that comply with Misag combined with HumanOral
     title: MisagHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_oral_data
-    range: MisagHumanOral
     multivalued: true
+    range: MisagHumanOral
     inlined: true
     inlined_as_list: true
   misag_human_skin_data:
     description: Data that comply with Misag combined with HumanSkin
     title: MisagHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_skin_data
-    range: MisagHumanSkin
     multivalued: true
+    range: MisagHumanSkin
     inlined: true
     inlined_as_list: true
   misag_human_vaginal_data:
     description: Data that comply with Misag combined with HumanVaginal
     title: MisagHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_human_vaginal_data
-    range: MisagHumanVaginal
     multivalued: true
+    range: MisagHumanVaginal
     inlined: true
     inlined_as_list: true
   misag_hydrocarbon_resources_cores_data:
     description: Data that comply with Misag combined with HydrocarbonResourcesCores
     title: MisagHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_hydrocarbon_resources_cores_data
-    range: MisagHydrocarbonResourcesCores
     multivalued: true
+    range: MisagHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   misag_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Misag combined with HydrocarbonResourcesFluidsSwabs
     title: MisagHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_hydrocarbon_resources_fluids_swabs_data
-    range: MisagHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MisagHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   misag_microbial_mat_biofilm_data:
     description: Data that comply with Misag combined with MicrobialMatBiofilm
     title: MisagMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_microbial_mat_biofilm_data
-    range: MisagMicrobialMatBiofilm
     multivalued: true
+    range: MisagMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   misag_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Misag combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MisagMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_miscellaneous_natural_or_artificial_environment_data
-    range: MisagMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MisagMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   misag_plant_associated_data:
     description: Data that comply with Misag combined with PlantAssociated
     title: MisagPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_plant_associated_data
-    range: MisagPlantAssociated
     multivalued: true
+    range: MisagPlantAssociated
     inlined: true
     inlined_as_list: true
   misag_sediment_data:
     description: Data that comply with Misag combined with Sediment
     title: MisagSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_sediment_data
-    range: MisagSediment
     multivalued: true
+    range: MisagSediment
     inlined: true
     inlined_as_list: true
   misag_soil_data:
     description: Data that comply with Misag combined with Soil
     title: MisagSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_soil_data
-    range: MisagSoil
     multivalued: true
+    range: MisagSoil
     inlined: true
     inlined_as_list: true
   misag_symbiont_associated_data:
     description: Data that comply with Misag combined with SymbiontAssociated
     title: MisagSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_symbiont_associated_data
-    range: MisagSymbiontAssociated
     multivalued: true
+    range: MisagSymbiontAssociated
     inlined: true
     inlined_as_list: true
   misag_wastewater_sludge_data:
     description: Data that comply with Misag combined with WastewaterSludge
     title: MisagWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_wastewater_sludge_data
-    range: MisagWastewaterSludge
     multivalued: true
+    range: MisagWastewaterSludge
     inlined: true
     inlined_as_list: true
   misag_water_data:
     description: Data that comply with Misag combined with Water
     title: MisagWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:misag_water_data
-    range: MisagWater
     multivalued: true
+    range: MisagWater
     inlined: true
     inlined_as_list: true
   miuvig_data:
     description: Data that comply with checklist Miuvig
     title: Miuvig data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_data
-    range: Miuvig
     multivalued: true
+    range: Miuvig
     inlined: true
     inlined_as_list: true
   miuvig_agriculture_data:
     description: Data that comply with Miuvig combined with Agriculture
     title: MiuvigAgriculture data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_agriculture_data
-    range: MiuvigAgriculture
     multivalued: true
+    range: MiuvigAgriculture
     inlined: true
     inlined_as_list: true
   miuvig_air_data:
     description: Data that comply with Miuvig combined with Air
     title: MiuvigAir data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_air_data
-    range: MiuvigAir
     multivalued: true
+    range: MiuvigAir
     inlined: true
     inlined_as_list: true
   miuvig_built_environment_data:
     description: Data that comply with Miuvig combined with BuiltEnvironment
     title: MiuvigBuiltEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_built_environment_data
-    range: MiuvigBuiltEnvironment
     multivalued: true
+    range: MiuvigBuiltEnvironment
     inlined: true
     inlined_as_list: true
   miuvig_food_animal_and_animal_feed_data:
     description: Data that comply with Miuvig combined with FoodAnimalAndAnimalFeed
     title: MiuvigFoodAnimalAndAnimalFeed data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_animal_and_animal_feed_data
-    range: MiuvigFoodAnimalAndAnimalFeed
     multivalued: true
+    range: MiuvigFoodAnimalAndAnimalFeed
     inlined: true
     inlined_as_list: true
   miuvig_food_farm_environment_data:
     description: Data that comply with Miuvig combined with FoodFarmEnvironment
     title: MiuvigFoodFarmEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_farm_environment_data
-    range: MiuvigFoodFarmEnvironment
     multivalued: true
+    range: MiuvigFoodFarmEnvironment
     inlined: true
     inlined_as_list: true
   miuvig_food_food_production_facility_data:
     description: Data that comply with Miuvig combined with FoodFoodProductionFacility
     title: MiuvigFoodFoodProductionFacility data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_food_production_facility_data
-    range: MiuvigFoodFoodProductionFacility
     multivalued: true
+    range: MiuvigFoodFoodProductionFacility
     inlined: true
     inlined_as_list: true
   miuvig_food_human_foods_data:
     description: Data that comply with Miuvig combined with FoodHumanFoods
     title: MiuvigFoodHumanFoods data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_food_human_foods_data
-    range: MiuvigFoodHumanFoods
     multivalued: true
+    range: MiuvigFoodHumanFoods
     inlined: true
     inlined_as_list: true
   miuvig_host_associated_data:
     description: Data that comply with Miuvig combined with HostAssociated
     title: MiuvigHostAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_host_associated_data
-    range: MiuvigHostAssociated
     multivalued: true
+    range: MiuvigHostAssociated
     inlined: true
     inlined_as_list: true
   miuvig_human_associated_data:
     description: Data that comply with Miuvig combined with HumanAssociated
     title: MiuvigHumanAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_associated_data
-    range: MiuvigHumanAssociated
     multivalued: true
+    range: MiuvigHumanAssociated
     inlined: true
     inlined_as_list: true
   miuvig_human_gut_data:
     description: Data that comply with Miuvig combined with HumanGut
     title: MiuvigHumanGut data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_gut_data
-    range: MiuvigHumanGut
     multivalued: true
+    range: MiuvigHumanGut
     inlined: true
     inlined_as_list: true
   miuvig_human_oral_data:
     description: Data that comply with Miuvig combined with HumanOral
     title: MiuvigHumanOral data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_oral_data
-    range: MiuvigHumanOral
     multivalued: true
+    range: MiuvigHumanOral
     inlined: true
     inlined_as_list: true
   miuvig_human_skin_data:
     description: Data that comply with Miuvig combined with HumanSkin
     title: MiuvigHumanSkin data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_skin_data
-    range: MiuvigHumanSkin
     multivalued: true
+    range: MiuvigHumanSkin
     inlined: true
     inlined_as_list: true
   miuvig_human_vaginal_data:
     description: Data that comply with Miuvig combined with HumanVaginal
     title: MiuvigHumanVaginal data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_human_vaginal_data
-    range: MiuvigHumanVaginal
     multivalued: true
+    range: MiuvigHumanVaginal
     inlined: true
     inlined_as_list: true
   miuvig_hydrocarbon_resources_cores_data:
     description: Data that comply with Miuvig combined with HydrocarbonResourcesCores
     title: MiuvigHydrocarbonResourcesCores data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_hydrocarbon_resources_cores_data
-    range: MiuvigHydrocarbonResourcesCores
     multivalued: true
+    range: MiuvigHydrocarbonResourcesCores
     inlined: true
     inlined_as_list: true
   miuvig_hydrocarbon_resources_fluids_swabs_data:
     description: Data that comply with Miuvig combined with HydrocarbonResourcesFluidsSwabs
     title: MiuvigHydrocarbonResourcesFluidsSwabs data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_hydrocarbon_resources_fluids_swabs_data
-    range: MiuvigHydrocarbonResourcesFluidsSwabs
     multivalued: true
+    range: MiuvigHydrocarbonResourcesFluidsSwabs
     inlined: true
     inlined_as_list: true
   miuvig_microbial_mat_biofilm_data:
     description: Data that comply with Miuvig combined with MicrobialMatBiofilm
     title: MiuvigMicrobialMatBiofilm data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_microbial_mat_biofilm_data
-    range: MiuvigMicrobialMatBiofilm
     multivalued: true
+    range: MiuvigMicrobialMatBiofilm
     inlined: true
     inlined_as_list: true
   miuvig_miscellaneous_natural_or_artificial_environment_data:
     description: Data that comply with Miuvig combined with MiscellaneousNaturalOrArtificialEnvironment
     title: MiuvigMiscellaneousNaturalOrArtificialEnvironment data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_miscellaneous_natural_or_artificial_environment_data
-    range: MiuvigMiscellaneousNaturalOrArtificialEnvironment
     multivalued: true
+    range: MiuvigMiscellaneousNaturalOrArtificialEnvironment
     inlined: true
     inlined_as_list: true
   miuvig_plant_associated_data:
     description: Data that comply with Miuvig combined with PlantAssociated
     title: MiuvigPlantAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_plant_associated_data
-    range: MiuvigPlantAssociated
     multivalued: true
+    range: MiuvigPlantAssociated
     inlined: true
     inlined_as_list: true
   miuvig_sediment_data:
     description: Data that comply with Miuvig combined with Sediment
     title: MiuvigSediment data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_sediment_data
-    range: MiuvigSediment
     multivalued: true
+    range: MiuvigSediment
     inlined: true
     inlined_as_list: true
   miuvig_soil_data:
     description: Data that comply with Miuvig combined with Soil
     title: MiuvigSoil data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_soil_data
-    range: MiuvigSoil
     multivalued: true
+    range: MiuvigSoil
     inlined: true
     inlined_as_list: true
   miuvig_symbiont_associated_data:
     description: Data that comply with Miuvig combined with SymbiontAssociated
     title: MiuvigSymbiontAssociated data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_symbiont_associated_data
-    range: MiuvigSymbiontAssociated
     multivalued: true
+    range: MiuvigSymbiontAssociated
     inlined: true
     inlined_as_list: true
   miuvig_wastewater_sludge_data:
     description: Data that comply with Miuvig combined with WastewaterSludge
     title: MiuvigWastewaterSludge data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_wastewater_sludge_data
-    range: MiuvigWastewaterSludge
     multivalued: true
+    range: MiuvigWastewaterSludge
     inlined: true
     inlined_as_list: true
   miuvig_water_data:
     description: Data that comply with Miuvig combined with Water
     title: MiuvigWater data
+    domain: MixsCompliantData
     slot_uri: MIXS:miuvig_water_data
-    range: MiuvigWater
     multivalued: true
+    range: MiuvigWater
     inlined: true
     inlined_as_list: true
   HACCP_term:
@@ -3593,8 +3743,8 @@ slots:
       - food
       - term
     slot_uri: MIXS:0001215
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -3602,12 +3752,10 @@ slots:
       partial_match: true
   IFSAC_category:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: IFSAC term
+      Expected_value: IFSAC term
     description: 'The IFSAC food categorization scheme has five distinct levels to
-      which foods can be assigned, depending upon the type of food. First, foods
-      are assigned to one of four food groups (aquatic animals, land animals, plants,
+      which foods can be assigned, depending upon the type of food. First, foods are
+      assigned to one of four food groups (aquatic animals, land animals, plants,
       and other). Food groups include increasingly specific food categories; dairy,
       eggs, meat and poultry, and game are in the land animal food group, and the
       category meat and poultry is further subdivided into more specific categories
@@ -3622,15 +3770,13 @@ slots:
       - value: Plants:Produce:Vegetables:Herbs:Dried Herbs
     keywords:
       - food
-    slot_uri: MIXS:0001179
     range: string
-    required: true
+    slot_uri: MIXS:0001179
     multivalued: true
+    required: true
   abs_air_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per gram, kilogram per kilogram, kilogram, pound
+      Preferred_unit: gram per gram, kilogram per kilogram, kilogram, pound
     description: Actual mass of water vapor - mh20 - present in the air water vapor
       mixture
     title: absolute air humidity
@@ -3644,7 +3790,7 @@ slots:
     range: string
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -3658,16 +3804,15 @@ slots:
       - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
     in_subset:
       - sequencing
-    slot_uri: MIXS:0000048
-    pattern: ^[ACGTRKSYMWBHDVN]+;[ACGTRKSYMWBHDVN]+$
     structured_pattern:
       syntax: ^{adapter_A_DNA_sequence};{adapter_B_DNA_sequence}$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0000048
   add_recov_method:
     description: Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed
-      for increase of hydrocarbon recovery from resource and start date for each
-      one of them. If "other" is specified, please propose entry in "additional info"
+      for increase of hydrocarbon recovery from resource and start date for each one
+      of them. If "other" is specified, please propose entry in "additional info"
       field
     title: secondary and tertiary recovery methods and start date
     examples:
@@ -3678,17 +3823,15 @@ slots:
       - recover
       - secondary
       - start
-    slot_uri: MIXS:0001009
-    required: true
-    pattern: ^(Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer
-      Addition|Surfactant Addition|Not Applicable|other);(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$$
     structured_pattern:
-      syntax: ^({add_recov_methods});{date_time_stamp}$
+      syntax: '^({add_recov_methods});{date_time_stamp}$'
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0001009
+    required: true
   additional_info:
-    description: Information that doesn't fit anywhere else. Can also be used to
-      propose new entries for fields with controlled vocabulary
+    description: Information that doesn't fit anywhere else. Can also be used to propose
+      new entries for fields with controlled vocabulary
     title: additional info
     keywords:
       - information
@@ -3697,12 +3840,11 @@ slots:
   address:
     description: The street name and building number where the sampling occurred
     title: address
-    slot_uri: MIXS:0000218
-    pattern: ^[1-9][0-9]* .*}$
     structured_pattern:
       syntax: ^{integer} {text}}$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0000218
   adj_room:
     description: List of rooms (room number, room name) immediately adjacent to the
       sampling room
@@ -3719,9 +3861,7 @@ slots:
       partial_match: true
   adjacent_environment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO_01001110 or ENVO_00000070
+      Expected_value: ENVO_01001110 or ENVO_00000070
     description: Description of the environmental system or features that are adjacent
       to the sampling site. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110)
       and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple
@@ -3747,22 +3887,19 @@ slots:
     range: AeroStrucEnum
   agrochem_addition:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Addition of fertilizers, pesticides, etc. - amount and time of applications
     title: history/agrochemical additions
     examples:
       - value: roundup;5 milligram per liter;2018-06-21
     keywords:
       - history
-    slot_uri: MIXS:0000639
-    multivalued: true
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+);(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$$
     structured_pattern:
       syntax: ^{agrochemical_name};{amount} {unit};{date_time_stamp}$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0000639
+    multivalued: true
   air_PM_concen:
     description: Concentration of substances that remain suspended in the air, and
       comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can
@@ -3775,18 +3912,15 @@ slots:
       - concentration
       - particle
       - particulate
-    slot_uri: MIXS:0000108
-    multivalued: true
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{particulate_matter_name};{float} {unit}$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0000108
+    multivalued: true
   air_flow_impede:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;obstruction type; distance from sampling device
+      Expected_value: enumeration;obstruction type; distance from sampling device
     description: Presence of objects in the area that would influence or impede air
       flow through the air filter
     title: local air flow impediments
@@ -3799,9 +3933,7 @@ slots:
     multivalued: true
   air_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of the air at the time of sampling
     title: air temperature
     keywords:
@@ -3810,23 +3942,19 @@ slots:
     slot_uri: MIXS:0000124
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   air_temp_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: temperature value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: temperature value;treatment interval and duration
+      Preferred_unit: meter
     description: Information about treatment involving an exposure to varying temperatures;
-      should include the temperature, treatment regimen including how many times
-      the treatment was repeated, how long each treatment lasted, and the start and
-      end time of the entire treatment; can include different temperature regimens
+      should include the temperature, treatment regimen including how many times the
+      treatment was repeated, how long each treatment lasted, and the start and end
+      time of the entire treatment; can include different temperature regimens
     title: air temperature regimen
     examples:
       - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -3839,9 +3967,7 @@ slots:
     multivalued: true
   al_sat:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Aluminum saturation (esp. For tropical soils)
     title: extreme_unusual_properties/Al saturation
     keywords:
@@ -3852,7 +3978,7 @@ slots:
     slot_uri: MIXS:0000607
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -3875,9 +4001,7 @@ slots:
       partial_match: true
   alkalinity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliequivalent per liter, milligram per liter
+      Preferred_unit: milliequivalent per liter, milligram per liter
     description: Alkalinity, the ability of a solution to neutralize acids to the
       equivalence point of carbonate or bicarbonate
     title: alkalinity
@@ -3888,7 +4012,7 @@ slots:
     slot_uri: MIXS:0000421
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -3911,21 +4035,19 @@ slots:
     slot_uri: MIXS:0000490
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   alt:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Heights of objects such as airplanes, space shuttles, rockets, atmospheric
       balloons and heights of places such as atmospheric layers and clouds. It is
       used to measure the height of an object which is above the earth's surface.
-      In this context, the altitude measurement is the vertical distance between
-      the earth's surface above sea level and the sampled position in the air
+      In this context, the altitude measurement is the vertical distance between the
+      earth's surface above sea level and the sampled position in the air
     title: altitude
     examples:
       - value: 100 meter
@@ -3934,16 +4056,14 @@ slots:
     slot_uri: MIXS:0000094
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   aminopept_act:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mole per liter per hour
+      Preferred_unit: mole per liter per hour
     description: Measurement of aminopeptidase activity
     title: aminopeptidase activity
     examples:
@@ -3951,16 +4071,14 @@ slots:
     slot_uri: MIXS:0000172
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ammonium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of ammonium in the sample
     title: ammonium
     examples:
@@ -3968,7 +4086,7 @@ slots:
     slot_uri: MIXS:0000427
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -3980,9 +4098,7 @@ slots:
     range: string
   amount_light:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: lux, lumens per square meter
+      Preferred_unit: lux, lumens per square meter
     description: The unit of illuminance and luminous emittance, measuring luminous
       flux per unit area
     title: amount of light
@@ -3991,7 +4107,7 @@ slots:
     slot_uri: MIXS:0000140
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4006,10 +4122,9 @@ slots:
     slot_uri: MIXS:0000247
     range: string
   anim_water_method:
-    description: Description of the equipment or method used to distribute water
-      to livestock. This field accepts termed listed under water delivery equipment
-      (http://opendata.inra.fr/EOL/EOL_0001653). Multiple terms can be separated
-      by pipes
+    description: Description of the equipment or method used to distribute water to
+      livestock. This field accepts termed listed under water delivery equipment (http://opendata.inra.fr/EOL/EOL_0001653).
+      Multiple terms can be separated by pipes
     title: animal water delivery method
     examples:
       - value: water trough [EOL:0001618]
@@ -4019,16 +4134,16 @@ slots:
       - method
       - water
     slot_uri: MIXS:0001115
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
       interpolated: true
       partial_match: true
   animal_am:
-    description: The name(s) (generic or brand) of the antimicrobial(s) given to
-      the food animal within the last 30 days
+    description: The name(s) (generic or brand) of the antimicrobial(s) given to the
+      food animal within the last 30 days
     title: food animal antimicrobial
     examples:
       - value: tetracycline
@@ -4050,15 +4165,14 @@ slots:
       - duration
       - food
       - period
-    slot_uri: MIXS:0001244
-    pattern: ^[-+]?[0-9]*\.?[0-9]+ days$
     structured_pattern:
       syntax: ^{float} days$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0001244
   animal_am_freq:
-    description: The frequency per day that the antimicrobial was administered to
-      the food animal
+    description: The frequency per day that the antimicrobial was administered to the
+      food animal
     title: food animal antimicrobial frequency
     examples:
       - value: '1.5'
@@ -4070,7 +4184,7 @@ slots:
     slot_uri: MIXS:0001245
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4118,11 +4232,9 @@ slots:
     range: AnimalBodyCondEnum
   animal_diet:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or FOODON_03309997
-    description: If the isolate is from a food animal, the type of diet eaten by
-      the food animal.  Please list the main food staple and the setting, if appropriate.  For
+      Expected_value: text or FOODON_03309997
+    description: If the isolate is from a food animal, the type of diet eaten by the
+      food animal.  Please list the main food staple and the setting, if appropriate.  For
       a list of acceptable animal feed terms or categories, please see http://www.feedipedia.org.  Multiple
       terms may apply and can be separated by pipes |Food product for animal covers
       foods intended for consumption by domesticated animals. Consult http://purl.obolibrary.org/obo/FOODON_03309997.
@@ -4137,14 +4249,12 @@ slots:
       - diet
       - food
       - source
-    slot_uri: MIXS:0001130
     range: string
+    slot_uri: MIXS:0001130
     multivalued: true
   animal_feed_equip:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: EOL:0001757
+      Expected_value: EOL:0001757
     description: Description of the feeding equipment used for livestock. This field
       accepts terms listed under feed delivery (http://opendata.inra.fr/EOL/EOL_0001757).
       Multiple terms can be separated by pipes
@@ -4154,13 +4264,12 @@ slots:
     keywords:
       - animal
       - equipment
-    slot_uri: MIXS:0001113
-    multivalued: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0001113
+    multivalued: true
   animal_group_size:
     description: The number of food animals of the same species that are maintained
       together as a unit, i.e. a herd or flock
@@ -4182,8 +4291,8 @@ slots:
     keywords:
       - animal
     slot_uri: MIXS:0001180
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -4204,8 +4313,8 @@ slots:
       - sample
       - source
     slot_uri: MIXS:0001114
-    range: string
     multivalued: true
+    range: string
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -4224,9 +4333,7 @@ slots:
     range: AnimalSexEnum
   annot:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name of tool or pipeline used, or annotation source description
+      Expected_value: name of tool or pipeline used, or annotation source description
     description: Tool used for annotation, or for cases where annotation was provided
       by a community jamboree or model organism database rather than by a specific
       submitter
@@ -4235,13 +4342,11 @@ slots:
       - value: prokka
     in_subset:
       - sequencing
-    slot_uri: MIXS:0000059
     range: string
+    slot_uri: MIXS:0000059
   annual_precpt:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter
+      Preferred_unit: millimeter
     description: The average of all annual precipitation values known, or an estimated
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean annual precipitation
@@ -4250,16 +4355,14 @@ slots:
     slot_uri: MIXS:0000644
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   annual_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Mean annual temperature
     title: mean annual temperature
     examples:
@@ -4270,19 +4373,15 @@ slots:
     slot_uri: MIXS:0000642
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   antibiotic_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: antibiotic name;antibiotic amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram
+      Expected_value: antibiotic name;antibiotic amount;treatment interval and duration
+      Preferred_unit: milligram
     description: Information about treatment involving antibiotic administration;
       should include the name of antibiotic, amount administered, treatment regimen
       including how many times the treatment was repeated, how long each treatment
@@ -4298,9 +4397,7 @@ slots:
     multivalued: true
   api:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degrees API
+      Preferred_unit: degrees API
     description: 'API gravity is a measure of how heavy or light a petroleum liquid
       is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g.
       31.1   API)'
@@ -4311,7 +4408,7 @@ slots:
     range: string
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4326,12 +4423,8 @@ slots:
     range: ArchStrucEnum
   area_samp_size:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter
+      Expected_value: measurement value
+      Preferred_unit: centimeter
     description: The total amount or size (volume (ml), mass (g) or area (m2) ) of
       sample collected
     title: area sampled size
@@ -4345,47 +4438,41 @@ slots:
     slot_uri: MIXS:0001255
   aromatics_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
-      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
+      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: aromatics wt%
     slot_uri: MIXS:0000133
     range: string
     recommended: true
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   asphaltenes_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
-      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
+      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: asphaltenes wt%
     slot_uri: MIXS:0000135
     range: string
     recommended: true
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   assembly_name:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name and version of assembly
+      Expected_value: name and version of assembly
     description: Name/version of the assembly provided by the submitter that is used
       in the genome browsers and in the community
     title: assembly name
@@ -4400,20 +4487,21 @@ slots:
       for each assembly quality category. For MISAG/MIMAG; Finished: Single, validated,
       contiguous sequence per replicon without gaps or ambiguities with a consensus
       error rate equivalent to Q50 or better. High Quality Draft:Multiple fragments
-      where gaps span repetitive regions. Presence of the large subunit (LSU) RNA,
-      small subunit (SSU) and the presence of 5.8S rRNA or 5S rRNA depending on whether
-      it is a eukaryotic or prokaryotic genome, respectively. Medium Quality Draft:Many
-      fragments with little to no review of assembly other than reporting of standard
-      assembly statistics. Low Quality Draft:Many fragments with little to no review
-      of assembly other than reporting of standard assembly statistics. Assembly
-      statistics include, but are not limited to total assembly size, number of contigs,
-      contig N50/L50, and maximum contig length. For MIUVIG; Finished: Single, validated,
-      contiguous sequence per replicon without gaps or ambiguities, with extensive
-      manual review and editing to annotate putative gene functions and transcriptional
-      units. High-quality draft genome: One or multiple fragments, totaling   90%
-      of the expected genome or replicon sequence or predicted complete. Genome fragment(s):
-      One or multiple fragments, totalling < 90% of the expected genome or replicon
-      sequence, or for which no genome size could be estimated'
+      where gaps span repetitive regions. Presence of the large subunit (LSU) RNA, small
+      subunit (SSU) and the presence of 5.8S rRNA or 5S rRNA depending on whether it is
+      a eukaryotic or prokaryotic genome, respectively.
+      Medium Quality Draft:Many fragments with little to no
+      review of assembly other than reporting of standard assembly statistics. Low
+      Quality Draft:Many fragments with little to no review of assembly other than
+      reporting of standard assembly statistics. Assembly statistics include, but
+      are not limited to total assembly size, number of contigs, contig N50/L50, and
+      maximum contig length. For MIUVIG; Finished: Single, validated, contiguous sequence
+      per replicon without gaps or ambiguities, with extensive manual review and editing
+      to annotate putative gene functions and transcriptional units. High-quality
+      draft genome: One or multiple fragments, totaling   90% of the expected genome
+      or replicon sequence or predicted complete. Genome fragment(s): One or multiple
+      fragments, totalling < 90% of the expected genome or replicon sequence, or for
+      which no genome size could be estimated'
     title: assembly quality
     examples:
       - value: High-quality draft genome
@@ -4421,14 +4509,13 @@ slots:
       - sequencing
     keywords:
       - quality
-    slot_uri: MIXS:0000056
     range: AssemblyQualEnum
+    slot_uri: MIXS:0000056
   assembly_software:
     description: Tool(s) used for assembly, including version number and parameters
     title: assembly software
     examples:
-      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters
-          otherwise
+      - value: metaSPAdes;3.11.0;kmer set 21,33,55,77,99,121, default parameters otherwise
     in_subset:
       - sequencing
     keywords:
@@ -4442,9 +4529,7 @@ slots:
       partial_match: true
   associated_resource:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: reference to resource
+      Expected_value: reference to resource
     description: A related resource that is referenced, cited, or otherwise associated
       to the sequence
     title: relevant electronic resources
@@ -4456,13 +4541,11 @@ slots:
       - resource
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000091
-    recommended: true
     multivalued: true
+    recommended: true
   association_duration:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: year, day, hour
+      Preferred_unit: year, day, hour
     description: Time spent in host of the symbiotic organism at the time of sampling;
       relevant scale depends on symbiotic organism and study
     title: duration of association with the host
@@ -4474,16 +4557,14 @@ slots:
     slot_uri: MIXS:0001299
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   atmospheric_data:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: atmospheric data name;measurement value
+      Expected_value: atmospheric data name;measurement value
     description: Measurement of atmospheric data; can include multiple data
     title: atmospheric data
     examples:
@@ -4493,9 +4574,7 @@ slots:
     multivalued: true
   avg_dew_point:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The average of dew point measures taken at the beginning of every
       hour over a 24 hour period on the sampling day
     title: average dew point
@@ -4506,7 +4585,7 @@ slots:
     slot_uri: MIXS:0000141
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4521,9 +4600,7 @@ slots:
     range: float
   avg_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The average of temperatures taken at the beginning of every hour
       over a 24 hour period on the sampling day
     title: average temperature
@@ -4535,16 +4612,14 @@ slots:
     slot_uri: MIXS:0000142
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bac_prod:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter per day
+      Preferred_unit: milligram per cubic meter per day
     description: Bacterial production in the water column measured by isotope uptake
     title: bacterial production
     examples:
@@ -4554,17 +4629,14 @@ slots:
     slot_uri: MIXS:0000683
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bac_resp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter per day, micromole oxygen per liter per
-          hour
+      Preferred_unit: milligram per cubic meter per day, micromole oxygen per liter per hour
     description: Measurement of bacterial respiration in the water column
     title: bacterial respiration
     examples:
@@ -4572,7 +4644,7 @@ slots:
     slot_uri: MIXS:0000684
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4588,17 +4660,15 @@ slots:
     slot_uri: MIXS:0000173
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bacterial_density:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: colony forming units per milliliter; colony forming units per gram
-          of dry weight
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram
+        of dry weight
     description: Number of bacteria in sample, as defined by bacteria density (http://purl.obolibrary.org/obo/GENEPIO_0000043)
     title: bacteria density
     examples:
@@ -4608,16 +4678,14 @@ slots:
     slot_uri: MIXS:0001194
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   barometric_press:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millibar
+      Preferred_unit: millibar
     description: Force per unit area exerted against a surface by the weight of air
       above that surface
     title: barometric pressure
@@ -4628,7 +4696,7 @@ slots:
     slot_uri: MIXS:0000096
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4661,16 +4729,14 @@ slots:
     range: integer
   benzene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of benzene in the sample
     title: benzene
     slot_uri: MIXS:0000153
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4692,9 +4758,7 @@ slots:
     range: BinParamEnum
   bin_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names and versions of software(s) used
+      Expected_value: names and versions of software(s) used
     description: Tool(s) used for the extraction of genomes from metagenomic datasets,
       where possible include a product ID (PID) of the tool(s) used
     title: binning software
@@ -4708,28 +4772,24 @@ slots:
     slot_uri: MIXS:0000078
   biochem_oxygen_dem:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Amount of dissolved oxygen needed by aerobic biological organisms
-      in a body of water to break down organic material present in a given water
-      sample at certain temperature over a specific time period
+      in a body of water to break down organic material present in a given water sample
+      at certain temperature over a specific time period
     title: biochemical oxygen demand
     keywords:
       - oxygen
     slot_uri: MIXS:0000653
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   biocide:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name;name;timestamp
+      Expected_value: name;name;timestamp
     description: List of biocides (commercial name of product and supplier) and date
       of administration
     title: biocide administration
@@ -4742,15 +4802,11 @@ slots:
     recommended: true
   biocide_admin_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;frequency;duration;duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: measurement value;frequency;duration;duration
+      Preferred_unit: milligram per liter
     description: Method of biocide administration (dose, frequency, duration, time
-      elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr;
-      3 days)
+      elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr; 3
+      days)
     title: biocide administration method
     keywords:
       - administration
@@ -4760,21 +4816,19 @@ slots:
     recommended: true
   biocide_used:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: commercial name of biocide, active ingredient in biocide or class
-          of biocide
+      Expected_value: commercial name of biocide, active ingredient in biocide or class of
+        biocide
     description: Substance intended for preventing, neutralizing, destroying, repelling,
       or mitigating the effects of any pest or microorganism; that inhibits the growth,
-      reproduction, and activity of organisms, including fungal cells; decreases
-      the number of fungi or pests present; deters microbial growth and degradation
-      of other ingredients in the formulation. Indicate the biocide used on the location
+      reproduction, and activity of organisms, including fungal cells; decreases the
+      number of fungi or pests present; deters microbial growth and degradation of
+      other ingredients in the formulation. Indicate the biocide used on the location
       where the sample was taken. Multiple terms can be separated by pipes
     title: biocide
     examples:
       - value: Quaternary ammonium compound|SterBac
-    slot_uri: MIXS:0001258
     range: string
+    slot_uri: MIXS:0001258
     multivalued: true
   biol_stat:
     description: The level of genome modification
@@ -4783,16 +4837,12 @@ slots:
       - value: natural
     keywords:
       - status
-    slot_uri: MIXS:0000858
     range: BiolStatEnum
+    slot_uri: MIXS:0000858
   biomass:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: biomass type;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ton, kilogram, gram
+      Expected_value: biomass type;measurement value
+      Preferred_unit: ton, kilogram, gram
     description: Amount of biomass; should include the name for the part of biomass
       measured, e.g. Microbial, total. Can include multiple measurements
     title: biomass
@@ -4804,21 +4854,21 @@ slots:
     slot_uri: MIXS:0000174
     multivalued: true
   biotic_regm:
-    description: Information about treatment(s) involving use of biotic factors,
-      such as bacteria, viruses or fungi
+    description: Information about treatment(s) involving use of biotic factors, such
+      as bacteria, viruses or fungi
     title: biotic regimen
     examples:
       - value: sample inoculated with Rhizobium spp. Culture
     keywords:
       - regimen
     slot_uri: MIXS:0001038
-    range: string
     multivalued: true
+    range: string
   biotic_relationship:
-    description: Description of relationship(s) between the subject organism and
-      other organism(s) it is associated with. E.g., parasite on species X; mutualist
-      with species Y. The target organism is the subject of the relationship, and
-      the other organism(s) is the object
+    description: Description of relationship(s) between the subject organism and other
+      organism(s) it is associated with. E.g., parasite on species X; mutualist with
+      species Y. The target organism is the subject of the relationship, and the other
+      organism(s) is the object
     title: observed biotic relationship
     examples:
       - value: free living
@@ -4831,18 +4881,14 @@ slots:
     range: BioticRelationshipEnum
   birth_control:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: medication name
+      Expected_value: medication name
     description: Specification of birth control medication used
     title: birth control
-    slot_uri: MIXS:0000286
     range: string
+    slot_uri: MIXS:0000286
   bishomohopanol:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, microgram per gram
+      Preferred_unit: microgram per liter, microgram per gram
     description: Concentration of bishomohopanol
     title: bishomohopanol
     examples:
@@ -4850,7 +4896,7 @@ slots:
     slot_uri: MIXS:0000175
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4863,13 +4909,11 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000271
-    range: string
     multivalued: true
+    range: string
   blood_press_diast:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter mercury
+      Preferred_unit: millimeter mercury
     description: Resting diastolic blood pressure, measured as mm mercury
     title: host blood pressure diastolic
     keywords:
@@ -4879,16 +4923,14 @@ slots:
     slot_uri: MIXS:0000258
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   blood_press_syst:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter mercury
+      Preferred_unit: millimeter mercury
     description: Resting systolic blood pressure, measured as mm mercury
     title: host blood pressure systolic
     keywords:
@@ -4898,16 +4940,14 @@ slots:
     slot_uri: MIXS:0000259
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   bromide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: parts per million
+      Preferred_unit: parts per million
     description: Concentration of bromide
     title: bromide
     examples:
@@ -4915,7 +4955,7 @@ slots:
     slot_uri: MIXS:0000176
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4930,17 +4970,17 @@ slots:
     slot_uri: MIXS:0000787
     range: BuildDocsEnum
   build_occup_type:
-    description: The primary function for which a building or discrete part of a
-      building is intended to be used
+    description: The primary function for which a building or discrete part of a building
+      is intended to be used
     title: building occupancy type
     examples:
       - value: market
     keywords:
       - type
     slot_uri: MIXS:0000761
+    multivalued: true
     range: BuildOccupTypeEnum
     required: true
-    multivalued: true
   building_setting:
     description: A location (geography) where a building is set
     title: building setting
@@ -4951,9 +4991,7 @@ slots:
     required: true
   built_struc_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: year
+      Preferred_unit: year
     description: The age of the built structure since construction
     title: built structure age
     examples:
@@ -4963,7 +5001,7 @@ slots:
     slot_uri: MIXS:0000145
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -4986,9 +5024,7 @@ slots:
     range: string
   calcium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, micromole per liter, parts per million
+      Preferred_unit: milligram per liter, micromole per liter, parts per million
     description: Concentration of calcium in the sample
     title: calcium
     examples:
@@ -4996,16 +5032,14 @@ slots:
     slot_uri: MIXS:0000432
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   carb_dioxide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, parts per million
+      Preferred_unit: micromole per liter, parts per million
     description: Carbon dioxide (gas) amount or concentration at the time of sampling
     title: carbon dioxide
     examples:
@@ -5015,16 +5049,14 @@ slots:
     slot_uri: MIXS:0000097
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   carb_monoxide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, parts per million
+      Preferred_unit: micromole per liter, parts per million
     description: Carbon monoxide (gas) amount or concentration at the time of sampling
     title: carbon monoxide
     examples:
@@ -5034,16 +5066,14 @@ slots:
     slot_uri: MIXS:0000098
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   carb_nitro_ratio:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
+      Expected_value: measurement value
     description: Ratio of amount or concentrations of carbon to nitrogen
     title: carbon/nitrogen ratio
     examples:
@@ -5057,9 +5087,7 @@ slots:
     range: float
   ceil_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The area of the ceiling space within the room
     title: ceiling area
     examples:
@@ -5070,7 +5098,7 @@ slots:
     slot_uri: MIXS:0000148
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5117,9 +5145,7 @@ slots:
     range: CeilingWallTextureEnum
   ceil_thermal_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: joule per degree Celsius
+      Preferred_unit: joule per degree Celsius
     description: The ability of the ceiling to provide inertia against temperature
       fluctuations. Generally this means concrete that is exposed. A metal deck that
       supports a concrete slab will act thermally as long as it is exposed to room
@@ -5131,7 +5157,7 @@ slots:
     slot_uri: MIXS:0000143
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5157,9 +5183,7 @@ slots:
     range: MoldVisibilityEnum
   chem_administration:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: CHEBI;timestamp
+      Expected_value: CHEBI;timestamp
     description: List of chemical compounds administered to the host or site where
       sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can
       include multiple compounds. For chemical entities of biological interest ontology
@@ -5174,16 +5198,12 @@ slots:
     multivalued: true
   chem_mutagen:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: mutagen name;mutagen amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
-    description: Treatment involving use of mutagens; should include the name of
-      mutagen, amount administered, treatment regimen including how many times the
-      treatment was repeated, how long each treatment lasted, and the start and end
-      time of the entire treatment; can include multiple mutagen regimens
+      Expected_value: mutagen name;mutagen amount;treatment interval and duration
+      Preferred_unit: milligram per liter
+    description: Treatment involving use of mutagens; should include the name of mutagen,
+      amount administered, treatment regimen including how many times the treatment
+      was repeated, how long each treatment lasted, and the start and end time of
+      the entire treatment; can include multiple mutagen regimens
     title: chemical mutagen
     examples:
       - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -5192,31 +5212,25 @@ slots:
     multivalued: true
   chem_oxygen_dem:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
-    description: A measure of the capacity of water to consume oxygen during the
-      decomposition of organic matter and the oxidation of inorganic chemicals such
-      as ammonia and nitrite
+      Preferred_unit: milligram per liter
+    description: A measure of the capacity of water to consume oxygen during the decomposition
+      of organic matter and the oxidation of inorganic chemicals such as ammonia and
+      nitrite
     title: chemical oxygen demand
     keywords:
       - oxygen
     slot_uri: MIXS:0000656
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   chem_treat_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;frequency;duration;duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: measurement value;frequency;duration;duration
+      Preferred_unit: milligram per liter
     description: Method of chemical administration(dose, frequency, duration, time
       elapsed between administration and sampling) (e.g. 50 mg/l; twice a week; 1
       hr; 0 days)
@@ -5228,13 +5242,11 @@ slots:
     slot_uri: MIXS:0000457
   chem_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name;name;timestamp
+      Expected_value: name;name;timestamp
     description: List of chemical compounds administered upstream the sampling location
       where sampling occurred (e.g. Glycols, H2S scavenger, corrosion and scale inhibitors,
-      demulsifiers, and other production chemicals etc.). The commercial name of
-      the product and name of the supplier should be provided. The date of administration
+      demulsifiers, and other production chemicals etc.). The commercial name of the
+      product and name of the supplier should be provided. The date of administration
       should also be included
     title: chemical treatment
     examples:
@@ -5244,9 +5256,9 @@ slots:
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001012
   chimera_check:
-    description: Tool(s) used for chimera checking, including version number and
-      parameters, to discover and remove chimeric sequences. A chimeric sequence
-      is comprised of two or more phylogenetically distinct parent sequences
+    description: Tool(s) used for chimera checking, including version number and parameters,
+      to discover and remove chimeric sequences. A chimeric sequence is comprised
+      of two or more phylogenetically distinct parent sequences
     title: chimera check software
     examples:
       - value: uchime;v4.1;default parameters
@@ -5263,9 +5275,7 @@ slots:
       partial_match: true
   chloride:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of chloride in the sample
     title: chloride
     examples:
@@ -5273,16 +5283,14 @@ slots:
     slot_uri: MIXS:0000429
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   chlorophyll:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter, microgram per liter
+      Preferred_unit: milligram per cubic meter, microgram per liter
     description: Concentration of chlorophyll
     title: chlorophyll
     examples:
@@ -5290,29 +5298,27 @@ slots:
     slot_uri: MIXS:0000177
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   climate_environment:
     description: Treatment involving an exposure to a particular climate; treatment
-      regimen including how many times the treatment was repeated, how long each
-      treatment lasted, and the start and end time of the entire treatment; can include
-      multiple climates
+      regimen including how many times the treatment was repeated, how long each treatment
+      lasted, and the start and end time of the entire treatment; can include multiple
+      climates
     title: climate environment
     examples:
       - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
       - environment
     slot_uri: MIXS:0001040
-    range: string
     multivalued: true
+    range: string
   coll_site_geo_feat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:00000002 or ENVO:00000070
+      Expected_value: ENVO:00000002 or ENVO:00000070
     description: 'Text or terms that describe the geographic feature where the food
       sample was obtained by the researcher. This field accepts selected terms listed
       under the following ontologies: anthropogenic geographic feature (http://purl.obolibrary.org/obo/ENVO_00000002),
@@ -5346,9 +5352,7 @@ slots:
     required: true
   compl_appr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text
+      Expected_value: text
     description: The approach used to determine the completeness of a given genomic
       assembly, which would typically make use of a set of conserved marker genes
       or a closely related reference genome. For UViG completeness, include reference
@@ -5356,17 +5360,15 @@ slots:
     title: completeness approach
     examples:
       - value: other
-        description: was other <colon> UViG length compared to the average length
-          of reference genomes from the P22virus genus (NCBI RefSeq v83)
+        description: was other <colon> UViG length compared to the average length of
+          reference genomes from the P22virus genus (NCBI RefSeq v83)
     in_subset:
       - sequencing
     slot_uri: MIXS:0000071
     range: ComplApprEnum
   compl_score:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: quality;percent completeness
+      Expected_value: quality;percent completeness
     description: 'Completeness score is typically based on either the fraction of
       markers found as compared to a database or the percent of a genome found as
       compared to a closely related reference genome. High Quality Draft: >90%, Medium
@@ -5383,9 +5385,7 @@ slots:
     slot_uri: MIXS:0000069
   compl_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names and versions of software(s) used
+      Expected_value: names and versions of software(s) used
     description: Tools used for completion estimate, i.e. checkm, anvi'o, busco
     title: completeness software
     examples:
@@ -5398,9 +5398,7 @@ slots:
     slot_uri: MIXS:0000070
   conduc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliSiemens per centimeter
+      Preferred_unit: milliSiemens per centimeter
     description: Electrical conductivity of water
     title: conductivity
     examples:
@@ -5408,16 +5406,14 @@ slots:
     slot_uri: MIXS:0000692
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   cons_food_stor_dur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours or days
+      Preferred_unit: hours or days
     description: The storage duration of the food commodity by the consumer, prior
       to onset of illness or sample collection.  Indicate the timepoint written in
       ISO 8601 format
@@ -5438,14 +5434,10 @@ slots:
       partial_match: true
   cons_food_stor_temp:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
-    description: Temperature at which food commodity was stored by the consumer,
-      prior to onset of illness or sample collection
+      Expected_value: text or measurement value
+      Preferred_unit: degree Celsius
+    description: Temperature at which food commodity was stored by the consumer, prior
+      to onset of illness or sample collection
     title: food stored by consumer (storage temperature)
     examples:
       - value: 4 degree Celsius
@@ -5474,7 +5466,7 @@ slots:
       - quantity
     slot_uri: MIXS:0001198
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -5482,9 +5474,9 @@ slots:
   contam_score:
     description: 'The contamination score is based on the fraction of single-copy
       genes that are observed more than once in a query genome. The following scores
-      are acceptable for; High Quality Draft: < 5%, Medium Quality Draft: < 10%,
-      Low Quality Draft: < 10%. Contamination must be below 5% for a SAG or MAG to
-      be deposited into any of the public databases'
+      are acceptable for; High Quality Draft: < 5%, Medium Quality Draft: < 10%, Low
+      Quality Draft: < 10%. Contamination must be below 5% for a SAG or MAG to be
+      deposited into any of the public databases'
     title: contamination score
     examples:
       - value: '0.01'
@@ -5505,9 +5497,7 @@ slots:
     range: ContamScreenInputEnum
   contam_screen_param:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;value or name
+      Expected_value: enumeration;value or name
     description: Specific parameters used in the decontamination sofware, such as
       reference database, coverage, and kmers. Combinations of these parameters may
       also be used, i.e. kmer and coverage, or reference database and kmer
@@ -5531,9 +5521,7 @@ slots:
     range: integer
   crop_rotation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: crop rotation status;schedule
+      Expected_value: crop rotation status;schedule
     description: Whether or not crop is rotated, and if yes, rotation schedule
     title: history/crop rotation
     examples:
@@ -5543,9 +5531,7 @@ slots:
     slot_uri: MIXS:0000318
   crop_yield:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram per metre square
+      Preferred_unit: kilogram per metre square
     description: Amount of crop produced per unit or area of land
     title: crop yield
     examples:
@@ -5555,7 +5541,7 @@ slots:
     slot_uri: MIXS:0001116
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5592,8 +5578,8 @@ slots:
       - culture
       - organism
     slot_uri: MIXS:0001118
-    range: string
     multivalued: true
+    range: string
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -5601,9 +5587,7 @@ slots:
       partial_match: true
   cult_root_med:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name, PMID,DOI or url
+      Expected_value: name, PMID,DOI or url
     description: Name or reference for the hydroponic or in vitro culture rooting
       medium; can be the name of a commonly used medium or reference to a specific
       medium, e.g. Murashige and Skoog medium. If the medium has not been formally
@@ -5617,9 +5601,7 @@ slots:
     slot_uri: MIXS:0001041
   cult_target:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C14250 or NCBI taxid or culture independent
+      Expected_value: NCIT:C14250 or NCBI taxid or culture independent
     description: The target microbial analyte in terms of investigation scope. This
       field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
@@ -5635,9 +5617,7 @@ slots:
     multivalued: true
   cur_land_use:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Present state of sample site
     title: current land use
     examples:
@@ -5646,31 +5626,29 @@ slots:
       - land
       - use
     string_serialization: '[cities|farmstead|industrial areas|roads/railroads|rock|sand|gravel|mudflats|salt
-      flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste
-      areas|small grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
+      flats|badlands|permanent snow or ice|saline seeps|mines/quarries|oil waste areas|small
+      grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands
       (grass,sedges,rushes)|tundra (mosses,lichens)|rangeland|pastureland (grasslands
       used for livestock grazing)|hayland|meadows (grasses,alfalfa,fescue,bromegrass,timothy)|shrub
       land (e.g. mesquite,sage-brush,creosote bush,shrub oak,eucalyptus)|successional
       shrub land (tree saplings,hazels,sumacs,chokecherry,shrub dogwoods,blackberries)|shrub
       crops (blueberries,nursery ornamentals,filberts)|vine crops (grapes)|conifers
       (e.g. pine,spruce,fir,cypress)|hardwoods (e.g. oak,hickory,elm,aspen)|intermixed
-      hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen
-      forest receiving >406 cm annual rainfall)|swamp (permanent or semi-permanent
-      water body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery
+      hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen forest
+      receiving >406 cm annual rainfall)|swamp (permanent or semi-permanent water
+      body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery
       trees)]'
     slot_uri: MIXS:0001080
   cur_vegetation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: current vegetation type
+      Expected_value: current vegetation type
     description: Vegetation classification from one or more standard classification
       systems, or agricultural crop
     title: current vegetation
     keywords:
       - vegetation
-    slot_uri: MIXS:0000312
     range: string
+    slot_uri: MIXS:0000312
   cur_vegetation_meth:
     description: Reference or method used in vegetation classification
     title: current vegetation method
@@ -5685,9 +5663,8 @@ slots:
       interpolated: true
       partial_match: true
   date_extr_weath:
-    description: Date of unusual weather events that may have affected microbial
-      populations. Multiple terms can be separated by pipes, listed in reverse chronological
-      order
+    description: Date of unusual weather events that may have affected microbial populations.
+      Multiple terms can be separated by pipes, listed in reverse chronological order
     title: extreme weather date
     examples:
       - value: '2013-03-25T12:42:31+01:00'
@@ -5696,8 +5673,8 @@ slots:
       - extreme
       - weather
     slot_uri: MIXS:0001142
-    range: datetime
     multivalued: true
+    range: datetime
   date_last_rain:
     description: The date of the last time it rained
     title: date last rain
@@ -5710,9 +5687,7 @@ slots:
     range: datetime
   decontam_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Tool(s) used in contamination screening
     title: decontamination software
     examples:
@@ -5725,9 +5700,7 @@ slots:
     slot_uri: MIXS:0000074
   density:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per cubic meter, gram per cubic centimeter
+      Preferred_unit: gram per cubic meter, gram per cubic centimeter
     description: Density of the sample, which is its mass per unit volume (aka volumetric
       mass density)
     title: density
@@ -5738,7 +5711,7 @@ slots:
     slot_uri: MIXS:0000435
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5754,12 +5727,10 @@ slots:
     recommended: true
   depth:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
-    description: The vertical distance below local surface. For sediment or soil
-      samples depth is measured from sediment or soil surface, respectively. Depth
-      can be reported as an interval for subsurface samples
+      Preferred_unit: meter
+    description: The vertical distance below local surface. For sediment or soil samples
+      depth is measured from sediment or soil surface, respectively. Depth can be
+      reported as an interval for subsurface samples
     title: depth
     in_subset:
       - environment
@@ -5768,7 +5739,7 @@ slots:
     slot_uri: MIXS:0000018
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5781,13 +5752,11 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000284
-    range: string
     multivalued: true
+    range: string
   detec_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Type of UViG detection
     title: detection type
     examples:
@@ -5800,9 +5769,7 @@ slots:
     slot_uri: MIXS:0000084
   dew_point:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The temperature to which a given parcel of humid air must be cooled,
       at constant barometric pressure, for water vapor to condense into water
     title: dew point
@@ -5811,16 +5778,14 @@ slots:
     slot_uri: MIXS:0000129
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diet_last_six_month:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: diet change;current diet
+      Expected_value: diet change;current diet
     description: Specification of major diet changes in the last six months, if yes
       the change should be specified
     title: major diet change in last six months
@@ -5833,9 +5798,7 @@ slots:
     slot_uri: MIXS:0000266
   dietary_claim_use:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03510023
+      Expected_value: FOODON:03510023
     description: These descriptors are used either for foods intended for special
       dietary use as defined in 21 CFR 105 or for foods that have special characteristics
       indicated in the name or labeling. This field accepts terms listed under dietary
@@ -5853,12 +5816,8 @@ slots:
     multivalued: true
   diether_lipids:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: diether lipid name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: nanogram per liter
+      Expected_value: diether lipid name;measurement value
+      Preferred_unit: nanogram per liter
     description: Concentration of diether lipids; can include multiple types of diether
       lipids
     title: diether lipids
@@ -5869,9 +5828,7 @@ slots:
     multivalued: true
   diss_carb_dioxide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter
+      Preferred_unit: micromole per liter, milligram per liter
     description: Concentration of dissolved carbon dioxide in the sample or liquid
       portion of the sample
     title: dissolved carbon dioxide
@@ -5883,16 +5840,14 @@ slots:
     slot_uri: MIXS:0000436
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_hydrogen:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of dissolved hydrogen
     title: dissolved hydrogen
     examples:
@@ -5902,16 +5857,14 @@ slots:
     slot_uri: MIXS:0000179
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_inorg_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, milligram per liter, parts per million
+      Preferred_unit: microgram per liter, milligram per liter, parts per million
     description: Dissolved inorganic carbon concentration in the sample, typically
       measured after filtering the sample using a 0.45 micrometer filter
     title: dissolved inorganic carbon
@@ -5924,16 +5877,14 @@ slots:
     slot_uri: MIXS:0000434
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_inorg_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Concentration of dissolved inorganic nitrogen
     title: dissolved inorganic nitrogen
     examples:
@@ -5945,7 +5896,7 @@ slots:
     slot_uri: MIXS:0000698
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -5962,16 +5913,14 @@ slots:
     slot_uri: MIXS:0000106
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_iron:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Concentration of dissolved iron in the sample
     title: dissolved iron
     keywords:
@@ -5980,18 +5929,16 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_org_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter
-    description: Concentration of dissolved organic carbon in the sample, liquid
-      portion of the sample, or aqueous phase of the fluid
+      Preferred_unit: micromole per liter, milligram per liter
+    description: Concentration of dissolved organic carbon in the sample, liquid portion
+      of the sample, or aqueous phase of the fluid
     title: dissolved organic carbon
     examples:
       - value: 197 micromole per liter
@@ -6002,7 +5949,7 @@ slots:
     slot_uri: MIXS:0000433
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6020,16 +5967,14 @@ slots:
     slot_uri: MIXS:0000162
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_oxygen:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per kilogram, milligram per liter
+      Preferred_unit: micromole per kilogram, milligram per liter
     description: Concentration of dissolved oxygen
     title: dissolved oxygen
     examples:
@@ -6040,16 +5985,14 @@ slots:
     slot_uri: MIXS:0000119
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   diss_oxygen_fluid:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per kilogram, milligram per liter
+      Preferred_unit: micromole per kilogram, milligram per liter
     description: Concentration of dissolved oxygen in the oil field produced fluids
       as it contributes to oxgen-corrosion and microbial activity (e.g. Mic)
     title: dissolved oxygen in fluids
@@ -6059,7 +6002,7 @@ slots:
     slot_uri: MIXS:0000438
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6132,9 +6075,7 @@ slots:
     range: DoorMoveEnum
   door_size:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The size of the door
     title: door area or size
     examples:
@@ -6146,7 +6087,7 @@ slots:
     slot_uri: MIXS:0000158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6173,9 +6114,7 @@ slots:
     range: DoorTypeMetalEnum
   door_type_wood:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The type of wood door
     title: door type, wood
     examples:
@@ -6184,8 +6123,8 @@ slots:
       - door
       - type
     string_serialization: '[bettened and ledged|battened|ledged and braced|battened|ledged
-      and framed|battened|ledged, braced and frame|framed and paneled|glashed or
-      sash|flush|louvered|wire gauged]'
+      and framed|battened|ledged, braced and frame|framed and paneled|glashed or sash|flush|louvered|wire
+      gauged]'
     slot_uri: MIXS:0000797
   door_water_mold:
     description: Signs of the presence of mold or mildew on a door
@@ -6205,10 +6144,8 @@ slots:
     range: datetime
   down_par:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microEinstein per square meter per second, microEinstein per square
-          centimeter per second
+      Preferred_unit: microEinstein per square meter per second, microEinstein per square
+        centimeter per second
     description: Visible waveband radiance and irradiance measurements in the water
       column
     title: downward PAR
@@ -6217,14 +6154,13 @@ slots:
     slot_uri: MIXS:0000703
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   drainage_class:
-    description: Drainage classification from a standard system such as the USDA
-      system
+    description: Drainage classification from a standard system such as the USDA system
     title: drainage classification
     examples:
       - value: well
@@ -6244,9 +6180,7 @@ slots:
     range: DrawingsEnum
   drug_usage:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: drug name;frequency
+      Expected_value: drug name;frequency
     description: Any drug used by subject and the frequency of usage; can include
       multiple drugs used
     title: drug usage
@@ -6260,9 +6194,7 @@ slots:
     multivalued: true
   efficiency_percent:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Percentage of volatile solids removed from the anaerobic digestor
     title: efficiency percent
     keywords:
@@ -6270,16 +6202,14 @@ slots:
     slot_uri: MIXS:0000657
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   elev:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Elevation of the sampling site is its height above a fixed reference
       point, most commonly the mean sea level. Elevation is mainly used when referring
       to points on the earth's surface, while altitude is used for points above the
@@ -6294,7 +6224,7 @@ slots:
     slot_uri: MIXS:0000093
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6310,12 +6240,8 @@ slots:
     range: integer
   emulsions:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: emulsion name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per liter
+      Expected_value: emulsion name;measurement value
+      Preferred_unit: gram per liter
     description: Amount or concentration of substances such as paints, adhesives,
       mayonnaise, hair colorants, emulsified oils, etc.; can include multiple emulsion
       types
@@ -6325,9 +6251,7 @@ slots:
     multivalued: true
   encoded_traits:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for plasmid: antibiotic resistance; for phage: converting genes'
+      Expected_value: 'for plasmid: antibiotic resistance; for phage: converting genes'
     description: Should include key traits like antibiotic resistance or xenobiotic
       degradation phenotypes for plasmids, converting genes for phage
     title: encoded traits
@@ -6335,12 +6259,12 @@ slots:
       - value: beta-lactamase class A
     in_subset:
       - nucleic acid sequence source
-    slot_uri: MIXS:0000034
     range: string
+    slot_uri: MIXS:0000034
   enrichment_protocol:
     description: The microbiological workflow or protocol followed to test for the
-      presence or enumeration of the target microbial analyte(s). Please provide
-      a PubMed or DOI reference for published protocols
+      presence or enumeration of the target microbial analyte(s). Please provide a
+      PubMed or DOI reference for published protocols
     title: enrichment protocol
     examples:
       - value: 'BAM Chapter 4: Enumeration of Escherichia coli and the Coliform Bacteria'
@@ -6349,7 +6273,7 @@ slots:
       - protocol
     slot_uri: MIXS:0001177
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
@@ -6378,10 +6302,8 @@ slots:
       partial_match: true
   env_local_scale:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Environmental entities having causal influences upon the entity at
-          time of sampling
+      Expected_value: Environmental entities having causal influences upon the entity at
+        time of sampling
     description: 'Report the entity or entities which are in the sample or specimen
       s local vicinity and which you believe have significant causal influences on
       your sample or specimen. We recommend using EnvO terms which are of smaller
@@ -6397,18 +6319,17 @@ slots:
     keywords:
       - context
       - environmental
-    slot_uri: MIXS:0000013
-    required: true
-    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
       interpolated: true
       partial_match: true
+    slot_uri: MIXS:0000013
+    required: true
   env_medium:
     description: 'Report the environmental material(s) immediately surrounding the
       sample or specimen at the time of sampling. We recommend using subclasses of
-      ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483).
-      EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS
+      ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO
+      documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS
       . Terms from other OBO ontologies are permissible as long as they reference
       mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities
       (e.g. a tree, a leaf, a table top)'
@@ -6429,16 +6350,14 @@ slots:
       partial_match: true
   env_monitoring_zone:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO
+      Expected_value: ENVO
     description: An environmental monitoring zone is a formal designation as part
       of an environmental monitoring program, in which areas of a food production
       facility are categorized, commonly as zones 1-4, based on likelihood or risk
-      of foodborne pathogen contamination. This field accepts terms listed under
-      food production environmental monitoring zone (http://purl.obolibrary.org/obo/ENVO).
-      Please add a term to indicate the environmental monitoring zone the sample
-      was taken from
+      of foodborne pathogen contamination. This field accepts terms listed under food
+      production environmental monitoring zone (http://purl.obolibrary.org/obo/ENVO).
+      Please add a term to indicate the environmental monitoring zone the sample was
+      taken from
     title: food production environmental monitoring zone
     examples:
       - value: Zone 1
@@ -6446,8 +6365,8 @@ slots:
       - environmental
       - food
       - production
-    slot_uri: MIXS:0001254
     range: string
+    slot_uri: MIXS:0001254
   escalator:
     description: The number of escalators within the built structure
     title: escalator count
@@ -6459,9 +6378,7 @@ slots:
     range: integer
   estimated_size:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: number of base pairs
+      Expected_value: number of base pairs
     description: The estimated size of the genome prior to sequencing. Of particular
       importance in the sequencing of (eukaryotic) genome which could remain in draft
       form for a long or unspecified period
@@ -6476,45 +6393,39 @@ slots:
     slot_uri: MIXS:0000024
   ethnicity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text recommend from Wikipedia list
+      Expected_value: text recommend from Wikipedia list
     description: A category of people who identify with each other, usually on the
       basis of presumed similarities such as a common language, ancestry, history,
       society, culture, nation or social treatment within their residing area. https://en.wikipedia.org/wiki/List_of_contemporary_ethnic_groups
     title: ethnicity
     examples:
       - value: native american
-    slot_uri: MIXS:0000895
     range: string
+    slot_uri: MIXS:0000895
     multivalued: true
   ethylbenzene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of ethylbenzene in the sample
     title: ethylbenzene
     slot_uri: MIXS:0000155
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   exp_duct:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The amount of exposed ductwork in the room
     title: exposed ductwork
     slot_uri: MIXS:0000144
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -6526,16 +6437,14 @@ slots:
       - pipes
     slot_uri: MIXS:0000220
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
       partial_match: true
   experimental_factor:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or EFO and/or OBI
+      Expected_value: text or EFO and/or OBI
     description: Variable aspects of an experiment design that can be used to describe
       an experiment, or set of experiments, in an increasingly detailed manner. This
       field accepts ontology terms from Experimental Factor Ontology (EFO) and/or
@@ -6550,8 +6459,8 @@ slots:
       - factor
     string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000008
-    range: string
     multivalued: true
+    range: string
     pattern: ^\S+.*\S+ \[[a-zA-Z]{2,}:\d+\]$
   ext_door:
     description: The number of exterior doors in the built structure
@@ -6593,8 +6502,8 @@ slots:
       - extreme
       - weather
     slot_uri: MIXS:0001141
-    range: ExtrWeatherEventEnum
     multivalued: true
+    range: ExtrWeatherEventEnum
   extrachrom_elements:
     description: Do plasmids exist of significant phenotypic consequence (e.g. ones
       that determine virulence or antibiotic resistance). Megaplasmids? Other plasmids
@@ -6624,12 +6533,10 @@ slots:
       - facility
       - type
     slot_uri: MIXS:0001252
-    range: FacilityTypeEnum
     multivalued: true
+    range: FacilityTypeEnum
   fao_class:
-    description: Soil classification from the FAO World soil distribution from International
-      Soil Reference and Information Centre (ISRIC). The list of available soil classifications
-      can be found at https://www.isric.org/explore/world-soil-distribution
+    description: Soil classification from the FAO World soil distribution from International Soil Reference and Information Centre (ISRIC). The list of available soil classifications can be found at https://www.isric.org/explore/world-soil-distribution
     title: soil_taxonomic/FAO classification
     examples:
       - value: Luvisols
@@ -6638,11 +6545,10 @@ slots:
     slot_uri: MIXS:0001083
     range: FaoClassEnum
   farm_equip:
-    description: List of equipment used for planting, fertilization, harvesting,
-      irrigation, land levelling, residue management, weeding or transplanting during
-      the growing season.  This field accepts terms listed under agricultural implement
-      (http://purl.obolibrary.org/obo/AGRO_00000416). Multiple terms can be separated
-      by pipes
+    description: List of equipment used for planting, fertilization, harvesting, irrigation,
+      land levelling, residue management, weeding or transplanting during the growing
+      season.  This field accepts terms listed under agricultural implement (http://purl.obolibrary.org/obo/AGRO_00000416).
+      Multiple terms can be separated by pipes
     title: farm equipment used
     examples:
       - value: combine harvester [AGRO:00000473]
@@ -6651,8 +6557,8 @@ slots:
       - farm
       - use
     slot_uri: MIXS:0001126
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -6660,13 +6566,9 @@ slots:
       partial_match: true
   farm_equip_san:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or commercial name of sanitizer or class of sanitizer or active
-          ingredient in sanitizer
-      Preferred_unit:
-        tag: Preferred_unit
-        value: parts per million
+      Expected_value: text or commercial name of sanitizer or class of sanitizer or active
+        ingredient in sanitizer
+      Preferred_unit: parts per million
     description: Method used to sanitize growing and harvesting equipment. This can
       including type and concentration of sanitizing solution.  Multiple terms can
       be separated by one or more pipes
@@ -6702,8 +6604,8 @@ slots:
       - equipment
       - farm
     slot_uri: MIXS:0001123
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -6724,8 +6626,8 @@ slots:
     range: FarmWaterSourceEnum
     recommended: true
   feat_pred:
-    description: Method used to predict UViGs features such as ORFs, integration
-      site, etc
+    description: Method used to predict UViGs features such as ORFs, integration site,
+      etc
     title: feature prediction
     examples:
       - value: Prodigal;2.6.3;default parameters
@@ -6743,9 +6645,7 @@ slots:
       partial_match: true
   ferm_chem_add:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: chemical ingredient
+      Expected_value: chemical ingredient
     description: Any chemicals that are added to the fermentation process to achieve
       the desired final product
     title: fermentation chemical additives
@@ -6755,13 +6655,11 @@ slots:
       - fermentation
     string_serialization: '{float} {unit}'
     slot_uri: MIXS:0001185
-    recommended: true
     multivalued: true
+    recommended: true
   ferm_chem_add_perc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: The amount of chemical added to the fermentation process
     title: fermentation chemical additives percentage
     examples:
@@ -6770,14 +6668,12 @@ slots:
       - fermentation
       - percent
     slot_uri: MIXS:0001186
+    multivalued: true
     range: float
     recommended: true
-    multivalued: true
   ferm_headspace_oxy:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: The amount of headspace oxygen in a fermentation vessel
     title: fermentation headspace oxygen
     examples:
@@ -6790,8 +6686,8 @@ slots:
     recommended: true
   ferm_medium:
     description: The growth medium used for the fermented food fermentation process,
-      which supplies the required nutrients.  Usually this includes a carbon and
-      nitrogen source, water, micronutrients and chemical additives
+      which supplies the required nutrients.  Usually this includes a carbon and nitrogen
+      source, water, micronutrients and chemical additives
     title: fermentation medium
     examples:
       - value: molasses
@@ -6813,9 +6709,7 @@ slots:
     recommended: true
   ferm_rel_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: The relative humidity of the fermented food fermentation process
     title: fermentation relative humidity
     comments:
@@ -6830,16 +6724,14 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ferm_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The temperature of the fermented food fermentation process
     title: fermentation temperature
     examples:
@@ -6851,16 +6743,14 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ferm_time:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days
+      Preferred_unit: days
     description: The time duration of the fermented food fermentation process
     title: fermentation time
     examples:
@@ -6890,8 +6780,8 @@ slots:
     description: Type of fertilizer or amendment added to the soil or water for the
       purpose of improving substrate health and quality for plant growth. This field
       accepts terms listed under agronomic fertilizer (http://purl.obolibrary.org/obo/AGRO_00002062).
-      Multiple terms may apply and can be separated by pipes, listing in reverse
-      chronological order
+      Multiple terms may apply and can be separated by pipes, listing in reverse chronological
+      order
     title: fertilizer administration
     examples:
       - value: fish emulsion [AGRO:00000082]
@@ -6918,16 +6808,12 @@ slots:
     range: datetime
   fertilizer_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: fertilizer name;fertilizer amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Expected_value: fertilizer name;fertilizer amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of fertilizers; should
       include the name of fertilizer, amount administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted,
-      and the start and end time of the entire treatment; can include multiple fertilizer
+      how many times the treatment was repeated, how long each treatment lasted, and
+      the start and end time of the entire treatment; can include multiple fertilizer
       regimens
     title: fertilizer regimen
     examples:
@@ -6944,8 +6830,7 @@ slots:
     range: string
     recommended: true
   filter_type:
-    description: A device which removes solid particulates or airborne molecular
-      contaminants
+    description: A device which removes solid particulates or airborne molecular contaminants
     title: filter type
     examples:
       - value: HEPA
@@ -6953,9 +6838,9 @@ slots:
       - filter
       - type
     slot_uri: MIXS:0000765
+    multivalued: true
     range: FilterTypeEnum
     required: true
-    multivalued: true
   fire:
     description: Historical and/or physical evidence of fire
     title: history/fire
@@ -6981,9 +6866,7 @@ slots:
     range: datetime
   floor_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: years, weeks, days
+      Preferred_unit: years, weeks, days
     description: The time period since installment of the carpet or flooring
     title: floor age
     keywords:
@@ -6992,16 +6875,14 @@ slots:
     slot_uri: MIXS:0000164
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   floor_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The area of the floor space within the room
     title: floor area
     keywords:
@@ -7010,7 +6891,7 @@ slots:
     slot_uri: MIXS:0000165
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7037,9 +6918,7 @@ slots:
     range: integer
   floor_finish_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The floor covering type; the finished surface that is walked on
     title: floor finish material
     examples:
@@ -7063,11 +6942,8 @@ slots:
     range: FloorStrucEnum
   floor_thermal_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: joule per degree Celsius
-    description: The ability of the floor to provide inertia against temperature
-      fluctuations
+      Preferred_unit: joule per degree Celsius
+    description: The ability of the floor to provide inertia against temperature fluctuations
     title: floor thermal mass
     keywords:
       - floor
@@ -7075,7 +6951,7 @@ slots:
     slot_uri: MIXS:0000166
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7091,9 +6967,7 @@ slots:
     range: FloorWaterMoldEnum
   fluor:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram chlorophyll a per cubic meter, volts
+      Preferred_unit: milligram chlorophyll a per cubic meter, volts
     description: Raw or converted fluorescence of water
     title: fluorescence
     examples:
@@ -7101,7 +6975,7 @@ slots:
     slot_uri: MIXS:0000704
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7115,15 +6989,13 @@ slots:
     range: string
   food_additive:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03412972
+      Expected_value: FOODON:03412972
     description: A substance or substances added to food to maintain or improve safety
-      and freshness, to improve or maintain nutritional value, or improve taste,
-      texture and appearance.  This field accepts terms listed under food additive
-      (http://purl.obolibrary.org/obo/FOODON_03412972). Multiple terms can be separated
-      by one or more pipes, but please consider limiting this list to the top 5 ingredients
-      listed in order as on the food label.  See also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
+      and freshness, to improve or maintain nutritional value, or improve taste, texture
+      and appearance.  This field accepts terms listed under food additive (http://purl.obolibrary.org/obo/FOODON_03412972).
+      Multiple terms can be separated by one or more pipes, but please consider limiting
+      this list to the top 5 ingredients listed in order as on the food label.  See
+      also, https://www.fda.gov/food/food-ingredients-packaging/overview-food-ingredients-additives-colors
     title: food additive
     examples:
       - value: xanthan gum [FOODON:03413321]
@@ -7134,9 +7006,7 @@ slots:
     multivalued: true
   food_allergen_label:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03510213
+      Expected_value: FOODON:03510213
     description: A label indication that the product contains a recognized allergen.
       This field accepts terms listed under dietary claim or use (http://purl.obolibrary.org/obo/FOODON_03510213)
     title: food allergen labeling
@@ -7163,9 +7033,7 @@ slots:
     range: FoodCleanProcEnum
   food_contact_surf:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03500010
+      Expected_value: FOODON:03500010
     description: The specific container or coating materials in direct contact with
       the food. Multiple values can be assigned.  This field accepts terms listed
       under food contact surface (http://purl.obolibrary.org/obo/FOODON_03500010)
@@ -7180,9 +7048,7 @@ slots:
     multivalued: true
   food_contain_wrap:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03490100
+      Expected_value: FOODON:03490100
     description: Type of container or wrapping defined by the main container material,
       the container form, and the material of the liner lids or ends. Also type of
       container or wrapping by form; prefer description by material first, then by
@@ -7196,11 +7062,9 @@ slots:
     slot_uri: MIXS:0001132
   food_cooking_proc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03450002
-    description: The transformation of raw food by the application of heat. This
-      field accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
+      Expected_value: FOODON:03450002
+    description: The transformation of raw food by the application of heat. This field
+      accepts terms listed under food cooking (http://purl.obolibrary.org/obo/FOODON_03450002)
     title: food cooking process
     examples:
       - value: food blanching [FOODON:03470175]
@@ -7225,18 +7089,16 @@ slots:
       - geographic
       - location
     slot_uri: MIXS:0001203
-    range: string
     multivalued: true
-    pattern: '^.*: .*, .*$'
+    range: string
+    pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
     structured_pattern:
       syntax: '^{text}: {text}, {text}$'
       interpolated: true
       partial_match: true
   food_dis_point_city:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: GAZ:00000448
+      Expected_value: GAZ:00000448
     description: 'A reference to a place on the Earth, by its name or by its geographical
       location that refers to a distribution point along the food chain. This field
       accepts terms listed under geographic location (http://purl.obolibrary.org/obo/GAZ_00000448).
@@ -7265,13 +7127,11 @@ slots:
       - food
       - process
     slot_uri: MIXS:0001133
-    range: string
     multivalued: true
+    range: string
   food_ingredient:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON
+      Expected_value: FOODON
     description: In this field, please list individual ingredients for multi-component
       food [FOODON:00002501] and simple foods that is not captured in food_type.  Please
       use terms that are present in FoodOn.  Multiple terms can be separated by one
@@ -7287,8 +7147,8 @@ slots:
     slot_uri: MIXS:0001205
     multivalued: true
   food_name_status:
-    description: A datum indicating that use of a food product name is regulated
-      in some legal jurisdiction. This field accepts terms listed under food product
+    description: A datum indicating that use of a food product name is regulated in
+      some legal jurisdiction. This field accepts terms listed under food product
       name legal status (http://purl.obolibrary.org/obo/FOODON_03530087)
     title: food product name legal status
     examples:
@@ -7319,16 +7179,14 @@ slots:
       - product
     slot_uri: MIXS:0001207
     range: string
-    pattern: '^.*: .*, .*$'
+    pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
     structured_pattern:
       syntax: '^{text}: {text}, {text}$'
       interpolated: true
       partial_match: true
   food_pack_capacity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: grams
+      Preferred_unit: grams
     description: The maximum number of product units within a package
     title: food package capacity
     examples:
@@ -7339,16 +7197,14 @@ slots:
     slot_uri: MIXS:0001208
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   food_pack_integrity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03530218
+      Expected_value: FOODON:03530218
     description: A term label and term id to describe the state of the packing material
       and text to explain the exact condition.  This field accepts terms listed under
       food packing medium integrity (http://purl.obolibrary.org/obo/FOODON_03530218)
@@ -7362,17 +7218,15 @@ slots:
     multivalued: true
   food_pack_medium:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03480020
+      Expected_value: FOODON:03480020
     description: The medium in which the food is packed for preservation and handling
       or the medium surrounding homemade foods, e.g., peaches cooked in sugar syrup.
       The packing medium may provide a controlled environment for the food. It may
       also serve to improve palatability and consumer appeal.  This includes edible
       packing media (e.g. fruit juice), gas other than air (e.g. carbon dioxide),
-      vacuum packed, or packed with aerosol propellant. This field accepts terms
-      under food packing medium (http://purl.obolibrary.org/obo/FOODON_03480020).
-      Multiple terms may apply and can be separated by pipes
+      vacuum packed, or packed with aerosol propellant. This field accepts terms under
+      food packing medium (http://purl.obolibrary.org/obo/FOODON_03480020). Multiple
+      terms may apply and can be separated by pipes
     title: food packing medium
     keywords:
       - food
@@ -7381,9 +7235,7 @@ slots:
     multivalued: true
   food_preserv_proc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03470107
+      Expected_value: FOODON:03470107
     description: The methods contributing to the prevention or retardation of microbial,
       enzymatic or oxidative spoilage and thus to the extension of shelf life. This
       field accepts terms listed under food preservation process (http://purl.obolibrary.org/obo/FOODON_03470107)
@@ -7398,14 +7250,12 @@ slots:
     multivalued: true
   food_prior_contact:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03530077
+      Expected_value: FOODON:03530077
     description: The material the food contacted (e.g., was processed in) prior to
-      packaging. This field accepts terms listed under material of contact prior
-      to food packaging (http://purl.obolibrary.org/obo/FOODON_03530077). If the
-      proper descriptor is not listed please use text to describe the material of
-      contact prior to food packaging
+      packaging. This field accepts terms listed under material of contact prior to
+      food packaging (http://purl.obolibrary.org/obo/FOODON_03530077). If the proper
+      descriptor is not listed please use text to describe the material of contact
+      prior to food packaging
     title: material of contact prior to food packaging
     examples:
       - value: processed in stainless steel container [FOODON:03530081]
@@ -7419,10 +7269,9 @@ slots:
   food_prod:
     description: Descriptors of the food production system or of the agricultural
       environment and growing conditions related to the farm production system, such
-      as wild caught, organic, free-range, industrial, dairy, beef,  domestic or
-      cultivated food production. This field accepts terms listed under food production
-      (http://purl.obolibrary.org/obo/FOODON_03530206). Multiple terms may apply
-      and can be separated by pipes
+      as wild caught, organic, free-range, industrial, dairy, beef,  domestic or cultivated
+      food production. This field accepts terms listed under food production (http://purl.obolibrary.org/obo/FOODON_03530206).
+      Multiple terms may apply and can be separated by pipes
     title: food production system characteristics
     examples:
       - value: organic plant cultivation [FOODON:03530253]
@@ -7430,8 +7279,8 @@ slots:
       - food
       - production
     slot_uri: MIXS:0001211
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -7447,8 +7296,8 @@ slots:
       - food
       - production
     slot_uri: MIXS:0001136
-    range: string
     multivalued: true
+    range: string
   food_prod_synonym:
     description: Other names by which the food product is known by (e.g., regional
       or non-English names)
@@ -7459,14 +7308,14 @@ slots:
       - food
       - product
     slot_uri: MIXS:0001212
-    range: string
     multivalued: true
+    range: string
   food_product_qual:
     description: Descriptors for describing food visually or via other senses, which
       is useful for tasks like food inspection where little prior knowledge of how
-      the food came to be is available. Some terms like "food (frozen)" are both
-      a quality descriptor and the output of a process. This field accepts terms
-      listed under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
+      the food came to be is available. Some terms like "food (frozen)" are both a
+      quality descriptor and the output of a process. This field accepts terms listed
+      under food product by quality (http://purl.obolibrary.org/obo/FOODON_00002454)
     title: food product by quality
     examples:
       - value: raw [FOODON:03311126]
@@ -7483,15 +7332,13 @@ slots:
       partial_match: true
   food_product_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:00001002 or FOODON:03309997
+      Expected_value: FOODON:00001002 or FOODON:03309997
     description: A food product type is a class of food products that is differentiated
       by its food composition (e.g., single- or multi-ingredient), processing and/or
-      consumption characteristics. This does not include brand name products but
-      it may include generic food dish categories. This field accepts terms under
-      food product type (http://purl.obolibrary.org/obo/FOODON:03400361). For terms
-      related to food product for an animal, consult food product for animal (http://purl.obolibrary.org/obo/FOODON_03309997).
+      consumption characteristics. This does not include brand name products but it
+      may include generic food dish categories. This field accepts terms under food
+      product type (http://purl.obolibrary.org/obo/FOODON:03400361). For terms related
+      to food product for an animal, consult food product for animal (http://purl.obolibrary.org/obo/FOODON_03309997).
       If the proper descriptor is not listed please use text to describe the food
       type. Multiple terms can be separated by one or more pipes
     title: food product type
@@ -7503,13 +7350,11 @@ slots:
     slot_uri: MIXS:0001184
   food_quality_date:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration, date
+      Expected_value: enumeration, date
     description: The date recommended for the use of the product while at peak quality,
-      this date is not a reflection of safety unless used on infant formula this
-      date is not a reflection of safety and is typically labeled on a food product
-      as "best if used by," best by," "use by," or "freeze by."
+      this date is not a reflection of safety unless used on infant formula this date
+      is not a reflection of safety and is typically labeled on a food product as
+      "best if used by," best by," "use by," or "freeze by."
     title: food quality date
     examples:
       - value: best by 2020-05-24
@@ -7521,9 +7366,7 @@ slots:
     slot_uri: MIXS:0001178
   food_source:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON term
+      Expected_value: FOODON term
     description: Type of plant or animal from which the food product or its major
       ingredient is derived or a chemical food source [FDA CFSAN 1995]
     title: food source
@@ -7534,9 +7377,7 @@ slots:
     slot_uri: MIXS:0001139
   food_source_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days
+      Preferred_unit: days
     description: The age of the food source host organim. Depending on the type of
       host organism, age may be more appropriate to report in days, weeks, or years
     title: food source age
@@ -7551,19 +7392,19 @@ slots:
     slot_uri: MIXS:0001251
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   food_trace_list:
     description: The FDA is proposing to establish additional traceability recordkeeping
-      requirements (beyond what is already required in existing regulations) for
-      persons who manufacture, process, pack, or hold foods the Agency has designated
-      for inclusion on the Food Traceability List. The Food Traceability List (FTL)
-      identifies the foods for which the additional traceability records described
-      in the proposed rule would be required. The term  Food Traceability List  (FTL)
-      refers not only to the foods specifically listed (https://www.fda.gov/media/142303/download),
+      requirements (beyond what is already required in existing regulations) for persons
+      who manufacture, process, pack, or hold foods the Agency has designated for
+      inclusion on the Food Traceability List. The Food Traceability List (FTL) identifies
+      the foods for which the additional traceability records described in the proposed
+      rule would be required. The term  Food Traceability List  (FTL) refers not only
+      to the foods specifically listed (https://www.fda.gov/media/142303/download),
       but also to any foods that contain listed foods as ingredients
     title: food traceability list category
     examples:
@@ -7573,11 +7414,11 @@ slots:
     slot_uri: MIXS:0001214
     range: FoodTraceListEnum
   food_trav_mode:
-    description: A descriptor for the method of movement of food commodity along
-      the food distribution system.  This field accepts terms listed under travel
-      mode (http://purl.obolibrary.org/obo/GENEPIO_0001064). If the proper descrptor
-      is not listed please use text to describe the mode of travel. Multiple terms
-      can be separated by one or more pipes
+    description: A descriptor for the method of movement of food commodity along the
+      food distribution system.  This field accepts terms listed under travel mode
+      (http://purl.obolibrary.org/obo/GENEPIO_0001064). If the proper descrptor is
+      not listed please use text to describe the mode of travel. Multiple terms can
+      be separated by one or more pipes
     title: food shipping transportation method
     examples:
       - value: train travel [GENEPIO:0001060]
@@ -7586,8 +7427,8 @@ slots:
       - method
       - transport
     slot_uri: MIXS:0001137
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -7595,9 +7436,7 @@ slots:
       partial_match: true
   food_trav_vehic:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:01000604
+      Expected_value: ENVO:01000604
     description: A descriptor for the mobile machine which is used to transport food
       commodities along the food distribution system.  This field accepts terms listed
       under vehicle (http://purl.obolibrary.org/obo/ENVO_01000604). If the proper
@@ -7614,9 +7453,7 @@ slots:
     multivalued: true
   food_treat_proc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03460111
+      Expected_value: FOODON:03460111
     description: Used to specifically characterize a food product based on the treatment
       or processes applied to the product or any indexed ingredient. The processes
       include adding, substituting or removing components or modifying the food or
@@ -7649,29 +7486,26 @@ slots:
       - frequency
     slot_uri: MIXS:0000227
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
       partial_match: true
   fungicide_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
-    description: Information about treatment involving use of fungicides; should
-      include the name of fungicide, amount administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted,
-      and the start and end time of the entire treatment; can include multiple fungicide
-      regimens
+      Preferred_unit: gram, mole per liter, milligram per liter
+    description: Information about treatment involving use of fungicides; should include
+      the name of fungicide, amount administered, treatment regimen including how
+      many times the treatment was repeated, how long each treatment lasted, and the
+      start and end time of the entire treatment; can include multiple fungicide regimens
     title: fungicide regimen
     examples:
       - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
       - regimen
     slot_uri: MIXS:0000557
-    range: string
     multivalued: true
+    range: string
   furniture:
     description: The types of furniture present in the sampled room
     title: furniture
@@ -7681,9 +7515,7 @@ slots:
     range: FurnitureEnum
   gaseous_environment:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Use of conditions with differing gaseous environments; should include
       the name of gaseous compound, amount administered, treatment duration, interval
       and total experimental duration; can include multiple gaseous environment regimens
@@ -7693,18 +7525,14 @@ slots:
     keywords:
       - environment
     slot_uri: MIXS:0000558
-    range: string
     multivalued: true
+    range: string
   gaseous_substances:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gaseous substance name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
-    description: Amount or concentration of substances such as hydrogen sulfide,
-      carbon dioxide, methane, etc.; can include multiple substances
+      Expected_value: gaseous substance name;measurement value
+      Preferred_unit: micromole per liter
+    description: Amount or concentration of substances such as hydrogen sulfide, carbon
+      dioxide, methane, etc.; can include multiple substances
     title: gaseous substances
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000661
@@ -7718,8 +7546,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000280
-    range: string
     multivalued: true
+    range: string
   gender_restroom:
     description: The gender type of the restroom
     title: gender of restroom
@@ -7729,9 +7557,7 @@ slots:
     range: GenderRestroomEnum
   genetic_mod:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: PMID, DOI, URL or text
+      Expected_value: PMID, DOI, URL or text
     description: Genetic modifications of the genome of an organism, which may occur
       naturally by spontaneous mutation, or be introduced by some experimental means,
       e.g. specification of a transgene or the gene knocked-out or details of transient
@@ -7742,10 +7568,10 @@ slots:
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000859
   geo_loc_name:
-    description: The geographical origin of the sample as defined by the country
-      or sea name followed by specific region name. Country or sea names should be
-      chosen from the INSDC country list (http://insdc.org/country.html), or the
-      GAZ ontology (http://purl.bioontology.org/ontology/GAZ)
+    description: The geographical origin of the sample as defined by the country or
+      sea name followed by specific region name. Country or sea names should be chosen
+      from the INSDC country list (http://insdc.org/country.html), or the GAZ ontology
+      (http://purl.bioontology.org/ontology/GAZ)
     title: geographic location (country and/or sea,region)
     examples:
       - value: 'USA: Maryland, Bethesda'
@@ -7757,7 +7583,7 @@ slots:
     slot_uri: MIXS:0000010
     range: string
     required: true
-    pattern: '^.*: .*, .*$'
+    pattern: '^([^\s-]{1,2}|[^\s-]+.+[^\s-]+): ([^\s-]{1,2}|[^\s-]+.+[^\s-]+), ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$'
     structured_pattern:
       syntax: '^{text}: {text}, {text}$'
       interpolated: true
@@ -7769,9 +7595,7 @@ slots:
     range: string
   glucosidase_act:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mol per liter per hour
+      Preferred_unit: mol per liter per hour
     description: Measurement of glucosidase activity
     title: glucosidase activity
     examples:
@@ -7779,7 +7603,7 @@ slots:
     slot_uri: MIXS:0000137
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7794,17 +7618,13 @@ slots:
     slot_uri: MIXS:0000875
   gravity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gravity factor value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter per square second, g
+      Expected_value: gravity factor value;treatment interval and duration
+      Preferred_unit: meter per square second, g
     description: Information about treatment involving use of gravity factor to study
       various types of responses in presence, absence or modified levels of gravity;
-      treatment regimen including how many times the treatment was repeated, how
-      long each treatment lasted, and the start and end time of the entire treatment;
-      can include multiple treatments
+      treatment regimen including how many times the treatment was repeated, how long
+      each treatment lasted, and the start and end time of the entire treatment; can
+      include multiple treatments
     title: gravity
     examples:
       - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -7813,12 +7633,10 @@ slots:
     multivalued: true
   growth_facil:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: free text or CO
-    description: 'Type of facility where the sampled plant was grown; controlled
-      vocabulary: growth chamber, open top chamber, glasshouse, experimental garden,
-      field. Alternatively use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
+      Expected_value: free text or CO
+    description: 'Type of facility where the sampled plant was grown; controlled vocabulary:
+      growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively
+      use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
     title: growth facility
     examples:
       - value: Growth chamber [CO_715:0000189]
@@ -7838,17 +7656,13 @@ slots:
     range: GrowthHabitEnum
   growth_hormone_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: growth hormone name;growth hormone amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Expected_value: growth hormone name;growth hormone amount;treatment interval and duration
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of growth hormones; should
-      include the name of growth hormone, amount administered, treatment regimen
-      including how many times the treatment was repeated, how long each treatment
-      lasted, and the start and end time of the entire treatment; can include multiple
-      growth hormone regimens
+      include the name of growth hormone, amount administered, treatment regimen including
+      how many times the treatment was repeated, how long each treatment lasted, and
+      the start and end time of the entire treatment; can include multiple growth
+      hormone regimens
     title: growth hormone regimen
     examples:
       - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -7860,8 +7674,8 @@ slots:
     multivalued: true
   growth_medium:
     description: A liquid or gel containing nutrients, salts, and other factors formulated
-      to support the growth of microorganisms, cells, or plants (National Cancer
-      Institute Thesaurus).  The name of the medium used to grow the microorganism
+      to support the growth of microorganisms, cells, or plants (National Cancer Institute
+      Thesaurus).  The name of the medium used to grow the microorganism
     title: growth medium
     examples:
       - value: LB broth
@@ -7877,8 +7691,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000288
-    range: string
     multivalued: true
+    range: string
   hall_count:
     description: The total count of hallways and cooridors in the built structure
     title: hallway/corridor count
@@ -7908,13 +7722,13 @@ slots:
     range: HcProducedEnum
     required: true
   hcr:
-    description: Main Hydrocarbon Resource type. The term "Hydrocarbon Resource"
-      HCR defined as a natural environmental feature containing large amounts of
-      hydrocarbons at high concentrations potentially suitable for commercial exploitation.
-      This term should not be confused with the Hydrocarbon Occurrence term which
-      also includes hydrocarbon-rich environments with currently limited commercial
-      interest such as seeps, outcrops, gas hydrates etc. If "other" is specified,
-      please propose entry in "additional info" field
+    description: Main Hydrocarbon Resource type. The term "Hydrocarbon Resource" HCR
+      defined as a natural environmental feature containing large amounts of hydrocarbons
+      at high concentrations potentially suitable for commercial exploitation. This
+      term should not be confused with the Hydrocarbon Occurrence term which also
+      includes hydrocarbon-rich environments with currently limited commercial interest
+      such as seeps, outcrops, gas hydrates etc. If "other" is specified, please propose
+      entry in "additional info" field
     title: hydrocarbon resource type
     examples:
       - value: Oil Sand
@@ -7927,9 +7741,7 @@ slots:
     required: true
   hcr_fw_salinity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Original formation water salinity (prior to secondary recovery e.g.
       Waterflooding) expressed as TDS
     title: formation water salinity
@@ -7940,7 +7752,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -7960,9 +7772,7 @@ slots:
     recommended: true
   hcr_pressure:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: atmosphere, kilopascal
+      Preferred_unit: atmosphere, kilopascal
     description: Original pressure of the hydrocarbon resource
     title: hydrocarbon resource original pressure
     keywords:
@@ -7978,9 +7788,7 @@ slots:
       partial_match: true
   hcr_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Original temperature of the hydrocarbon resource
     title: hydrocarbon resource original temperature
     examples:
@@ -8004,9 +7812,9 @@ slots:
     keywords:
       - type
     slot_uri: MIXS:0000766
+    multivalued: true
     range: HeatCoolTypeEnum
     required: true
-    multivalued: true
   heat_deliv_loc:
     description: The location of heat delivery within the room
     title: heating delivery locations
@@ -8037,12 +7845,8 @@ slots:
     range: integer
   heavy_metals:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: heavy metal name;measurement value unit
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per gram
+      Expected_value: heavy metal name;measurement value unit
+      Preferred_unit: microgram per gram
     description: Heavy metals present in the sequenced sample and their concentrations.
       For multiple heavy metals and concentrations, add multiple copies of this field
     title: extreme_unusual_properties/heavy metals
@@ -8072,9 +7876,7 @@ slots:
       partial_match: true
   height_carper_fiber:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter
+      Preferred_unit: centimeter
     description: The average carpet fiber height in the indoor environment
     title: height carpet fiber mat
     keywords:
@@ -8082,29 +7884,27 @@ slots:
     slot_uri: MIXS:0000167
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   herbicide_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of herbicides; information
       about treatment involving use of growth hormones; should include the name of
-      herbicide, amount administered, treatment regimen including how many times
-      the treatment was repeated, how long each treatment lasted, and the start and
-      end time of the entire treatment; can include multiple regimens
+      herbicide, amount administered, treatment regimen including how many times the
+      treatment was repeated, how long each treatment lasted, and the start and end
+      time of the entire treatment; can include multiple regimens
     title: herbicide regimen
     examples:
       - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
     keywords:
       - regimen
     slot_uri: MIXS:0000561
-    range: string
     multivalued: true
+    range: string
   horizon_meth:
     description: Reference or method used in determining the horizon
     title: horizon method
@@ -8120,9 +7920,7 @@ slots:
       partial_match: true
   host_age:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: year, day, hour
+      Preferred_unit: year, day, hour
     description: Age of host at the time of sampling; relevant scale depends on species
       and study, e.g. Could be seconds for amoebae or centuries for trees
     title: host age
@@ -8133,7 +7931,7 @@ slots:
     slot_uri: MIXS:0000255
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8150,9 +7948,7 @@ slots:
     range: string
   host_body_mass_index:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram per square meter
+      Preferred_unit: kilogram per square meter
     description: Body mass index, calculated as weight/(height)squared
     title: host body-mass index
     examples:
@@ -8163,16 +7959,14 @@ slots:
     slot_uri: MIXS:0000317
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_body_product:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FMA or UBERON
+      Expected_value: FMA or UBERON
     description: Substance produced by the body, e.g. Stool, mucus, where the sample
       was obtained from. Use terms from the foundational model of anatomy ontology
       (fma) or Uber-anatomy ontology (UBERON)
@@ -8188,12 +7982,10 @@ slots:
     slot_uri: MIXS:0000888
   host_body_site:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FMA or UBERON
-    description: Name of body site where the sample was obtained from, such as a
-      specific organ or tissue (tongue, lung etc...). Use terms from the foundational
-      model of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
+      Expected_value: FMA or UBERON
+    description: Name of body site where the sample was obtained from, such as a specific
+      organ or tissue (tongue, lung etc...). Use terms from the foundational model
+      of anatomy ontology (fma) or the Uber-anatomy ontology (UBERON)
     title: host body site
     keywords:
       - body
@@ -8203,9 +7995,7 @@ slots:
     slot_uri: MIXS:0000867
   host_body_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Core body temperature of the host when sample was collected
     title: host body temperature
     keywords:
@@ -8216,7 +8006,7 @@ slots:
     slot_uri: MIXS:0000274
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8246,9 +8036,7 @@ slots:
     range: string
   host_common_name:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ''
+      Preferred_unit: ''
     description: Common name of the host
     title: host common name
     keywords:
@@ -8276,16 +8064,14 @@ slots:
       - host
       - host.
     slot_uri: MIXS:0000869
-    range: string
     multivalued: true
+    range: string
   host_disease_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: disease name or Disease Ontology term
+      Expected_value: disease name or Disease Ontology term
     description: List of diseases with which the host has been diagnosed; can include
-      multiple diagnoses. The value of the field depends on host; for humans the
-      terms should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org,
+      multiple diagnoses. The value of the field depends on host; for humans the terms
+      should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org,
       non-human host diseases are free text
     title: host disease status
     in_subset:
@@ -8299,9 +8085,7 @@ slots:
     slot_uri: MIXS:0000031
   host_dry_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Preferred_unit: kilogram, gram
     description: Measurement of dry mass
     title: host dry mass
     examples:
@@ -8314,16 +8098,14 @@ slots:
     slot_uri: MIXS:0000257
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_fam_rel:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: relationship type;arbitrary identifier
+      Expected_value: relationship type;arbitrary identifier
     description: Relationships to other hosts in the same study; can include multiple
       relationships
     title: host family relationship
@@ -8355,16 +8137,14 @@ slots:
       - host.
     slot_uri: MIXS:0000871
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   host_height:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter, millimeter, meter
+      Preferred_unit: centimeter, millimeter, meter
     description: The height of subject
     title: host height
     keywords:
@@ -8374,16 +8154,14 @@ slots:
     slot_uri: MIXS:0000264
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_hiv_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: HIV status;HAART initiation status
+      Expected_value: HIV status;HAART initiation status
     description: HIV status of subject, if yes HAART initiation status should also
       be indicated as [YES or NO]
     title: host HIV status
@@ -8415,9 +8193,7 @@ slots:
     range: string
   host_last_meal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: content;duration
+      Expected_value: content;duration
     description: Content of last meal and time since feeding; can include multiple
       values
     title: host last meal
@@ -8429,9 +8205,7 @@ slots:
     multivalued: true
   host_length:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter, millimeter, meter
+      Preferred_unit: centimeter, millimeter, meter
     description: The length of subject
     title: host length
     examples:
@@ -8443,29 +8217,25 @@ slots:
     slot_uri: MIXS:0000256
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_life_stage:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: stage
+      Expected_value: stage
     description: Description of life stage of host
     title: host life stage
     keywords:
       - host
       - host.
       - life
-    slot_uri: MIXS:0000251
     range: string
+    slot_uri: MIXS:0000251
   host_number:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: count
+      Expected_value: count
     description: Number of symbiotic host individuals pooled at the time of collection
     title: host number individual
     examples:
@@ -8481,8 +8251,8 @@ slots:
     title: host occupation
     comments:
       - Couldn't convert host_occupation with value veterinary to integer
-      - almost all host_occupation values in the NCBI biosample_set are strings,
-        not integers
+      - almost all host_occupation values in the NCBI biosample_set are strings, not
+        integers
     examples:
       - value: veterinary
     keywords:
@@ -8492,9 +8262,7 @@ slots:
     range: string
   host_of_host_coinf:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: species name of coinfecting organism(s)
+      Expected_value: species name of coinfecting organism(s)
     description: The taxonomic name of any coinfecting organism observed in a symbiotic
       relationship with the host of the sampled host organism. e.g. where a sample
       collected from a host trematode species (A) which was collected from a host_of_host
@@ -8510,18 +8278,15 @@ slots:
       - host.
       - observed
       - organism
-    slot_uri: MIXS:0001310
     range: string
+    slot_uri: MIXS:0001310
   host_of_host_disease:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: disease name or Disease Ontology term
+      Expected_value: disease name or Disease Ontology term
     description: List of diseases with which the host of the symbiotic host organism
-      has been diagnosed; can include multiple diagnoses. The value of the field
-      depends on host; for humans the terms should be chosen from the DO (Human Disease
-      Ontology) at https://www.disease-ontology.org, non-human host diseases are
-      free text
+      has been diagnosed; can include multiple diagnoses. The value of the field depends
+      on host; for humans the terms should be chosen from the DO (Human Disease Ontology)
+      at https://www.disease-ontology.org, non-human host diseases are free text
     title: host of the symbiotic host disease status
     examples:
       - value: rabies [DOID:11260]
@@ -8536,16 +8301,13 @@ slots:
     multivalued: true
   host_of_host_env_loc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: UBERON term(s), multiple values can be separated by pipes
+      Expected_value: UBERON term(s), multiple values can be separated by pipes
     description: For a symbiotic host organism the local anatomical environment within
-      its host may have causal influences. Report the anatomical entity(s) which
-      are in the direct environment of the symbiotic host organism being sampled
-      and which you believe have significant causal influences on your sample or
-      specimen. For example, if the symbiotic host organism being sampled is an intestinal
-      worm, its local environmental context will be the term for intestine from UBERON
-      (http://uberon.github.io/)
+      its host may have causal influences. Report the anatomical entity(s) which are
+      in the direct environment of the symbiotic host organism being sampled and which
+      you believe have significant causal influences on your sample or specimen. For
+      example, if the symbiotic host organism being sampled is an intestinal worm,
+      its local environmental context will be the term for intestine from UBERON (http://uberon.github.io/)
     title: host of the symbiotic host local environmental context
     examples:
       - value: small intestine[uberon:0002108]
@@ -8560,10 +8322,7 @@ slots:
     multivalued: true
   host_of_host_env_med:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: An ontology term for a material such as a tissue type or excreted
-          substance
+      Expected_value: An ontology term for a material such as a tissue type or excreted substance
     description: 'Report the environmental material(s) immediately surrounding the
       symbiotic host organism at the time of sampling. This usually will be a tissue
       or substance type from the host, but may be another material if the symbiont
@@ -8587,9 +8346,7 @@ slots:
     slot_uri: MIXS:0001326
   host_of_host_fam_rel:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: relationship type;arbitrary identifier
+      Expected_value: relationship type;arbitrary identifier
     description: Familial relationship of the host of the symbiotic host organisms
       to other hosts of symbiotic host organism in the same study; can include multiple
       relationships
@@ -8614,9 +8371,7 @@ slots:
     range: string
   host_of_host_gravid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gravidity status;timestamp
+      Expected_value: gravidity status;timestamp
     description: Whether or not the host of the symbiotic host organism is gravid,
       and if yes date due or date post-conception, specifying which is used
     title: host of the symbiotic host gravidity
@@ -8637,8 +8392,8 @@ slots:
     slot_uri: MIXS:0001329
     range: string
   host_of_host_infrank:
-    description: Taxonomic rank information about the host of the symbiotic host
-      organism below subspecies level, such as variety, form, rank etc
+    description: Taxonomic rank information about the host of the symbiotic host organism
+      below subspecies level, such as variety, form, rank etc
     title: host of the symbiotic host infra-specific rank
     keywords:
       - host
@@ -8660,9 +8415,7 @@ slots:
     range: string
   host_of_host_pheno:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: phenotype of the host of the symbiotic organism; PATO
+      Expected_value: phenotype of the host of the symbiotic organism; PATO
     description: Phenotype of the host of the symbiotic host organism. For phenotypic
       quality ontology (PATO) terms, see http://purl.bioontology.org/ontology/pato
     title: host of the symbiotic host phenotype
@@ -8687,9 +8440,7 @@ slots:
     range: string
   host_of_host_taxid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCBI taxon identifier of the host of the symbiotic taxon organism
+      Expected_value: NCBI taxon identifier of the host of the symbiotic taxon organism
     description: NCBI taxon id of the host of the symbiotic host organism
     title: host of the symbiotic host taxon id
     examples:
@@ -8715,18 +8466,16 @@ slots:
     slot_uri: MIXS:0001334
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_phenotype:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: PATO or HP
-    description: Phenotype of human or other host. Use terms from the phenotypic
-      quality ontology (pato) or the Human Phenotype Ontology (HP)
+      Expected_value: PATO or HP
+    description: Phenotype of human or other host. Use terms from the phenotypic quality
+      ontology (pato) or the Human Phenotype Ontology (HP)
     title: host phenotype
     keywords:
       - host
@@ -8752,7 +8501,7 @@ slots:
     title: host prediction estimated accuracy
     examples:
       - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
-          genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
+        genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
     in_subset:
       - sequencing
     keywords:
@@ -8763,9 +8512,7 @@ slots:
     range: string
   host_pulse:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: beats per minute
+      Preferred_unit: beats per minute
     description: Resting pulse, measured as beats per minute
     title: host pulse
     examples:
@@ -8776,16 +8523,14 @@ slots:
     slot_uri: MIXS:0000333
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_sex:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Gender or physical sex of the host
     title: host sex
     comments:
@@ -8811,9 +8556,7 @@ slots:
     range: string
   host_spec_range:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCBI taxid
+      Expected_value: NCBI taxid
     description: The range and diversity of host species that an organism is capable
       of infecting, defined by NCBI taxonomy identifier
     title: host specificity or range
@@ -8851,15 +8594,13 @@ slots:
     range: string
   host_subspecf_genlin:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
-          e.g. serovar, biotype, ecotype, variety, cultivar
-    description: Information about the genetic distinctness of the host organism
-      below the subspecies level e.g., serovar, serotype, biotype, ecotype, variety,
-      cultivar, or any relevant genetic typing schemes like Group I plasmid. Subspecies
-      should not be recorded in this term, but in the NCBI taxonomy. Supply both
-      the lineage name and the lineage rank separated by a colon, e.g., biovar:abc123
+      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
+        e.g. serovar, biotype, ecotype, variety, cultivar
+    description: Information about the genetic distinctness of the host organism below
+      the subspecies level e.g., serovar, serotype, biotype, ecotype, variety, cultivar,
+      or any relevant genetic typing schemes like Group I plasmid. Subspecies should
+      not be recorded in this term, but in the NCBI taxonomy. Supply both the lineage
+      name and the lineage rank separated by a colon, e.g., biovar:abc123
     title: host subspecific genetic lineage
     examples:
       - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
@@ -8882,27 +8623,23 @@ slots:
     range: string
   host_symbiont:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: species name or common name
+      Expected_value: species name or common name
     description: The taxonomic name of the organism(s) found living in mutualistic,
-      commensalistic, or parasitic symbiosis with the specific host. The sampled
-      symbiont can have its own symbionts. For example, parasites may have hyperparasites
-      (=parasites of the parasite)
+      commensalistic, or parasitic symbiosis with the specific host. The sampled symbiont
+      can have its own symbionts. For example, parasites may have hyperparasites (=parasites
+      of the parasite)
     title: observed host symbionts
     keywords:
       - host
       - host.
       - observed
       - symbiosis
-    slot_uri: MIXS:0001298
     range: string
+    slot_uri: MIXS:0001298
     multivalued: true
   host_taxid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCBI taxon identifier
+      Expected_value: NCBI taxon identifier
     description: NCBI taxon id of the host, e.g. 9606
     title: host taxid
     keywords:
@@ -8912,9 +8649,7 @@ slots:
     slot_uri: MIXS:0000250
   host_tot_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Preferred_unit: kilogram, gram
     description: Total mass of the host at collection, the unit depends on host
     title: host total mass
     keywords:
@@ -8925,16 +8660,14 @@ slots:
     slot_uri: MIXS:0000263
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   host_wet_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Preferred_unit: kilogram, gram
     description: Measurement of wet mass
     title: host wet mass
     examples:
@@ -8947,7 +8680,7 @@ slots:
     slot_uri: MIXS:0000567
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -8968,24 +8701,20 @@ slots:
     slot_uri: MIXS:0000100
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   humidity_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: humidity value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per cubic meter
+      Expected_value: humidity value;treatment interval and duration
+      Preferred_unit: gram per cubic meter
     description: Information about treatment involving an exposure to varying degree
-      of humidity; information about treatment involving use of growth hormones;
-      should include amount of humidity administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted,
-      and the start and end time of the entire treatment; can include multiple regimens
+      of humidity; information about treatment involving use of growth hormones; should
+      include amount of humidity administered, treatment regimen including how many
+      times the treatment was repeated, how long each treatment lasted, and the start
+      and end time of the entire treatment; can include multiple regimens
     title: humidity regimen
     examples:
       - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -8997,9 +8726,7 @@ slots:
     multivalued: true
   hygienic_area:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Expected value
+      Expected_value: Expected value
     description: The subdivision of areas within a food production facility according
       to hygienic requirements. This field accepts terms listed under hygienic food
       production area (http://purl.obolibrary.org/obo/ENVO). Please add a term that
@@ -9012,8 +8739,8 @@ slots:
       - area
       - food
       - production
-    slot_uri: MIXS:0001253
     range: string
+    slot_uri: MIXS:0001253
   hysterectomy:
     description: Specification of whether hysterectomy was performed
     title: hysterectomy
@@ -9029,8 +8756,8 @@ slots:
     keywords:
       - code
     slot_uri: MIXS:0000884
-    range: integer
     multivalued: true
+    range: integer
   indoor_space:
     description: A distinguishable space within a structure, the purpose for which
       discrete areas of a building is used
@@ -9054,9 +8781,7 @@ slots:
     range: IndoorSurfEnum
   indust_eff_percent:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Percentage of industrial effluents received by wastewater treatment
       plant
     title: industrial effluent percent
@@ -9065,21 +8790,17 @@ slots:
     slot_uri: MIXS:0000662
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   inorg_particles:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: inorganic particle name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mole per liter, milligram per liter
-    description: Concentration of particles such as sand, grit, metal particles,
-      ceramics, etc.; can include multiple particles
+      Expected_value: inorganic particle name;measurement value
+      Preferred_unit: mole per liter, milligram per liter
+    description: Concentration of particles such as sand, grit, metal particles, ceramics,
+      etc.; can include multiple particles
     title: inorganic particles
     keywords:
       - inorganic
@@ -9089,9 +8810,7 @@ slots:
     multivalued: true
   inside_lux:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilowatt per square metre
+      Preferred_unit: kilowatt per square metre
     description: The recorded value at sampling time (power density)
     title: inside lux light
     keywords:
@@ -9100,7 +8819,7 @@ slots:
     slot_uri: MIXS:0000168
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9119,12 +8838,10 @@ slots:
     range: DamagedEnum
   intended_consumer:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON_03510136 or NCBI taxid
-    description: Food consumer type, human or animal, for which the food product
-      is produced and marketed. This field accepts terms listed under food consumer
-      group (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
+      Expected_value: FOODON_03510136 or NCBI taxid
+    description: Food consumer type, human or animal, for which the food product is
+      produced and marketed. This field accepts terms listed under food consumer group
+      (http://purl.obolibrary.org/obo/FOODON_03510136) or NCBI taxid
     title: intended consumer
     examples:
       - value: 9606 o rsenior as food consumer [FOODON:03510254]
@@ -9166,9 +8883,7 @@ slots:
     range: datetime
   iwf:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: Proportion of the produced fluids derived from injected water at
       the time of sampling. (e.g. 87%)
     title: injection water fraction
@@ -9184,7 +8899,7 @@ slots:
     range: float
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9197,8 +8912,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000277
-    range: string
     multivalued: true
+    range: string
   last_clean:
     description: The last time the floor was cleaned (swept, mopped, vacuumed)
     title: last time swept/mopped/vacuumed
@@ -9210,8 +8925,8 @@ slots:
     range: datetime
   lat_lon:
     description: The geographical origin of the sample as defined by latitude and
-      longitude. The values should be reported in decimal degrees, limited to 8 decimal
-      points, and in WGS84 system
+      longitude. The values should be reported in decimal degrees, limited to 8 decimal points,
+      and in WGS84 system
     title: geographic location (latitude and longitude)
     examples:
       - value: 50.586825 6.408977
@@ -9252,9 +8967,7 @@ slots:
     range: integer
   lib_screen:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: screening strategy name
+      Expected_value: screening strategy name
     description: Specific enrichment or screening methods applied before and/or after
       creating libraries
     title: library screening strategy
@@ -9264,8 +8977,8 @@ slots:
       - sequencing
     keywords:
       - library
-    slot_uri: MIXS:0000043
     range: string
+    slot_uri: MIXS:0000043
   lib_size:
     description: Total number of clones in the library prepared for the project
     title: library size
@@ -9280,9 +8993,7 @@ slots:
     range: integer
   lib_vector:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: vector
+      Expected_value: vector
     description: Cloning vector type(s) used in construction of libraries
     title: library vector
     examples:
@@ -9291,13 +9002,11 @@ slots:
       - sequencing
     keywords:
       - library
-    slot_uri: MIXS:0000042
     range: string
+    slot_uri: MIXS:0000042
   library_prep_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name of library preparation kit
+      Expected_value: name of library preparation kit
     description: Packaged kits (containing adapters, indexes, enzymes, buffers etc.),
       tailored for specific sequencing workflows, which allow the simplified preparation
       of sequencing-ready libraries for small genomes, amplicons, and plasmids
@@ -9306,13 +9015,11 @@ slots:
       - kit
       - library
       - preparation
-    slot_uri: MIXS:0001145
     range: string
+    slot_uri: MIXS:0001145
   light_intensity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: lux
+      Preferred_unit: lux
     description: Measurement of light intensity
     title: light intensity
     examples:
@@ -9323,19 +9030,15 @@ slots:
     slot_uri: MIXS:0000706
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   light_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: exposure type;light intensity;light quality
-      Preferred_unit:
-        tag: Preferred_unit
-        value: lux; micrometer, nanometer, angstrom
+      Expected_value: exposure type;light intensity;light quality
+      Preferred_unit: lux; micrometer, nanometer, angstrom
     description: Information about treatment(s) involving exposure to light, including
       both light intensity and quality
     title: light regimen
@@ -9349,8 +9052,8 @@ slots:
   light_type:
     description: Application of light to achieve some practical or aesthetic effect.
       Lighting includes the use of both artificial light sources such as lamps and
-      light fixtures, as well as natural illumination by capturing daylight. Can
-      also include absence of light
+      light fixtures, as well as natural illumination by capturing daylight. Can also
+      include absence of light
     title: light type
     examples:
       - value: desk lamp
@@ -9358,9 +9061,9 @@ slots:
       - light
       - type
     slot_uri: MIXS:0000769
+    multivalued: true
     range: LightTypeEnum
     required: true
-    multivalued: true
   link_addit_analys:
     description: Link to additional analysis results performed on the sample
     title: links to additional analysis
@@ -9375,9 +9078,7 @@ slots:
       partial_match: true
   link_class_info:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: PMID,DOI or url
+      Expected_value: PMID,DOI or url
     description: Link to digitized soil maps or other soil classification information
     title: link to classification information
     keywords:
@@ -9411,26 +9112,24 @@ slots:
     range: LithologyEnum
     recommended: true
   liver_disord:
-    description: History of liver disorders; can include multiple disorders. The
-      terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
+    description: History of liver disorders; can include multiple disorders. The terms
+      should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
       liver disease (https://disease-ontology.org/?id=DOID:409)
     title: liver disorder
     keywords:
       - disorder
     slot_uri: MIXS:0000282
-    range: string
     multivalued: true
+    range: string
   local_class:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: local classification name
+      Expected_value: local classification name
     description: Soil classification based on local soil classification system
     title: soil_taxonomic/local classification
     keywords:
       - classification
-    slot_uri: MIXS:0000330
     range: string
+    slot_uri: MIXS:0000330
   local_class_meth:
     description: Reference or method used in determining the local soil classification
     title: soil_taxonomic/local classification method
@@ -9446,9 +9145,7 @@ slots:
       partial_match: true
   lot_number:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: lot number, item
+      Expected_value: lot number, item
     description: 'A distinctive alpha-numeric identification code assigned by the
       manufacturer or distributor to a specific quantity of manufactured material
       or product within a batch. Synonym: Batch Number.  The submitter should provide
@@ -9476,10 +9173,8 @@ slots:
     range: MagCovSoftwareEnum
   magnesium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mole per liter, milligram per liter, parts per million, micromole
-          per kilogram
+      Preferred_unit: mole per liter, milligram per liter, parts per million, micromole per
+        kilogram
     description: Concentration of magnesium in the sample
     title: magnesium
     examples:
@@ -9487,7 +9182,7 @@ slots:
     slot_uri: MIXS:0000431
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9506,16 +9201,14 @@ slots:
       - maximum
     slot_uri: MIXS:0000229
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
       partial_match: true
   mean_frict_vel:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter per second
+      Preferred_unit: meter per second
     description: Measurement of mean friction velocity
     title: mean friction velocity
     examples:
@@ -9526,16 +9219,14 @@ slots:
     slot_uri: MIXS:0000498
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   mean_peak_frict_vel:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter per second
+      Preferred_unit: meter per second
     description: Measurement of mean peak friction velocity
     title: mean peak friction velocity
     examples:
@@ -9547,7 +9238,7 @@ slots:
     slot_uri: MIXS:0000502
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9561,9 +9252,7 @@ slots:
     range: MechStrucEnum
   mechanical_damage:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: damage type;body site
+      Expected_value: damage type;body site
     description: Information about any mechanical damage exerted on the plant; can
       include multiple damages and sites
     title: mechanical damage
@@ -9597,15 +9286,13 @@ slots:
     range: datetime
   methane:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, parts per billion, parts per million
+      Preferred_unit: micromole per liter, parts per billion, parts per million
     description: Methane (gas) amount or concentration at the time of sampling
     title: methane
     slot_uri: MIXS:0000101
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9642,18 +9329,16 @@ slots:
       - microbiological
     slot_uri: MIXS:0001216
     range: string
-    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   microb_start:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03544453
-    description: Any type of microorganisms used in food production.  This field
-      accepts terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
+      Expected_value: FOODON:03544453
+    description: Any type of microorganisms used in food production.  This field accepts
+      terms listed under live organisms for food production (http://purl.obolibrary.org/obo/FOODON_0344453)
     title: microbial starter
     examples:
       - value: starter cultures [FOODON:03544454]
@@ -9663,21 +9348,16 @@ slots:
     slot_uri: MIXS:0001217
   microb_start_count:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: organism name; measurement value; enumeration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: colony forming units per milliliter; colony forming units per gram
-          of dry weight
+      Expected_value: organism name; measurement value; enumeration
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram
+        of dry weight
     description: 'Total cell count of starter culture per gram, volume or area of
       sample and the method that was used for the enumeration (e.g. qPCR, atp, mpn,
       etc.) should also be provided. (example : total prokaryotes; 3.5e7 cells per
       ml; qPCR)'
     title: microbial starter organism count
     examples:
-      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread
-          plate
+      - value: total prokaryotes;3.5e9 colony forming units per milliliter;spread plate
     keywords:
       - count
       - microbial
@@ -9686,9 +9366,7 @@ slots:
     slot_uri: MIXS:0001218
   microb_start_inoc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram or gram
+      Preferred_unit: milligram or gram
     description: The amount of starter culture used to inoculate a new batch
     title: microbial starter inoculation
     examples:
@@ -9698,7 +9376,7 @@ slots:
     slot_uri: MIXS:0001219
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9746,9 +9424,7 @@ slots:
       partial_match: true
   microbial_biomass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ton, kilogram, gram per kilogram soil
+      Preferred_unit: ton, kilogram, gram per kilogram soil
     description: The part of the organic matter in the soil that constitutes living
       microorganisms smaller than 5-10 micrometer. If you keep this, you would need
       to have correction factors used for conversion to the final units
@@ -9759,7 +9435,7 @@ slots:
     slot_uri: MIXS:0000650
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -9784,18 +9460,14 @@ slots:
       partial_match: true
   mineral_nutr_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: mineral nutrient name;mineral nutrient amount;treatment interval and
-          duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Expected_value: mineral nutrient name;mineral nutrient amount;treatment interval and
+        duration
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the use of mineral supplements;
       should include the name of mineral nutrient, amount administered, treatment
-      regimen including how many times the treatment was repeated, how long each
-      treatment lasted, and the start and end time of the entire treatment; can include
-      multiple mineral nutrient regimens
+      regimen including how many times the treatment was repeated, how long each treatment
+      lasted, and the start and end time of the entire treatment; can include multiple
+      mineral nutrient regimens
     title: mineral nutrient regimen
     examples:
       - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -9808,11 +9480,9 @@ slots:
     multivalued: true
   misc_param:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: parameter name;measurement value
-    description: Any other measurement performed or parameter collected, that is
-      not listed here
+      Expected_value: parameter name;measurement value
+    description: Any other measurement performed or parameter collected, that is not
+      listed here
     title: miscellaneous parameter
     examples:
       - value: Bicarbonate ion concentration;2075 micromole per kilogram
@@ -9832,9 +9502,7 @@ slots:
     recommended: true
   n_alkanes:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: n-alkane name;measurement value
+      Expected_value: n-alkane name;measurement value
     description: Concentration of n-alkanes; can include multiple n-alkanes
     title: n-alkanes
     examples:
@@ -9844,9 +9512,7 @@ slots:
     multivalued: true
   neg_cont_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration or text
+      Expected_value: enumeration or text
     description: The substance or equipment used as a negative control in an investigation
     title: negative control type
     in_subset:
@@ -9858,9 +9524,7 @@ slots:
     recommended: true
   nitrate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of nitrate in the sample
     title: nitrate
     examples:
@@ -9870,16 +9534,14 @@ slots:
     slot_uri: MIXS:0000425
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   nitrite:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of nitrite in the sample
     title: nitrite
     examples:
@@ -9889,16 +9551,14 @@ slots:
     slot_uri: MIXS:0000426
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of nitrogen (total)
     title: nitrogen
     examples:
@@ -9908,16 +9568,14 @@ slots:
     slot_uri: MIXS:0000504
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   non_min_nutr_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving the exposure of plant to non-mineral
       nutrient such as oxygen, hydrogen or carbon; should include the name of non-mineral
       nutrient, amount administered, treatment regimen including how many times the
@@ -9931,20 +9589,20 @@ slots:
       - nutrient
       - regimen
     slot_uri: MIXS:0000571
-    range: string
     multivalued: true
+    range: string
   nose_mouth_teeth_throat_disord:
     description: History of nose/mouth/teeth/throat disorders; can include multiple
-      disorders. The terms should be chosen from the DO (Human Disease Ontology)
-      at http://www.disease-ontology.org, nose disease (https://disease-ontology.org/?id=DOID:2825),
+      disorders. The terms should be chosen from the DO (Human Disease Ontology) at
+      http://www.disease-ontology.org, nose disease (https://disease-ontology.org/?id=DOID:2825),
       mouth disease (https://disease-ontology.org/?id=DOID:403), tooth disease (https://disease-ontology.org/?id=DOID:1091),
       or upper respiratory tract disease (https://disease-ontology.org/?id=DOID:974)
     title: nose/mouth/teeth/throat disorder
     keywords:
       - disorder
     slot_uri: MIXS:0000283
-    range: string
     multivalued: true
+    range: string
   nose_throat_disord:
     description: History of nose-throat disorders; can include multiple disorders,  The
       terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
@@ -9954,8 +9612,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000270
-    range: string
     multivalued: true
+    range: string
   nucl_acid_amp:
     description: A link to a literature reference, electronic resource or a standard
       operating procedure (SOP), that describes the enzymatic amplification (PCR,
@@ -9990,24 +9648,20 @@ slots:
       partial_match: true
   nucl_acid_ext_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: The name of an extraction kit
-    description: The name of the extraction kit used to recover the nucleic acid
-      fraction of an input material is performed
+      Expected_value: The name of an extraction kit
+    description: The name of the extraction kit used to recover the nucleic acid fraction
+      of an input material is performed
     title: nucleic acid extraction kit
     examples:
       - value: Qiagen PowerSoil Kit
     keywords:
       - kit
-    slot_uri: MIXS:0001223
     range: string
+    slot_uri: MIXS:0001223
     multivalued: true
   num_replicons:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses:
+      Expected_value: 'for eukaryotes and bacteria: chromosomes (haploid count); for viruses:
           segments'
     description: Reports the number of replicons in a nuclear genome of eukaryotes,
       in the genome of a bacterium or archaea or the number of segments in a segmented
@@ -10033,7 +9687,7 @@ slots:
     slot_uri: MIXS:0001224
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10057,7 +9711,7 @@ slots:
       - number
     slot_uri: MIXS:0000231
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -10069,7 +9723,7 @@ slots:
       - number
     slot_uri: MIXS:0000230
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -10081,7 +9735,7 @@ slots:
       - number
     slot_uri: MIXS:0000232
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -10113,7 +9767,7 @@ slots:
     slot_uri: MIXS:0000772
     range: float
     required: true
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -10129,26 +9783,22 @@ slots:
     slot_uri: MIXS:0000508
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   org_count_qpcr_info:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
-          denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
-          elongation:degrees_minutes; total cycles
-      Preferred_unit:
-        tag: Preferred_unit
-        value: number of cells per gram (or ml or cm^2)
-    description: 'If qpcr was used for the cell count, the target gene name, the
-      primer sequence and the cycling conditions should also be provided. (Example:
-      16S rrna; FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min;
-      denaturation:90C_2min; annealing:52C_30 sec; elongation:72C_30 sec; 90 C for
-      1 min; final elongation:72C_5min; 30 cycles)'
+      Expected_value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial
+        denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
+        elongation:degrees_minutes; total cycles
+      Preferred_unit: number of cells per gram (or ml or cm^2)
+    description: 'If qpcr was used for the cell count, the target gene name, the primer
+      sequence and the cycling conditions should also be provided. (Example: 16S rrna;
+      FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min; denaturation:90C_2min;
+      annealing:52C_30 sec; elongation:72C_30 sec; 90 C for 1 min; final elongation:72C_5min;
+      30 cycles)'
     title: organism count qPCR information
     keywords:
       - count
@@ -10159,9 +9809,7 @@ slots:
     slot_uri: MIXS:0000099
   org_matter:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter
+      Preferred_unit: microgram per liter
     description: Concentration of organic matter
     title: organic matter
     examples:
@@ -10171,7 +9819,7 @@ slots:
     slot_uri: MIXS:0000204
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10187,19 +9835,15 @@ slots:
     slot_uri: MIXS:0000205
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   org_particles:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: particle name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per liter
+      Expected_value: particle name;measurement value
+      Preferred_unit: gram per liter
     description: Concentration of particles such as faeces, hairs, food, vomit, paper
       fibers, plant material, humus, etc
     title: organic particles
@@ -10211,9 +9855,7 @@ slots:
     multivalued: true
   organism_count:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: organism name;measurement value;enumeration
+      Expected_value: organism name;measurement value;enumeration
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
       The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should
@@ -10227,13 +9869,11 @@ slots:
     multivalued: true
   otu_class_appr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: cutoffs and method used
-    description: Cutoffs and approach used when clustering  species-level  OTUs.
-      Note that results from standard 95% ANI / 85% AF clustering should be provided
-      alongside OTUS defined from another set of thresholds, even if the latter are
-      the ones primarily used during the analysis
+      Expected_value: cutoffs and method used
+    description: Cutoffs and approach used when clustering  species-level  OTUs. Note
+      that results from standard 95% ANI / 85% AF clustering should be provided alongside
+      OTUS defined from another set of thresholds, even if the latter are the ones
+      primarily used during the analysis
     title: OTU classification approach
     examples:
       - value: 95% ANI;85% AF; greedy incremental clustering
@@ -10246,11 +9886,9 @@ slots:
     slot_uri: MIXS:0000085
   otu_db:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: database and version
-    description: Reference database (i.e. sequences not generated as part of the
-      current study) used to cluster new genomes in "species-level" OTUs, if any
+      Expected_value: database and version
+    description: Reference database (i.e. sequences not generated as part of the current
+      study) used to cluster new genomes in "species-level" OTUs, if any
     title: OTU database
     examples:
       - value: NCBI Viral RefSeq;83
@@ -10263,9 +9901,7 @@ slots:
     slot_uri: MIXS:0000087
   otu_seq_comp_appr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: software name, version and relevant parameters
+      Expected_value: software name, version and relevant parameters
     description: Tool and thresholds used to compare sequences when computing "species-level"
       OTUs
     title: OTU sequence comparison approach
@@ -10279,11 +9915,8 @@ slots:
     slot_uri: MIXS:0000086
   owc_tvdss:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
-    description: Depth of the original oil water contact (OWC) zone (average) (m
-      TVDSS)
+      Preferred_unit: meter
+    description: Depth of the original oil water contact (OWC) zone (average) (m TVDSS)
     title: oil water contact depth
     keywords:
       - depth
@@ -10292,7 +9925,7 @@ slots:
     slot_uri: MIXS:0000405
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10310,9 +9943,7 @@ slots:
     range: OxyStatSampEnum
   oxygen:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Oxygen (gas) amount or concentration at the time of sampling
     title: oxygen
     examples:
@@ -10322,7 +9953,7 @@ slots:
     slot_uri: MIXS:0000104
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10340,16 +9971,14 @@ slots:
     slot_uri: MIXS:0000515
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   part_org_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Concentration of particulate organic nitrogen
     title: particulate organic nitrogen
     examples:
@@ -10362,16 +9991,14 @@ slots:
     slot_uri: MIXS:0000719
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   part_plant_animal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03420116
+      Expected_value: FOODON:03420116
     description: The anatomical part of the organism being involved in food production
       or consumption; e.g., a carrot is the root of the plant (root vegetable). This
       field accepts terms listed under part of plant or animal (http://purl.obolibrary.org/obo/FOODON_03420116)
@@ -10386,16 +10013,11 @@ slots:
     multivalued: true
   particle_class:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: particle name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micrometer
-    description: Particles are classified, based on their size, into six general
-      categories:clay, silt, sand, gravel, cobbles, and boulders; should include
-      amount of particle preceded by the name of the particle type; can include multiple
-      values
+      Expected_value: particle name;measurement value
+      Preferred_unit: micrometer
+    description: Particles are classified, based on their size, into six general categories:clay,
+      silt, sand, gravel, cobbles, and boulders; should include amount of particle
+      preceded by the name of the particle type; can include multiple values
     title: particle classification
     keywords:
       - classification
@@ -10405,25 +10027,20 @@ slots:
     multivalued: true
   pathogenicity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names of organisms that the entity is pathogenic to
+      Expected_value: names of organisms that the entity is pathogenic to
     description: To what is the entity pathogenic
     title: known pathogenicity
     examples:
       - value: human, animal, plant, fungi, bacteria
     in_subset:
       - nucleic acid sequence source
-    slot_uri: MIXS:0000027
     range: string
+    slot_uri: MIXS:0000027
   pcr_cond:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
-          elongation:degrees_minutes;total cycles
-    description: Description of reaction conditions and components of polymerase
-      chain reaction performed during library preparation.
+      Expected_value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final
+        elongation:degrees_minutes;total cycles
+    description: Description of reaction conditions and components of polymerase chain reaction performed during library preparation.
     title: pcr conditions
     examples:
       - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
@@ -10438,14 +10055,11 @@ slots:
     slot_uri: MIXS:0000049
   pcr_primers:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'FWD: forward primer sequence;REV:reverse primer sequence'
+      Expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
     description: PCR primers that were used to amplify the sequence of the targeted
-      gene, locus or subfragment. This field should contain all the primers used
-      for a single PCR reaction if multiple forward or reverse primers are present
-      in a single PCR reaction. The primer sequence should be reported in uppercase
-      letters
+      gene, locus or subfragment. This field should contain all the primers used for
+      a single PCR reaction if multiple forward or reverse primers are present in
+      a single PCR reaction. The primer sequence should be reported in uppercase letters
     title: pcr primers
     examples:
       - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
@@ -10457,12 +10071,8 @@ slots:
     slot_uri: MIXS:0000046
   permeability:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value range
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mD
+      Expected_value: measurement value range
+      Preferred_unit: mD
     description: 'Measure of the ability of a hydrocarbon resource to allow fluids
       to pass through it. (Additional information: https://en.wikipedia.org/wiki/Permeability_(earth_sciences))'
     title: permeability
@@ -10470,9 +10080,7 @@ slots:
     slot_uri: MIXS:0000404
   perturbation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: perturbation type name;perturbation interval and duration
+      Expected_value: perturbation type name;perturbation interval and duration
     description: Type of perturbation, e.g. chemical administration, physical disturbance,
       etc., coupled with perturbation regimen including how many times the perturbation
       was repeated, how long each perturbation lasted, and the start and end time
@@ -10487,13 +10095,11 @@ slots:
     multivalued: true
   pesticide_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter
+      Preferred_unit: gram, mole per liter, milligram per liter
     description: Information about treatment involving use of insecticides; should
       include the name of pesticide, amount administered, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted,
-      and the start and end time of the entire treatment; can include multiple pesticide
+      how many times the treatment was repeated, how long each treatment lasted, and
+      the start and end time of the entire treatment; can include multiple pesticide
       regimens
     title: pesticide regimen
     examples:
@@ -10501,13 +10107,11 @@ slots:
     keywords:
       - regimen
     slot_uri: MIXS:0000573
-    range: string
     multivalued: true
+    range: string
   pet_farm_animal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: presence status;type of animal or pet
+      Expected_value: presence status;type of animal or pet
     description: Specification of presence of pets or farm animals in the environment
       of subject, if yes the animals should be specified; can include multiple animals
       present
@@ -10523,9 +10127,7 @@ slots:
     multivalued: true
   petroleum_hydrocarb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of petroleum hydrocarbon
     title: petroleum hydrocarbon
     examples:
@@ -10536,7 +10138,7 @@ slots:
     slot_uri: MIXS:0000516
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10578,16 +10180,12 @@ slots:
       - ph
       - regimen
     slot_uri: MIXS:0001056
-    range: string
     multivalued: true
+    range: string
   phaeopigments:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: phaeopigment name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter
+      Expected_value: phaeopigment name;measurement value
+      Preferred_unit: milligram per cubic meter
     description: Concentration of phaeopigments; can include multiple phaeopigments
     title: phaeopigments
     examples:
@@ -10597,9 +10195,7 @@ slots:
     multivalued: true
   phosphate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of phosphate
     title: phosphate
     examples:
@@ -10609,18 +10205,15 @@ slots:
     slot_uri: MIXS:0000505
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   phosplipid_fatt_acid:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: phospholipid fatty acid name;measurement value
-    description: Concentration of phospholipid fatty acids; can include multiple
-      values
+      Expected_value: phospholipid fatty acid name;measurement value
+    description: Concentration of phospholipid fatty acids; can include multiple values
     title: phospholipid fatty acid
     examples:
       - value: 2.98 milligram per liter
@@ -10629,9 +10222,7 @@ slots:
     multivalued: true
   photon_flux:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: number of photons per second per unit area
+      Preferred_unit: number of photons per second per unit area
     description: Measurement of photon flux
     title: photon flux
     examples:
@@ -10639,19 +10230,17 @@ slots:
     slot_uri: MIXS:0000725
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   photosynt_activ:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: mol m-2 s-1
-    description: Measurement of photosythetic activity (i.e. leaf gas exchange /
-      chlorophyll fluorescence emissions / reflectance / transpiration) Please also
-      include the term method term detailing the method of activity measurement
+      Preferred_unit: mol m-2 s-1
+    description: Measurement of photosythetic activity (i.e. leaf gas exchange / chlorophyll
+      fluorescence emissions / reflectance / transpiration) Please also include the
+      term method term detailing the method of activity measurement
     title: photosynthetic activity
     examples:
       - value: 0.1 mol CO2 m-2 s-1
@@ -10661,7 +10250,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10672,19 +10261,17 @@ slots:
     keywords:
       - method
     slot_uri: MIXS:0001336
+    multivalued: true
     range: string
     recommended: true
-    multivalued: true
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   plant_growth_med:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: EO or enumeration
+      Expected_value: EO or enumeration
     description: Specification of the media for growing the plants or tissue cultured
       samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in
       vitro liquid culture medium. Recommended value is a specific value from EO:plant
@@ -10699,9 +10286,7 @@ slots:
     slot_uri: MIXS:0001057
   plant_part_maturity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: FOODON:03530050
+      Expected_value: FOODON:03530050
     description: A description of the stage of development of a plant or plant part
       based on maturity or ripeness. This field accepts terms listed under degree
       of plant maturity (http://purl.obolibrary.org/obo/FOODON_03530050)
@@ -10715,9 +10300,7 @@ slots:
     slot_uri: MIXS:0001120
   plant_product:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: product name
+      Expected_value: product name
     description: Substance produced by the plant, where the sample was obtained from
     title: plant product
     examples:
@@ -10725,8 +10308,8 @@ slots:
     keywords:
       - plant
       - product
-    slot_uri: MIXS:0001058
     range: string
+    slot_uri: MIXS:0001058
   plant_reprod_crop:
     description: Plant reproductive part used in the field during planting to start
       the crop
@@ -10736,8 +10319,8 @@ slots:
     keywords:
       - plant
     slot_uri: MIXS:0001150
-    range: PlantReprodCropEnum
     multivalued: true
+    range: PlantReprodCropEnum
   plant_sex:
     description: Sex of the reproductive parts on the whole plant, e.g. pistillate,
       staminate, monoecieous, hermaphrodite
@@ -10749,8 +10332,8 @@ slots:
     slot_uri: MIXS:0001059
     range: PlantSexEnum
   plant_struc:
-    description: Name of plant structure the sample was obtained from; for Plant
-      Ontology (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO,
+    description: Name of plant structure the sample was obtained from; for Plant Ontology
+      (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO,
       e.g. petiole epidermis (PO_0000051). If an individual flower is sampled, the
       sex of it can be recorded here
     title: plant structure
@@ -10766,8 +10349,8 @@ slots:
       interpolated: true
       partial_match: true
   plant_water_method:
-    description: Description of the equipment or method used to distribute water
-      to crops. This field accepts termed listed under irrigation process (http://purl.obolibrary.org/obo/AGRO_00000006).
+    description: Description of the equipment or method used to distribute water to
+      crops. This field accepts termed listed under irrigation process (http://purl.obolibrary.org/obo/AGRO_00000006).
       Multiple terms can be separated by pipes
     title: plant water delivery method
     examples:
@@ -10806,12 +10389,8 @@ slots:
       partial_match: true
   pollutants:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: pollutant name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, mole per liter, milligram per liter, microgram per cubic meter
+      Expected_value: pollutant name;measurement value
+      Preferred_unit: gram, mole per liter, milligram per liter, microgram per cubic meter
     description: Pollutant types and, amount or concentrations measured at the time
       of sampling; can report multiple pollutants by entering numeric values preceded
       by name of pollutant
@@ -10823,12 +10402,8 @@ slots:
     multivalued: true
   pool_dna_extracts:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: pooling status;number of pooled extracts
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, milliliter, microliter
+      Expected_value: pooling status;number of pooled extracts
+      Preferred_unit: gram, milliliter, microliter
     description: Indicate whether multiple DNA extractions were mixed. If the answer
       yes, the number of extracts that were pooled should be given
     title: pooling of DNA extracts (if done)
@@ -10840,12 +10415,8 @@ slots:
     slot_uri: MIXS:0000325
   porosity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value or range
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Expected_value: measurement value or range
+      Preferred_unit: percentage
     description: Porosity of deposited sediment is volume of voids divided by the
       total volume of sample
     title: porosity
@@ -10866,9 +10437,7 @@ slots:
     recommended: true
   potassium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of potassium in the sample
     title: potassium
     examples:
@@ -10876,39 +10445,35 @@ slots:
     slot_uri: MIXS:0000430
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   pour_point:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
-    description: 'Temperature at which a liquid becomes semi solid and loses its
-      flow characteristics. In crude oil a high  pour point  is generally associated
-      with a high paraffin content, typically found in crude deriving from a larger
-      proportion of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
+      Preferred_unit: degree Celsius
+    description: 'Temperature at which a liquid becomes semi solid and loses its flow
+      characteristics. In crude oil a high  pour point  is generally associated with
+      a high paraffin content, typically found in crude deriving from a larger proportion
+      of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
     title: pour point
     slot_uri: MIXS:0000127
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   pre_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: pre-treatment type
+      Expected_value: pre-treatment type
     description: The process of pre-treatment removes materials that can be easily
       collected from the raw wastewater
     title: pre-treatment
-    slot_uri: MIXS:0000348
     range: string
+    slot_uri: MIXS:0000348
   pred_genome_struc:
     description: Expected structure of the viral genome
     title: predicted genome structure
@@ -10922,9 +10487,7 @@ slots:
     range: PredGenomeStrucEnum
   pred_genome_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Type of genome predicted for the UViG
     title: predicted genome type
     examples:
@@ -10945,9 +10508,7 @@ slots:
     range: datetime
   pres_animal_insect:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration;count
+      Expected_value: enumeration;count
     description: The type and number of animals or insects present in the sampling
       space
     title: presence of pets, animals, or insects
@@ -10960,9 +10521,7 @@ slots:
     slot_uri: MIXS:0000819
   pressure:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: atmosphere
+      Preferred_unit: atmosphere
     description: Pressure to which the sample is subject to, in atmospheres
     title: pressure
     examples:
@@ -10972,7 +10531,7 @@ slots:
     slot_uri: MIXS:0000412
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -10994,9 +10553,7 @@ slots:
       partial_match: true
   previous_land_use:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: land use name;date
+      Expected_value: land use name;date
     description: Previous land use and dates
     title: history/previous land use
     examples:
@@ -11009,9 +10566,7 @@ slots:
     slot_uri: MIXS:0000315
   primary_prod:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per cubic meter per day, gram per square meter per day
+      Preferred_unit: milligram per cubic meter per day, gram per square meter per day
     description: Measurement of primary production, generally measured as isotope
       uptake
     title: primary production
@@ -11023,16 +10578,14 @@ slots:
     slot_uri: MIXS:0000728
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   primary_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: primary treatment type
+      Expected_value: primary treatment type
     description: The process to produce both a generally homogeneous liquid capable
       of being treated biologically and a sludge that can be separately treated or
       processed
@@ -11040,25 +10593,23 @@ slots:
     keywords:
       - primary
       - treatment
-    slot_uri: MIXS:0000349
     range: string
+    slot_uri: MIXS:0000349
   prod_label_claims:
     description: Labeling claims containing descriptors such as wild caught, free-range,
-      organic, free-range, industrial, hormone-free, antibiotic free, cage free.
-      Can include more than one term, separated by ";"
+      organic, free-range, industrial, hormone-free, antibiotic free, cage free. Can
+      include more than one term, separated by ";"
     title: production labeling claims
     examples:
       - value: free range
     keywords:
       - production
     slot_uri: MIXS:prod_label_claims
-    range: string
     multivalued: true
+    range: string
   prod_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per day
+      Preferred_unit: cubic meter per day
     description: Oil and/or gas production rates per well (e.g. 524 m3 / day)
     title: production rate
     keywords:
@@ -11068,7 +10619,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11107,9 +10658,7 @@ slots:
     required: true
   propagation:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid:
+      Expected_value: 'for virus: lytic, lysogenic, temperate, obligately lytic; for plasmid:
           incompatibility group; for eukaryote: asexual, sexual; other more specific
           values (e.g., incompatibility group) are allowed'
     description: 'The type of reproduction from the parent stock. Values for this
@@ -11120,18 +10669,18 @@ slots:
       - value: lytic
     in_subset:
       - nucleic acid sequence source
-    slot_uri: MIXS:0000033
     range: string
+    slot_uri: MIXS:0000033
   pulmonary_disord:
-    description: History of pulmonary disorders; can include multiple disorders.
-      The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
+    description: History of pulmonary disorders; can include multiple disorders. The
+      terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
       lung disease (https://disease-ontology.org/?id=DOID:850)
     title: lung/pulmonary disorder
     keywords:
       - disorder
     slot_uri: MIXS:0000269
-    range: string
     multivalued: true
+    range: string
   quad_pos:
     description: The quadrant position of the sampling room within the building
     title: quadrant position
@@ -11141,17 +10690,13 @@ slots:
     range: QuadPosEnum
   radiation_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: radiation type name;radiation amount;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: rad, gray
+      Expected_value: radiation type name;radiation amount;treatment interval and duration
+      Preferred_unit: rad, gray
     description: Information about treatment involving exposure of plant or a plant
-      part to a particular radiation regimen; should include the radiation type,
-      amount or intensity administered, treatment regimen including how many times
-      the treatment was repeated, how long each treatment lasted, and the start and
-      end time of the entire treatment; can include multiple radiation regimens
+      part to a particular radiation regimen; should include the radiation type, amount
+      or intensity administered, treatment regimen including how many times the treatment
+      was repeated, how long each treatment lasted, and the start and end time of
+      the entire treatment; can include multiple radiation regimens
     title: radiation regimen
     examples:
       - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -11162,12 +10707,8 @@ slots:
     multivalued: true
   rainfall_regm:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;treatment interval and duration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter
+      Expected_value: measurement value;treatment interval and duration
+      Preferred_unit: millimeter
     description: Information about treatment involving an exposure to a given amount
       of rainfall, treatment regimen including how many times the treatment was repeated,
       how long each treatment lasted, and the start and end time of the entire treatment;
@@ -11183,20 +10724,18 @@ slots:
     multivalued: true
   reactor_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: reactor type name
+      Expected_value: reactor type name
     description: Anaerobic digesters can be designed and engineered to operate using
       a number of different process configurations, as batch or continuous, mesophilic,
       high solid or low solid, and single stage or multistage
     title: reactor type
     keywords:
       - type
-    slot_uri: MIXS:0000350
     range: string
+    slot_uri: MIXS:0000350
   reassembly_bin:
-    description: Has an assembly been performed on a genome bin extracted from a
-      metagenomic assembly?
+    description: Has an assembly been performed on a genome bin extracted from a metagenomic
+      assembly?
     title: reassembly post binning
     examples:
       - value: 'no'
@@ -11208,9 +10747,7 @@ slots:
     range: boolean
   redox_potential:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millivolt
+      Preferred_unit: millivolt
     description: Redox potential, measured relative to a hydrogen cell, indicating
       oxidation or reduction potential
     title: redox potential
@@ -11219,7 +10756,7 @@ slots:
     slot_uri: MIXS:0000182
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11241,11 +10778,9 @@ slots:
       partial_match: true
   ref_db:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: names, versions, and references of databases
-    description: List of database(s) used for ORF annotation, along with version
-      number and reference to website or publication
+      Expected_value: names, versions, and references of databases
+    description: List of database(s) used for ORF annotation, along with version number
+      and reference to website or publication
     title: reference database(s)
     examples:
       - value: pVOGs;5;http://dmk-brain.ecn.uiowa.edu/pVOGs/ Grazziotin et al. 2017
@@ -11258,9 +10793,7 @@ slots:
     slot_uri: MIXS:0000062
   rel_air_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: Partial vapor and air pressure, density of the vapor and air, or
       by the actual mass of the vapor and air
     title: relative air humidity
@@ -11276,16 +10809,14 @@ slots:
     range: float
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   rel_humidity_out:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram of air, kilogram of air
+      Preferred_unit: gram of air, kilogram of air
     description: The recorded outside relative humidity value at the time of sampling
     title: outside relative humidity
     examples:
@@ -11296,7 +10827,7 @@ slots:
     slot_uri: MIXS:0000188
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -11338,17 +10869,15 @@ slots:
     range: RelToOxygenEnum
   repository_name:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Institution
+      Expected_value: Institution
     description: The name of the institution where the sample or DNA extract is held
       or "sample not available" if the sample was used in its entirety for analysis
       or otherwise not retained
     title: repository name
     examples:
       - value: FDA CFSAN Microbiology Laboratories
-    slot_uri: MIXS:0001152
     range: string
+    slot_uri: MIXS:0001152
     multivalued: true
   reservoir:
     description: Name of the reservoir (e.g. Carapebus)
@@ -11358,28 +10887,24 @@ slots:
     recommended: true
   resins_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
-      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
+      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: resins wt%
     slot_uri: MIXS:0000134
     range: string
     recommended: true
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   room_air_exch_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: liter per hour
+      Preferred_unit: liter per hour
     description: The rate at which outside air replaces indoor air in a given space
     title: room air exchange rate
     keywords:
@@ -11389,14 +10914,14 @@ slots:
     slot_uri: MIXS:0000169
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   room_architec_elem:
-    description: The unique details and component parts that, together, form the
-      architecture of a distinguisahable space within a built structure
+    description: The unique details and component parts that, together, form the architecture
+      of a distinguisahable space within a built structure
     title: room architectural elements
     keywords:
       - room
@@ -11433,12 +10958,8 @@ slots:
     range: integer
   room_dim:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: measurement value
+      Preferred_unit: meter
     description: The length, width and height of sampling room
     title: room dimensions
     examples:
@@ -11450,9 +10971,7 @@ slots:
     slot_uri: MIXS:0000192
   room_door_dist:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Distance between doors (meters) in the hallway between the sampling
       room and adjacent rooms
     title: room door distance
@@ -11462,7 +10981,7 @@ slots:
       - room
     slot_uri: MIXS:0000193
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11517,9 +11036,7 @@ slots:
     range: integer
   room_net_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square feet, square meter
+      Preferred_unit: square feet, square meter
     description: The net floor area of sampling room. Net area excludes wall thicknesses
     title: room net area
     keywords:
@@ -11527,7 +11044,7 @@ slots:
       - room
     slot_uri: MIXS:0000194
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11539,7 +11056,7 @@ slots:
       - room
     slot_uri: MIXS:0000236
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11556,9 +11073,7 @@ slots:
     range: RoomSampPosEnum
   room_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The main purpose or activity of the sampling room. A room is any
       distinguishable space within a structure
     title: room type
@@ -11573,9 +11088,7 @@ slots:
     slot_uri: MIXS:0000825
   room_vol:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic feet, cubic meter
+      Preferred_unit: cubic feet, cubic meter
     description: Volume of sampling room
     title: room volume
     keywords:
@@ -11583,7 +11096,7 @@ slots:
       - volume
     slot_uri: MIXS:0000195
     range: string
-    pattern: ^[1-9][0-9]* .*$
+    pattern: ^[1-9][0-9]* ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{integer} {text}$
       interpolated: true
@@ -11621,19 +11134,15 @@ slots:
       - condition
     slot_uri: MIXS:0001061
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   root_med_carbon:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: carbon source name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: carbon source name;measurement value
+      Preferred_unit: milligram per liter
     description: Source of organic carbon in the culture rooting medium; e.g. sucrose
     title: rooting medium carbon
     examples:
@@ -11644,12 +11153,8 @@ slots:
     slot_uri: MIXS:0000577
   root_med_macronutr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: macronutrient name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: macronutrient name;measurement value
+      Preferred_unit: milligram per liter
     description: Measurement of the culture rooting medium macronutrients (N,P, K,
       Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
     title: rooting medium macronutrients
@@ -11661,12 +11166,8 @@ slots:
     slot_uri: MIXS:0000578
   root_med_micronutr:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: micronutrient name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: micronutrient name;measurement value
+      Preferred_unit: milligram per liter
     description: Measurement of the culture rooting medium micronutrients (Fe, Mn,
       Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
     title: rooting medium micronutrients
@@ -11687,12 +11188,8 @@ slots:
     range: float
   root_med_regl:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: regulator name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: regulator name;measurement value
+      Preferred_unit: milligram per liter
     description: Growth regulators in the culture rooting medium such as cytokinins,
       auxins, gybberellins, abscisic acid; e.g. 0.5  mg/L NAA
     title: rooting medium regulators
@@ -11710,15 +11207,11 @@ slots:
     range: string
   root_med_suppl:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: supplement name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Expected_value: supplement name;measurement value
+      Preferred_unit: milligram per liter
     description: Organic supplements of the culture rooting medium, such as vitamins,
-      amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic
-      acid (0.5  mg/L)
+      amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid
+      (0.5  mg/L)
     title: rooting medium organic supplements
     examples:
       - value: nicotinic acid;0.5 milligram per liter
@@ -11738,15 +11231,13 @@ slots:
     range: RouteTransmissionEnum
   salinity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: practical salinity unit, percentage
+      Preferred_unit: practical salinity unit, percentage
     description: The total concentration of all dissolved salts in a liquid or solid
       sample. While salinity can be measured by a complete chemical analysis, this
       method is difficult and time consuming. More often, it is instead derived from
       the conductivity measurement. This is known as practical salinity. These derivations
-      compare the specific conductance of the sample to a salinity standard such
-      as seawater
+      compare the specific conductance of the sample to a salinity standard such as
+      seawater
     title: salinity
     examples:
       - value: 25 practical salinity unit
@@ -11755,21 +11246,19 @@ slots:
     slot_uri: MIXS:0000183
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   salt_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, mole per liter, gram per liter
+      Preferred_unit: gram, microgram, mole per liter, gram per liter
     description: Information about treatment involving use of salts as supplement
       to liquid and soil growth media; should include the name of salt, amount administered,
-      treatment regimen including how many times the treatment was repeated, how
-      long each treatment lasted, and the start and end time of the entire treatment;
-      can include multiple salt regimens
+      treatment regimen including how many times the treatment was repeated, how long
+      each treatment lasted, and the start and end time of the entire treatment; can
+      include multiple salt regimens
     title: salt regimen
     examples:
       - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -11777,8 +11266,8 @@ slots:
       - regimen
       - salt
     slot_uri: MIXS:0000582
-    range: string
     multivalued: true
+    range: string
   samp_capt_status:
     description: Reason for the sample
     title: sample capture status
@@ -11791,9 +11280,7 @@ slots:
     range: SampCaptStatusEnum
   samp_collect_device:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: device name
+      Expected_value: device name
     description: The device used to collect an environmental sample. This field accepts
       terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
       This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094)
@@ -11815,7 +11302,7 @@ slots:
       - sample
     slot_uri: MIXS:0001225
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
@@ -11845,9 +11332,7 @@ slots:
     range: SampDisStageEnum
   samp_floor:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The floor of the building, where the sampling room is located
     title: sampling floor
     examples:
@@ -11869,16 +11354,14 @@ slots:
     range: SampLocConditionEnum
   samp_loc_corr_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter per year
-    description: Metal corrosion rate is the speed of metal deterioration due to
-      environmental conditions. As environmental conditions change corrosion rates
-      change accordingly. Therefore, long term corrosion rates are generally more
-      informative than short term rates and for that reason they are preferred during
-      reporting. In the case of suspected MIC, corrosion rate measurements at the
-      time of sampling might provide insights into the involvement of certain microbial
-      community members in MIC as well as potential microbial interplays
+      Preferred_unit: millimeter per year
+    description: Metal corrosion rate is the speed of metal deterioration due to environmental
+      conditions. As environmental conditions change corrosion rates change accordingly.
+      Therefore, long term corrosion rates are generally more informative than short
+      term rates and for that reason they are preferred during reporting. In the case
+      of suspected MIC, corrosion rate measurements at the time of sampling might
+      provide insights into the involvement of certain microbial community members
+      in MIC as well as potential microbial interplays
     title: corrosion rate at sample location
     keywords:
       - location
@@ -11894,8 +11377,8 @@ slots:
       partial_match: true
   samp_mat_process:
     description: A brief description of any processing applied to the sample during
-      or after retrieving the sample from environment, or a link to the relevant
-      protocol(s) performed
+      or after retrieving the sample from environment, or a link to the relevant protocol(s)
+      performed
     title: sample material processing
     examples:
       - value: filtering of seawater, storing samples in ethanol
@@ -11909,12 +11392,8 @@ slots:
     range: string
   samp_md:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;enumeration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: measurement value;enumeration
+      Preferred_unit: meter
     description: In non deviated well, measured depth is equal to the true vertical
       depth, TVD (TVD=TVDSS plus the reference or datum it refers to). In deviated
       wells, the MD is the length of trajectory of the borehole measured from the
@@ -11932,16 +11411,14 @@ slots:
     slot_uri: MIXS:0000413
   samp_name:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: ''
+      Preferred_unit: ''
     description: A local identifier or name that for the material sample used for
       extracting nucleic acids, and subsequent sequencing. It can refer either to
-      the original material collected or to any derived sub-samples. It can have
-      any format, but we suggest that you make it concise, unique and consistent
-      within your lab, and as informative as possible. INSDC requires every sample
-      name from a single Submitter to be unique. Use of a globally unique identifier
-      for the field source_mat_id is recommended in addition to sample_name
+      the original material collected or to any derived sub-samples. It can have any
+      format, but we suggest that you make it concise, unique and consistent within
+      your lab, and as informative as possible. INSDC requires every sample name from
+      a single Submitter to be unique. Use of a globally unique identifier for the
+      field source_mat_id is recommended in addition to sample_name
     title: sample name
     examples:
       - value: ISDsoil1
@@ -11954,8 +11431,8 @@ slots:
     required: true
   samp_pooling:
     description: Physical combination of several instances of like material, e.g.
-      RNA extracted from samples or dishes of cell cultures into one big aliquot
-      of cells. Please provide a short description of the samples that were pooled
+      RNA extracted from samples or dishes of cell cultures into one big aliquot of
+      cells. Please provide a short description of the samples that were pooled
     title: sample pooling
     examples:
       - value: 5uL of extracted genomic DNA from 5 leaves were pooled
@@ -11963,13 +11440,11 @@ slots:
       - pooling
       - sample
     slot_uri: MIXS:0001153
-    range: string
     multivalued: true
+    range: string
   samp_preserv:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliliter
+      Preferred_unit: milliliter
     description: Preservative added to the sample (e.g. Rnalater, alcohol, formaldehyde,
       etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)
     title: preservative added to sample
@@ -11977,16 +11452,14 @@ slots:
       - sample
     slot_uri: MIXS:0000463
     range: string
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
       partial_match: true
   samp_purpose:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration or {text}
+      Expected_value: enumeration or {text}
     description: The reason that the sample was collected
     title: purpose of sampling
     examples:
@@ -11996,8 +11469,8 @@ slots:
     string_serialization: '[active surveillance in response to an outbreak|active
       surveillance not initiated by an outbreak|clinical trial|cluster investigation|environmental
       assessment|farm sample|field trial|for cause|industry internal investigation|market
-      sample|passive surveillance|population based studies|research|research and
-      development] or {text}'
+      sample|passive surveillance|population based studies|research|research and development]
+      or {text}'
     slot_uri: MIXS:0001151
   samp_rep_biol:
     description: Measurements of biologically distinct samples that show biological
@@ -12010,7 +11483,7 @@ slots:
     slot_uri: MIXS:0001226
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12026,7 +11499,7 @@ slots:
     slot_uri: MIXS:0001227
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12054,14 +11527,14 @@ slots:
     slot_uri: MIXS:0000001
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   samp_sort_meth:
-    description: Method by which samples are sorted; open face filter collecting
-      total suspended particles, prefilter to remove particles larger than X micrometers
+    description: Method by which samples are sorted; open face filter collecting total
+      suspended particles, prefilter to remove particles larger than X micrometers
       in diameter, where common values of X would be 10 and 2.5 full size sorting
       in a cascade impactor
     title: sample size sorting method
@@ -12070,13 +11543,11 @@ slots:
       - sample
       - size
     slot_uri: MIXS:0000216
-    range: string
     multivalued: true
+    range: string
   samp_source_mat_cat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: GENEPIO:0001237
+      Expected_value: GENEPIO:0001237
     description: This is the scientific role or category that the subject organism
       or material has with respect to an investigation.  This field accepts terms
       listed under specimen source material category (http://purl.obolibrary.org/obo/GENEPIO_0001237
@@ -12092,9 +11563,7 @@ slots:
     slot_uri: MIXS:0001154
   samp_stor_device:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C4318
+      Expected_value: NCIT:C4318
     description: The container used to store the  sample. This field accepts terms
       listed under container (http://purl.obolibrary.org/obo/NCIT_C43186). If the
       proper descriptor is not listed please use text to describe the storage device
@@ -12110,8 +11579,8 @@ slots:
   samp_stor_media:
     description: The liquid that is added to the sample collection device prior to
       sampling. If the sample is pre-hydrated, indicate the liquid media the sample
-      is pre-hydrated with for storage purposes. This field accepts terms listed
-      under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067).
+      is pre-hydrated with for storage purposes. This field accepts terms listed under
+      microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067).
       If the proper descriptor is not listed please use text to describe the sample
       storage media
     title: sample storage media
@@ -12122,14 +11591,14 @@ slots:
       - storage
     slot_uri: MIXS:0001229
     range: string
-    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   samp_store_dur:
-    description: Duration for which the sample was stored. Indicate the duration
-      for which the sample was stored written in ISO 8601 format
+    description: Duration for which the sample was stored. Indicate the duration for
+      which the sample was stored written in ISO 8601 format
     title: sample storage duration
     examples:
       - value: P1Y6M
@@ -12147,11 +11616,8 @@ slots:
       partial_match: true
   samp_store_loc:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: location name
-    description: Location at which sample was stored, usually name of a specific
-      freezer/room
+      Expected_value: location name
+    description: Location at which sample was stored, usually name of a specific freezer/room
     title: sample storage location
     examples:
       - value: Freezer no:5
@@ -12159,13 +11625,11 @@ slots:
       - location
       - sample
       - storage
-    slot_uri: MIXS:0000755
     range: string
+    slot_uri: MIXS:0000755
   samp_store_sol:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: solution name
+      Expected_value: solution name
     description: Solution within which sample was stored, if any
     title: sample storage solution
     examples:
@@ -12173,13 +11637,11 @@ slots:
     keywords:
       - sample
       - storage
-    slot_uri: MIXS:0001317
     range: string
+    slot_uri: MIXS:0001317
   samp_store_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature at which sample was stored, e.g. -80 degree Celsius
     title: sample storage temperature
     examples:
@@ -12191,7 +11653,7 @@ slots:
     slot_uri: MIXS:0000110
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12220,8 +11682,8 @@ slots:
       - sample
       - surface
     slot_uri: MIXS:0001256
-    range: SampSurfMoistureEnum
     multivalued: true
+    range: SampSurfMoistureEnum
   samp_taxon_id:
     description: NCBI taxon id of the sample.  Maybe be a single taxon or mixed taxa
       sample. Use 'synthetic metagenome  for mock community/positive controls, or
@@ -12239,19 +11701,15 @@ slots:
     slot_uri: MIXS:0001320
     range: string
     required: true
-    pattern: ^.* \[NCBITaxon:\d+\]$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[NCBITaxon:\d+\]$
     structured_pattern:
       syntax: ^{text} \[{NCBItaxon_id}\]$
       interpolated: true
       partial_match: true
   samp_time_out:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: time
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hour
+      Expected_value: time
+      Preferred_unit: hour
     description: The recent and long term history of outside sampling
     title: sampling time outside
     keywords:
@@ -12260,12 +11718,8 @@ slots:
     slot_uri: MIXS:0000196
   samp_transport_cond:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days;degree Celsius
+      Expected_value: measurement value;measurement value
+      Preferred_unit: days;degree Celsius
     description: Sample transport duration (in days or hrs) and temperature the sample
       was exposed to (e.g. 5.5 days; 20   C)
     title: sample transport conditions
@@ -12290,9 +11744,7 @@ slots:
     range: SampTransportContEnum
   samp_transport_dur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: days
+      Preferred_unit: days
     description: The duration of time from when the sample was collected until processed.
       Indicate the duration for which the sample was stored written in ISO 8601 format
     title: sample transport duration
@@ -12312,12 +11764,8 @@ slots:
       partial_match: true
   samp_transport_temp:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: text or measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Expected_value: text or measurement value
+      Preferred_unit: degree Celsius
     description: Temperature at which sample was transported, e.g. -20 or 4 degree
       Celsius
     title: sample transport temperature
@@ -12331,12 +11779,8 @@ slots:
     slot_uri: MIXS:0001232
   samp_tvdss:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value or measurement value range
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Expected_value: measurement value or measurement value range
+      Preferred_unit: meter
     description: Depth of the sample i.e. The vertical distance between the sea level
       and the sampled position in the subsurface. Depth can be reported as an interval
       for subsurface samples e.g. 1325.75-1362.25 m
@@ -12370,9 +11814,7 @@ slots:
       partial_match: true
   samp_vol_we_dna_ext:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliliter, gram, milligram, square centimeter
+      Preferred_unit: milliliter, gram, milligram, square centimeter
     description: 'Volume (ml) or mass (g) of total collected sample processed for
       DNA extraction. Note: total sample collected should be entered under the term
       Sample Size (MIXS:0000001)'
@@ -12389,7 +11831,7 @@ slots:
     slot_uri: MIXS:0000111
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12414,19 +11856,17 @@ slots:
     recommended: true
   saturates_pc:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
       method that divides  crude oil  components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
-      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143
-      (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
+      popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
+      https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: saturates wt%
     slot_uri: MIXS:0000131
     range: string
     recommended: true
-    pattern: ^.*;[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+);[-+]?[0-9]*\.?[0-9]+ ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{name};{float} {unit}$
       interpolated: true
@@ -12445,9 +11885,7 @@ slots:
     range: ScLysisApproachEnum
   sc_lysis_method:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: kit, protocol name
+      Expected_value: kit, protocol name
     description: Name of the kit or standard protocol used for cell(s) or particle(s)
       lysis
     title: single cell or viral particle lysis kit protocol
@@ -12460,17 +11898,15 @@ slots:
       - particle
       - protocol
       - single
-    slot_uri: MIXS:0000054
     range: string
+    slot_uri: MIXS:0000054
   season:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732],
-          winter [NCIT:C94730]
-    description: The season when sampling occurred. Any of the four periods into
-      which the year is divided by the equinoxes and solstices. This field accepts
-      terms listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
+      Expected_value: autumn [NCIT:C94733], spring [NCIT:C94731], summer [NCIT:C94732], winter
+        [NCIT:C94730]
+    description: The season when sampling occurred. Any of the four periods into which
+      the year is divided by the equinoxes and solstices. This field accepts terms
+      listed under season (http://purl.obolibrary.org/obo/NCIT_C94729)
     title: season
     comments:
       - autumn [NCIT:C94733] does not match ^\\S+.*\\S+ \\[[a-zA-Z]{2,}:\\d+\\]$
@@ -12495,8 +11931,8 @@ slots:
       - environment
       - season
     slot_uri: MIXS:0001068
-    range: string
     multivalued: true
+    range: string
   season_humidity:
     description: Average humidity of the region throughout the growing season
     title: mean seasonal humidity
@@ -12511,16 +11947,14 @@ slots:
     slot_uri: MIXS:0001148
     range: float
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   season_precpt:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: millimeter
+      Preferred_unit: millimeter
     description: The average of all seasonal precipitation values known, or an estimated
       equivalent value derived by such methods as regional indexes or Isohyetal maps
     title: mean seasonal precipitation
@@ -12532,16 +11966,14 @@ slots:
     slot_uri: MIXS:0000645
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   season_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Mean seasonal temperature
     title: mean seasonal temperature
     examples:
@@ -12553,7 +11985,7 @@ slots:
     slot_uri: MIXS:0000643
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12570,17 +12002,15 @@ slots:
     range: SeasonUseEnum
   secondary_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: secondary treatment type
+      Expected_value: secondary treatment type
     description: The process for substantially degrading the biological content of
       the sewage
     title: secondary treatment
     keywords:
       - secondary
       - treatment
-    slot_uri: MIXS:0000351
     range: string
+    slot_uri: MIXS:0000351
   sediment_type:
     description: Information about the sediment type based on major constituents
     title: sediment type
@@ -12604,16 +12034,14 @@ slots:
     slot_uri: MIXS:0000050
     range: string
     required: true
-    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   seq_quality_check:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: none or manually edited
+      Expected_value: none or manually edited
     description: Indicate if the sequence has been called by automatic systems (none)
       or undergone a manual editing procedure (e.g. by inspecting the raw data or
       chromatograms). Applied only for sequences that are not submitted to SRA,ENA
@@ -12629,9 +12057,7 @@ slots:
     range: SeqQualityCheckEnum
   sequencing_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: name of sequencing kit used
+      Expected_value: name of sequencing kit used
     description: Pre-filled, ready-to-use reagent cartridges. Used to produce improved
       chemistry, cluster density and read length as well as improve quality (Q) scores.
       Reagent components are encoded to interact with the sequencing system to validate
@@ -12642,8 +12068,8 @@ slots:
       - value: NextSeq 500/550 High Output Kit v2.5 (75 Cycles)
     keywords:
       - kit
-    slot_uri: MIXS:0001155
     range: string
+    slot_uri: MIXS:0001155
   sequencing_location:
     description: The location the sequencing run was performed. Indicate the name
       of the lab or core facility where samples were sequenced
@@ -12656,15 +12082,15 @@ slots:
     range: string
   serovar_or_serotype:
     description: A characterization of a cell or microorganism based on the antigenic
-      properties of the molecules on its surface. Indicate the name of a serovar
-      or serotype of interest. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
+      properties of the molecules on its surface. Indicate the name of a serovar or
+      serotype of interest. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy
     title: serovar or serotype
     examples:
       - value: Escherichia coli strain O157:H7 [NCIT:C86883]
     slot_uri: MIXS:0001157
-    range: string
     multivalued: true
+    range: string
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -12672,24 +12098,20 @@ slots:
       partial_match: true
   sewage_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: sewage type name
+      Expected_value: sewage type name
     description: Type of wastewater treatment plant as municipial or industrial
     title: sewage type
     keywords:
       - type
-    slot_uri: MIXS:0000215
     range: string
+    slot_uri: MIXS:0000215
   sexual_act:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: partner sex;frequency
+      Expected_value: partner sex;frequency
     description: Current sexual partner and frequency of sex
     title: sexual activity
-    slot_uri: MIXS:0000285
     range: string
+    slot_uri: MIXS:0000285
   shad_dev_water_mold:
     description: Signs of the presence of mold or mildew on the shading device
     title: shading device signs of water/mold
@@ -12721,16 +12143,14 @@ slots:
     range: ShadingDeviceLocEnum
   shading_device_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: material name
+      Expected_value: material name
     description: The material the shading device is composed of
     title: shading device material
     keywords:
       - device
       - material
-    slot_uri: MIXS:0000245
     range: string
+    slot_uri: MIXS:0000245
   shading_device_type:
     description: The type of shading device
     title: shading device type
@@ -12744,9 +12164,7 @@ slots:
     range: ShadingDeviceTypeEnum
   sieving:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: design name and/or size;amount
+      Expected_value: design name and/or size;amount
     description: Collection design of pooled samples and/or sieve size and amount
       of sample sieved
     title: sieving
@@ -12754,9 +12172,7 @@ slots:
     slot_uri: MIXS:0000322
   silicate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter
+      Preferred_unit: micromole per liter
     description: Concentration of silicate
     title: silicate
     examples:
@@ -12764,14 +12180,14 @@ slots:
     slot_uri: MIXS:0000184
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sim_search_meth:
-    description: Tool used to compare ORFs with database, along with version and
-      cutoffs used
+    description: Tool used to compare ORFs with database, along with version and cutoffs
+      used
     title: similarity search method
     examples:
       - value: HMMER3;3.1b2;hmmsearch, cutoff of 50 on score
@@ -12788,9 +12204,7 @@ slots:
       partial_match: true
   size_frac:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: filter size value range
+      Expected_value: filter size value range
     description: Filtering pore size used in sample preparation
     title: size fraction selected
     examples:
@@ -12804,11 +12218,8 @@ slots:
     slot_uri: MIXS:0000017
   size_frac_low:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micrometer
-    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample.
-      Materials smaller than the size threshold are excluded from the sample
+      Preferred_unit: micrometer
+    description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials smaller than the size threshold are excluded from the sample
     title: size-fraction lower threshold
     examples:
       - value: 0.2 micrometer
@@ -12817,18 +12228,15 @@ slots:
     slot_uri: MIXS:0000735
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   size_frac_up:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micrometer
-    description: Mesh or pore size of the device used to retain the sample. Materials
-      larger than the size threshold are excluded from the sample.
+      Preferred_unit: micrometer
+    description: Mesh or pore size of the device used to retain the sample. Materials larger than the size threshold are excluded from the sample.
     title: size-fraction upper threshold
     examples:
       - value: 20 micrometer
@@ -12837,55 +12245,49 @@ slots:
     slot_uri: MIXS:0000736
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   slope_aspect:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree
+      Preferred_unit: degree
     description: The direction a slope faces. While looking down a slope use a compass
-      to record the direction you are facing (direction or degrees); e.g., nw or
-      315 degrees. This measure provides an indication of sun and wind exposure that
-      will influence soil temperature and evapotranspiration
+      to record the direction you are facing (direction or degrees); e.g., nw or 315
+      degrees. This measure provides an indication of sun and wind exposure that will
+      influence soil temperature and evapotranspiration
     title: slope aspect
     keywords:
       - slope
     slot_uri: MIXS:0000647
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   slope_gradient:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
-    description: Commonly called 'slope'. The angle between ground surface and a
-      horizontal line (in percent). This is the direction that overland water would
-      flow. This measure is usually taken with a hand level meter or clinometer
+      Preferred_unit: percentage
+    description: Commonly called 'slope'. The angle between ground surface and a horizontal
+      line (in percent). This is the direction that overland water would flow. This
+      measure is usually taken with a hand level meter or clinometer
     title: slope gradient
     keywords:
       - slope
     slot_uri: MIXS:0000646
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sludge_retent_time:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours
+      Preferred_unit: hours
     description: The time activated sludge remains in reactor
     title: sludge retention time
     keywords:
@@ -12893,7 +12295,7 @@ slots:
     slot_uri: MIXS:0000669
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -12907,9 +12309,7 @@ slots:
     range: boolean
   sodium:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Sodium concentration in the sample
     title: sodium
     examples:
@@ -12917,16 +12317,14 @@ slots:
     slot_uri: MIXS:0000428
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soil_conductivity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliSiemens per centimeter
+      Preferred_unit: milliSiemens per centimeter
     title: soil conductivity
     examples:
       - value: 10 milliSiemens per centimeter
@@ -12935,16 +12333,14 @@ slots:
     slot_uri: MIXS:0001158
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soil_cover:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
+      Expected_value: subclass of 'environmental material', http://purl.obolibrary.org/obo/ENVO_00010483
     description: Material covering the sampled soil. This field accepts terms under
       ENVO:00010483, environmental material
     title: soil cover
@@ -12977,12 +12373,8 @@ slots:
     range: float
   soil_porosity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: percent porosity
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Expected_value: percent porosity
+      Preferred_unit: percentage
     description: Porosity of soil or deposited sediment is volume of voids divided
       by the total volume of sample
     title: soil sediment porosity
@@ -12996,9 +12388,7 @@ slots:
     slot_uri: MIXS:0001162
   soil_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of soil at the time of sampling
     title: soil temperature
     examples:
@@ -13009,7 +12399,7 @@ slots:
     slot_uri: MIXS:0001163
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13026,15 +12416,15 @@ slots:
     slot_uri: MIXS:0000335
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soil_texture_class:
-    description: One of the 12 soil texture classes use to describe soil texture
-      based on the relative proportion of different grain sizes  of mineral particles
-      [sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
+    description: One of the 12 soil texture classes use to describe soil texture based
+      on the relative proportion of different grain sizes  of mineral particles [sand
+      (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um)] in a soil
     title: soil texture classification
     examples:
       - value: silty clay loam
@@ -13062,12 +12452,10 @@ slots:
       partial_match: true
   soil_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:00001998
+      Expected_value: ENVO:00001998
     description: Description of the soil type or classification. This field accepts
-      terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple
-      terms can be separated by pipes
+      terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple terms
+      can be separated by pipes
     title: soil type
     examples:
       - value: plinthosol [ENVO:00002250]
@@ -13094,32 +12482,26 @@ slots:
       partial_match: true
   solar_irradiance:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilowatts per square meter per day, ergs per square centimeter per
-          second
-    description: The amount of solar energy that arrives at a specific area of a
-      surface during a specific time interval
+      Preferred_unit: kilowatts per square meter per day, ergs per square centimeter per
+        second
+    description: The amount of solar energy that arrives at a specific area of a surface
+      during a specific time interval
     title: solar irradiance
     examples:
       - value: 1.36 kilowatts per square meter per day
     slot_uri: MIXS:0000112
-    range: string
     multivalued: true
+    range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   soluble_inorg_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: soluble inorganic material name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, mole per liter, gram per liter, parts per million
+      Expected_value: soluble inorganic material name;measurement value
+      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
     description: Concentration of substances such as ammonia, road-salt, sea-salt,
       cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc
     title: soluble inorganic material
@@ -13132,14 +12514,10 @@ slots:
     multivalued: true
   soluble_org_mat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: soluble organic material name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, mole per liter, gram per liter, parts per million
-    description: Concentration of substances such as urea, fruit sugars, soluble
-      proteins, drugs, pharmaceuticals, etc
+      Expected_value: soluble organic material name;measurement value
+      Preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
+    description: Concentration of substances such as urea, fruit sugars, soluble proteins,
+      drugs, pharmaceuticals, etc
     title: soluble organic material
     keywords:
       - material
@@ -13150,9 +12528,7 @@ slots:
     multivalued: true
   soluble_react_phosp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of soluble reactive phosphorus
     title: soluble reactive phosphorus
     examples:
@@ -13163,16 +12539,14 @@ slots:
     slot_uri: MIXS:0000738
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sop:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: reference to SOP
+      Expected_value: reference to SOP
     description: Standard operating procedures used in assembly and/or annotation
       of genomes, metagenomes or environmental sequences
     title: relevant standard operating procedures
@@ -13196,9 +12570,7 @@ slots:
     range: SortTechEnum
   source_mat_id:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: 'for cultures of microorganisms: identifiers for two culture collections;
+      Expected_value: 'for cultures of microorganisms: identifiers for two culture collections;
           for other material a unique arbitrary identifer'
     description: A unique identifier assigned to a material sample (as defined by
       http://rs.tdwg.org/dwc/terms/materialSampleID, and as opposed to a particular
@@ -13206,12 +12578,12 @@ slots:
       subsequent sequencing. The identifier can refer either to the original material
       collected or to any derived sub-samples. The INSDC qualifiers /specimen_voucher,
       /bio_material, or /culture_collection may or may not share the same value as
-      the source_mat_id field. For instance, the /specimen_voucher qualifier and
-      source_mat_id may both contain 'UAM:Herps:14' , referring to both the specimen
-      voucher and sampled tissue with the same identifier. However, the /culture_collection
-      qualifier may refer to a value from an initial culture (e.g. ATCC:11775) while
-      source_mat_id would refer to an identifier from some derived culture from which
-      the nucleic acids were extracted (e.g. xatc123 or ark:/2154/R2)
+      the source_mat_id field. For instance, the /specimen_voucher qualifier and source_mat_id
+      may both contain 'UAM:Herps:14' , referring to both the specimen voucher and
+      sampled tissue with the same identifier. However, the /culture_collection qualifier
+      may refer to a value from an initial culture (e.g. ATCC:11775) while source_mat_id
+      would refer to an identifier from some derived culture from which the nucleic
+      acids were extracted (e.g. xatc123 or ark:/2154/R2)
     title: source material identifiers
     examples:
       - value: MPI012345
@@ -13221,14 +12593,12 @@ slots:
       - identifier
       - material
       - source
-    slot_uri: MIXS:0000026
     range: string
+    slot_uri: MIXS:0000026
     multivalued: true
   source_uvig:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Type of dataset from which the UViG was obtained
     title: source of UViGs
     examples:
@@ -13240,8 +12610,8 @@ slots:
     string_serialization: '[metagenome (not viral targeted)|viral fraction metagenome
       (virome)|sequence-targeted metagenome|metatranscriptome (not viral targeted)|viral
       fraction RNA metagenome (RNA virome)|sequence-targeted RNA metagenome|microbial
-      single amplified genome (SAG)|viral single amplified genome (vSAG)|isolate
-      microbial genome|other]'
+      single amplified genome (SAG)|viral single amplified genome (vSAG)|isolate microbial
+      genome|other]'
     slot_uri: MIXS:0000035
   space_typ_state:
     description: Customary or normal state of the space
@@ -13252,17 +12622,17 @@ slots:
     range: SpaceTypStateEnum
     required: true
   spec_intended_cons:
-    description: Food consumer type, human or animal, for which the food product
-      is produced and marketed. This field accepts terms listed under food consumer
-      group (http://purl.obolibrary.org/obo/FOODON_03510136)
+    description: Food consumer type, human or animal, for which the food product is
+      produced and marketed. This field accepts terms listed under food consumer group
+      (http://purl.obolibrary.org/obo/FOODON_03510136)
     title: specific intended consumer
     examples:
       - value: senior as food consumer [FOODON:03510254]
     keywords:
       - consumer
     slot_uri: MIXS:0001234
-    range: string
     multivalued: true
+    range: string
     pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\]$
     structured_pattern:
       syntax: ^{termLabel} \[{termID}\]$
@@ -13270,9 +12640,7 @@ slots:
       partial_match: true
   special_diet:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Specification of special diet; can include multiple special diets
     title: special diet
     examples:
@@ -13292,9 +12660,7 @@ slots:
     range: SpecificEnum
   specific_host:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: host scientific name, taxonomy ID
+      Expected_value: host scientific name, taxonomy ID
     description: Report the host's taxonomic name and/or NCBI taxonomy ID
     title: host scientific name
     examples:
@@ -13308,12 +12674,10 @@ slots:
     slot_uri: MIXS:0000029
   specific_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram of air, kilogram of air
+      Preferred_unit: gram of air, kilogram of air
     description: The mass of water vapour in a unit mass of moist air, usually expressed
-      as grams of vapour per kilogram of air, or, in air conditioning, as grains
-      per pound
+      as grams of vapour per kilogram of air, or, in air conditioning, as grains per
+      pound
     title: specific humidity
     examples:
       - value: 15 per kilogram of air
@@ -13322,16 +12686,14 @@ slots:
     slot_uri: MIXS:0000214
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   spikein_AMR:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value ARO:3004299
+      Expected_value: measurement value ARO:3004299
     description: Qualitative description of a microbial response to antimicrobial
       agents. Bacteria may be susceptible or resistant to a broad range of antibiotic
       drugs or drug classes, with several intermediate states or phases. This field
@@ -13347,9 +12709,7 @@ slots:
     multivalued: true
   spikein_antibiotic:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: drug name; concentration
+      Expected_value: drug name; concentration
     description: Antimicrobials used in research study to assess effects of exposure
       on microbiome of a specific site.  Please list antimicrobial, common name and/or
       class and concentration used for spike-in
@@ -13363,13 +12723,9 @@ slots:
     multivalued: true
   spikein_count:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: organism name;measurement value;enumeration
-      Preferred_unit:
-        tag: Preferred_unit
-        value: colony forming units per milliliter; colony forming units per gram
-          of dry weight
+      Expected_value: organism name;measurement value;enumeration
+      Preferred_unit: colony forming units per milliliter; colony forming units per gram
+        of dry weight
     description: 'Total cell count of any organism (or group of organisms) per gram,
       volume or area of sample, should include name of organism followed by count.
       The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) should
@@ -13385,10 +12741,10 @@ slots:
     slot_uri: MIXS:0001335
   spikein_growth_med:
     description: A liquid or gel containing nutrients, salts, and other factors formulated
-      to support the growth of microorganisms, cells, or plants (National Cancer
-      Institute Thesaurus).  A growth medium is a culture medium which has the disposition
-      to encourage growth of particular bacteria to the exclusion of others in the
-      same growth environment.  In this case, list the culture medium used to propagate
+      to support the growth of microorganisms, cells, or plants (National Cancer Institute
+      Thesaurus).  A growth medium is a culture medium which has the disposition to
+      encourage growth of particular bacteria to the exclusion of others in the same
+      growth environment.  In this case, list the culture medium used to propagate
       the spike-in bacteria during preparation of spike-in inoculum. This field accepts
       terms listed under microbiological culture medium (http://purl.obolibrary.org/obo/MICRO_0000067).
       If the proper descriptor is not listed please use text to describe the spike
@@ -13400,18 +12756,16 @@ slots:
       - growth
       - spike
     slot_uri: MIXS:0001169
-    range: string
     multivalued: true
-    pattern: ^.*|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
+    range: string
+    pattern: ^([^\s-]{1,2}|[^\s-]+.+[^\s-]+)|(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])$
     structured_pattern:
       syntax: ^{text}|({termLabel} \[{termID}\])$
       interpolated: true
       partial_match: true
   spikein_metal:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: heavy metal name or chemical symbol; concentration
+      Expected_value: heavy metal name or chemical symbol; concentration
     description: Heavy metals used in research study to assess effects of exposure
       on microbiome of a specific site.  Please list heavy metals and concentration
       used for spike-in
@@ -13426,8 +12780,8 @@ slots:
     multivalued: true
   spikein_org:
     description: Taxonomic information about the spike-in organism(s). This field
-      accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
-      This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
+      accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250). This
+      field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
       Multiple terms can be separated by pipes
     title: spike in organism
     examples:
@@ -13436,8 +12790,8 @@ slots:
       - organism
       - spike
     slot_uri: MIXS:0001167
-    range: string
     multivalued: true
+    range: string
     pattern: ^(([^\s-]{1,2}|[^\s-]+.+[^\s-]+) \[[a-zA-Z]{2,}:[a-zA-Z0-9]\d+\])|[1-9][0-9]*$
     structured_pattern:
       syntax: ^({termLabel} \[{termID}\])|{integer}$
@@ -13445,9 +12799,7 @@ slots:
       partial_match: true
   spikein_serovar:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C14250 or antigenic formula or serovar name
+      Expected_value: NCIT:C14250 or antigenic formula or serovar name
     description: Taxonomic information about the spike-in organism(s) at the serovar
       or serotype level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
@@ -13462,9 +12814,7 @@ slots:
     multivalued: true
   spikein_strain:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: NCIT:C14250 or NCBI taxid or text
+      Expected_value: NCIT:C14250 or NCBI taxid or text
     description: Taxonomic information about the spike-in organism(s) at the strain
       level. This field accepts terms under organism (http://purl.obolibrary.org/obo/NCIT_C14250).
       This field also accepts identification numbers from NCBI under https://www.ncbi.nlm.nih.gov/taxonomy.
@@ -13528,8 +12878,8 @@ slots:
   standing_water_regm:
     description: Treatment involving an exposure to standing water during a plant's
       life span, types can be flood water or standing water, treatment regimen including
-      how many times the treatment was repeated, how long each treatment lasted,
-      and the start and end time of the entire treatment; can include multiple regimens
+      how many times the treatment was repeated, how long each treatment lasted, and
+      the start and end time of the entire treatment; can include multiple regimens
     title: standing water regimen
     examples:
       - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -13537,13 +12887,11 @@ slots:
       - regimen
       - water
     slot_uri: MIXS:0001069
-    range: string
     multivalued: true
+    range: string
   ster_meth_samp_room:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO:01001026
+      Expected_value: ENVO:01001026
     description: The method used to sterilize the sampling room. This field accepts
       terms listed under electromagnetic radiation (http://purl.obolibrary.org/obo/ENVO_01001026).
       If the proper descriptor is not listed, please use text to describe the sampling
@@ -13559,9 +12907,7 @@ slots:
     multivalued: true
   store_cond:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: storage condition type;duration
+      Expected_value: storage condition type;duration
     description: Explain how and for how long the soil sample was stored before DNA
       extraction (fresh/frozen/other)
     title: storage conditions
@@ -13574,10 +12920,8 @@ slots:
     slot_uri: MIXS:0000327
   study_complt_stat:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
-          up (4)other-specify
+      Expected_value: YES or NO due to (1)adverse event (2) non-compliance (3) lost to follow
+        up (4)other-specify
     description: Specification of study completion status, if no the reason should
       be specified
     title: study completion status
@@ -13590,15 +12934,13 @@ slots:
     slot_uri: MIXS:0000898
   study_design:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: OBI:0500000
+      Expected_value: OBI:0500000
     description: A plan specification comprised of protocols (which may specify how
       and what kinds of data will be gathered) that are executed as part of an investigation
       and is realized during a study design execution. This field accepts terms under
       study design (http://purl.obolibrary.org/obo/OBI_0500000). If the proper descriptor
-      is not listed please use text to describe the study design. Multiple terms
-      can be separated by pipes
+      is not listed please use text to describe the study design. Multiple terms can
+      be separated by pipes
     title: study design
     examples:
       - value: in vitro design [OBI:0001285]
@@ -13607,11 +12949,9 @@ slots:
     multivalued: true
   study_inc_dur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours or days
-    description: Sample incubation duration if unpublished or unvalidated method
-      is used. Indicate the timepoint written in ISO 8601 format
+      Preferred_unit: hours or days
+    description: Sample incubation duration if unpublished or unvalidated method is
+      used. Indicate the timepoint written in ISO 8601 format
     title: study incubation duration
     examples:
       - value: PT24H
@@ -13628,9 +12968,7 @@ slots:
       partial_match: true
   study_inc_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Sample incubation temperature if unpublished or unvalidated method
       is used
     title: study incubation temperature
@@ -13642,16 +12980,14 @@ slots:
     slot_uri: MIXS:0001238
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   study_timecourse:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: dpi
+      Preferred_unit: dpi
     description: For time-course research studies involving samples of the food commodity,
       indicate the total duration of the time-course study
     title: time-course duration
@@ -13664,22 +13000,20 @@ slots:
     slot_uri: MIXS:0001239
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   study_tmnt:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: MCO:0000866
+      Expected_value: MCO:0000866
     description: A process in which the act is intended to modify or alter some other
       material entity.  From the study design, each treatment is comprised of one
       level of one or multiple factors. This field accepts terms listed under treatment
       (http://purl.obolibrary.org/obo/MCO_0000866). If the proper descriptor is not
-      listed please use text to describe the study treatment. Multiple terms can
-      be separated by one or more pipes
+      listed please use text to describe the study treatment. Multiple terms can be
+      separated by one or more pipes
     title: study treatment
     examples:
       - value: Factor A|spike-in|levels high, medium, low
@@ -13690,10 +13024,8 @@ slots:
     multivalued: true
   subspecf_gen_lin:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
-          e.g. serovar, biotype, ecotype, variety, cultivar
+      Expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies,
+        e.g. serovar, biotype, ecotype, variety, cultivar
     description: Information about the genetic distinctness of the sequenced organism
       below the subspecies level, e.g., serovar, serotype, biotype, ecotype, or any
       relevant genetic typing schemes like Group I plasmid. Subspecies should not
@@ -13717,13 +13049,11 @@ slots:
     keywords:
       - type
     slot_uri: MIXS:0000767
-    range: SubstructureTypeEnum
     multivalued: true
+    range: SubstructureTypeEnum
   sulfate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of sulfate in the sample
     title: sulfate
     examples:
@@ -13733,16 +13063,14 @@ slots:
     slot_uri: MIXS:0000423
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sulfate_fw:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Original sulfate concentration in the hydrocarbon resource
     title: sulfate in formation water
     keywords:
@@ -13751,16 +13079,14 @@ slots:
     slot_uri: MIXS:0000407
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   sulfide:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: Concentration of sulfide in the sample
     title: sulfide
     examples:
@@ -13770,7 +13096,7 @@ slots:
     slot_uri: MIXS:0000424
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13781,14 +13107,12 @@ slots:
     examples:
       - value: radon
     slot_uri: MIXS:0000759
+    multivalued: true
     range: SurfAirContEnum
     recommended: true
-    multivalued: true
   surf_humidity:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percentage
+      Preferred_unit: percentage
     description: 'Surfaces: water activity as a function of air and material moisture'
     title: surface humidity
     comments:
@@ -13802,7 +13126,7 @@ slots:
     range: float
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13819,9 +13143,7 @@ slots:
     range: SurfMaterialEnum
   surf_moisture:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: parts per million, gram per cubic meter, gram per square meter
+      Preferred_unit: parts per million, gram per cubic meter, gram per square meter
     description: Water held on a surface
     title: surface moisture
     examples:
@@ -13833,7 +13155,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -13852,9 +13174,7 @@ slots:
     recommended: true
   surf_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of the surface at the time of sampling
     title: surface temperature
     examples:
@@ -13866,16 +13186,14 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   suspend_part_matter:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Concentration of suspended particulate matter
     title: suspended particulate matter
     examples:
@@ -13887,20 +13205,16 @@ slots:
     slot_uri: MIXS:0000741
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   suspend_solids:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: suspended solid name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram, microgram, milligram per liter, mole per liter, gram per liter,
-          part per million
+      Expected_value: suspended solid name;measurement value
+      Preferred_unit: gram, microgram, milligram per liter, mole per liter, gram per liter,
+        part per million
     description: Concentration of substances including a wide variety of material,
       such as silt, decaying plant and animal matter; can include multiple substances
     title: suspended solids
@@ -13912,9 +13226,7 @@ slots:
     multivalued: true
   sym_life_cycle_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: type of life cycle of the symbiotic organism (host of the samples)
+      Expected_value: type of life cycle of the symbiotic organism (host of the samples)
     description: Type of life cycle of the symbiotic host species (the thing being
       sampled). Simple life cycles occur within a single host, complex ones within
       multiple different hosts over the course of their normal life cycle
@@ -13945,9 +13257,7 @@ slots:
     recommended: true
   tan:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: 'Total Acid Number  (TAN) is a measurement of acidity that is determined
       by the amount of  potassium hydroxide  in milligrams that is needed to neutralize
       the acids in one gram of oil.  It is an important quality measurement of  crude
@@ -13960,7 +13270,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14019,9 +13329,7 @@ slots:
     range: TaxIdentEnum
   temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: Temperature of the sample at the time of sampling
     title: temperature
     examples:
@@ -14033,16 +13341,14 @@ slots:
     slot_uri: MIXS:0000113
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   temp_out:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
+      Preferred_unit: degree Celsius
     description: The recorded temperature value at sampling time outside
     title: temperature outside house
     examples:
@@ -14053,23 +13359,21 @@ slots:
     slot_uri: MIXS:0000197
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tertiary_treatment:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: tertiary treatment type
+      Expected_value: tertiary treatment type
     description: The process providing a final treatment stage to raise the effluent
       quality before it is discharged to the receiving environment
     title: tertiary treatment
     keywords:
       - treatment
-    slot_uri: MIXS:0000352
     range: string
+    slot_uri: MIXS:0000352
   tidal_stage:
     description: Stage of tide
     title: tidal stage
@@ -14085,8 +13389,8 @@ slots:
     keywords:
       - history
     slot_uri: MIXS:0001081
-    range: TillageEnum
     multivalued: true
+    range: TillageEnum
   time_last_toothbrush:
     description: Specification of the time since last toothbrushing
     title: time since last toothbrushing
@@ -14120,9 +13424,7 @@ slots:
       partial_match: true
   timepoint:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: hours or days
+      Preferred_unit: hours or days
     description: Time point at which a sample or observation is made or taken from
       a biomaterial as measured from some reference point. Indicate the timepoint
       written in ISO 8601 format
@@ -14148,23 +13450,21 @@ slots:
       - growth
     slot_uri: MIXS:0001070
     range: string
-    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|.*$
+    pattern: ^^PMID:\d+$|^doi:10.\d{2,9}/.*$|^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$|([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}|{text}$
       interpolated: true
       partial_match: true
   toluene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of toluene in the sample
     title: toluene
     slot_uri: MIXS:0000154
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14178,16 +13478,14 @@ slots:
     slot_uri: MIXS:0000525
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_depth_water_col:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: Measurement of total depth of water column
     title: total depth of water column
     examples:
@@ -14199,16 +13497,14 @@ slots:
     slot_uri: MIXS:0000634
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_diss_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter
+      Preferred_unit: microgram per liter
     description: 'Total dissolved nitrogen concentration, reported as nitrogen, measured
       by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen'
     title: total dissolved nitrogen
@@ -14221,16 +13517,14 @@ slots:
     slot_uri: MIXS:0000744
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_inorg_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter
+      Preferred_unit: microgram per liter
     description: Total inorganic nitrogen content
     title: total inorganic nitrogen
     examples:
@@ -14242,16 +13536,14 @@ slots:
     slot_uri: MIXS:0000745
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_iron:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, milligram per kilogram
+      Preferred_unit: milligram per liter, milligram per kilogram
     description: Concentration of total iron in the sample
     title: total iron
     keywords:
@@ -14260,16 +13552,14 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_nitro:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter, milligram per liter
+      Preferred_unit: microgram per liter, micromole per liter, milligram per liter
     description: 'Total nitrogen concentration of water samples, calculated by: total
       nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured
       without filtering, reported as nitrogen'
@@ -14283,7 +13573,7 @@ slots:
     slot_uri: MIXS:0000102
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14317,7 +13607,7 @@ slots:
     slot_uri: MIXS:0000530
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14341,9 +13631,7 @@ slots:
       partial_match: true
   tot_org_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram Carbon per kilogram sample material
+      Preferred_unit: gram Carbon per kilogram sample material
     description: Total organic carbon content
     title: total organic carbon
     examples:
@@ -14355,16 +13643,14 @@ slots:
     slot_uri: MIXS:0000533
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_part_carb:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Total particulate carbon content
     title: total particulate carbon
     examples:
@@ -14377,16 +13663,14 @@ slots:
     slot_uri: MIXS:0000747
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_phosp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
+      Preferred_unit: micromole per liter, milligram per liter, parts per million
     description: 'Total phosphorus concentration in the sample, calculated by: total
       phosphorus = total dissolved phosphorus + particulate phosphorus'
     title: total phosphorus
@@ -14398,16 +13682,14 @@ slots:
     slot_uri: MIXS:0000117
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_phosphate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per liter, micromole per liter
+      Preferred_unit: microgram per liter, micromole per liter
     description: Total amount or concentration of phosphate
     title: total phosphate
     keywords:
@@ -14416,16 +13698,14 @@ slots:
     slot_uri: MIXS:0000689
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tot_sulfur:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of total sulfur in the sample
     title: total sulfur
     keywords:
@@ -14435,7 +13715,7 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14472,16 +13752,14 @@ slots:
     range: TrainStopLocEnum
   travel_out_six_month:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: country name
+      Expected_value: country name
     description: Specification of the countries travelled in the last six months;
       can include multiple travels
     title: travel outside the country in last six months
     keywords:
       - months
-    slot_uri: MIXS:0000268
     range: string
+    slot_uri: MIXS:0000268
     multivalued: true
   trna_ext_software:
     description: Tools used for tRNA identification
@@ -14501,9 +13779,7 @@ slots:
       partial_match: true
   trnas:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: value from 0-21
+      Expected_value: value from 0-21
     description: The total number of tRNAs identified from the SAG or MAG
     title: number of standard tRNAs extracted
     examples:
@@ -14527,24 +13803,22 @@ slots:
     slot_uri: MIXS:0000032
     range: TrophicLevelEnum
   turbidity:
-    description: Measure of the amount of cloudiness or haziness in water caused
-      by individual particles
+    description: Measure of the amount of cloudiness or haziness in water caused by
+      individual particles
     title: turbidity
     examples:
       - value: 0.3 nephelometric turbidity units
     slot_uri: MIXS:0000191
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tvdss_of_hcr_press:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where
       the original pressure was measured (e.g. 1578 m)
     title: depth (TVDSS) of hydrocarbon resource pressure
@@ -14556,16 +13830,14 @@ slots:
     slot_uri: MIXS:0000397
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   tvdss_of_hcr_temp:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: meter
+      Preferred_unit: meter
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where
       the original temperature was measured (e.g. 1345 m)
     title: depth (TVDSS) of hydrocarbon resource temperature
@@ -14577,7 +13849,7 @@ slots:
     slot_uri: MIXS:0000394
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14624,9 +13896,7 @@ slots:
     range: UrineCollectMethEnum
   urobiom_sex:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: sex of the symbiotic organism (host of the samples); enumeration
+      Expected_value: sex of the symbiotic organism (host of the samples); enumeration
     description: Physical sex of the host
     title: host sex
     keywords:
@@ -14643,8 +13913,8 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000289
-    range: string
     multivalued: true
+    range: string
   urogenit_tract_disor:
     description: History of urogenital tract disorders; can include multiple disorders.
       The terms should be chosen from the DO (Human Disease Ontology) at http://www.disease-ontology.org,
@@ -14653,13 +13923,11 @@ slots:
     keywords:
       - disorder
     slot_uri: MIXS:0000278
-    range: string
     multivalued: true
+    range: string
   ventilation_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per minute, liters per second
+      Preferred_unit: cubic meter per minute, liters per second
     description: Ventilation rate of the system in the sampled premises
     title: ventilation rate
     examples:
@@ -14669,46 +13937,40 @@ slots:
     slot_uri: MIXS:0000114
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   ventilation_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ventilation type name
+      Expected_value: ventilation type name
     description: Ventilation system used in the sampled premises
     title: ventilation type
     examples:
       - value: Operable windows
     keywords:
       - type
-    slot_uri: MIXS:0000756
     range: string
+    slot_uri: MIXS:0000756
     multivalued: true
   vfa:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of Volatile Fatty Acids in the sample
     title: volatile fatty acids
     slot_uri: MIXS:0000152
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   vfa_fw:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter
+      Preferred_unit: milligram per liter
     description: Original volatile fatty acid concentration in the hydrocarbon resource
     title: vfa in formation water
     keywords:
@@ -14716,16 +13978,14 @@ slots:
     slot_uri: MIXS:0000408
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   vir_ident_software:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: software name, version and relevant parameters
+      Expected_value: software name, version and relevant parameters
     description: Tool(s) used for the identification of UViG as a viral genome, software
       or protocol name including version number, parameters, and cutoffs used
     title: viral identification software
@@ -14743,17 +14003,13 @@ slots:
     title: virus enrichment approach
     examples:
       - value: filtration
-        description: was filtration + FeCl Precipitation + ultracentrifugation +
-          DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
       - value: FeCl Precipitation
-        description: was filtration + FeCl Precipitation + ultracentrifugation +
-          DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
       - value: ultracentrifugation
-        description: was filtration + FeCl Precipitation + ultracentrifugation +
-          DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
       - value: DNAse
-        description: was filtration + FeCl Precipitation + ultracentrifugation +
-          DNAse
+        description: was filtration + FeCl Precipitation + ultracentrifugation + DNAse
     in_subset:
       - nucleic acid sequence source
     keywords:
@@ -14762,9 +14018,7 @@ slots:
     range: VirusEnrichApprEnum
   vis_media:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: The building visual media
     title: visual media
     examples:
@@ -14774,25 +14028,17 @@ slots:
     slot_uri: MIXS:0000840
   viscosity:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cP at degree Celsius
-    description: A measure of oil's resistance  to gradual deformation by  shear
-      stress  or  tensile stress (e.g. 3.5 cp; 100   C)
+      Expected_value: measurement value;measurement value
+      Preferred_unit: cP at degree Celsius
+    description: A measure of oil's resistance  to gradual deformation by  shear stress  or  tensile
+      stress (e.g. 3.5 cp; 100   C)
     title: viscosity
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000126
   volatile_org_comp:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: volatile organic compound name;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: microgram per cubic meter, parts per million, nanogram per liter
+      Expected_value: volatile organic compound name;measurement value
+      Preferred_unit: microgram per cubic meter, parts per million, nanogram per liter
     description: Concentration of carbon-based chemicals that easily evaporate at
       room temperature; can report multiple volatile organic compounds by entering
       numeric values preceded by name of compound
@@ -14806,9 +14052,7 @@ slots:
     multivalued: true
   wall_area:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The total area of the sampled room's walls
     title: wall area
     keywords:
@@ -14817,7 +14061,7 @@ slots:
     slot_uri: MIXS:0000198
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14845,9 +14089,7 @@ slots:
     range: WallFinishMatEnum
   wall_height:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: centimeter
+      Preferred_unit: centimeter
     description: The average height of the walls in the sampled room
     title: wall height
     keywords:
@@ -14856,7 +14098,7 @@ slots:
     slot_uri: MIXS:0000221
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14894,9 +14136,7 @@ slots:
     range: CeilingWallTextureEnum
   wall_thermal_mass:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: joule per degree Celsius
+      Preferred_unit: joule per degree Celsius
     description: The ability of the wall to provide inertia against temperature fluctuations.
       Generally this means concrete or concrete block that is either exposed or covered
       only with paint
@@ -14907,7 +14147,7 @@ slots:
     slot_uri: MIXS:0000222
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -14923,16 +14163,14 @@ slots:
     range: MoldVisibilityEnum
   wastewater_type:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: wastewater type name
+      Expected_value: wastewater type name
     description: The origin of wastewater such as human waste, rainfall, storm drains,
       etc
     title: wastewater type
     keywords:
       - type
-    slot_uri: MIXS:0000353
     range: string
+    slot_uri: MIXS:0000353
   water_cont_soil_meth:
     description: Reference or method used in determining the water content of soil
     title: water content method
@@ -14949,9 +14187,7 @@ slots:
       partial_match: true
   water_content:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: gram per gram or cubic centimeter per cubic centimeter
+      Preferred_unit: gram per gram or cubic centimeter per cubic centimeter
     description: Water content measurement
     title: water content
     keywords:
@@ -14960,16 +14196,14 @@ slots:
     slot_uri: MIXS:0000185
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_current:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per second, knots
+      Preferred_unit: cubic meter per second, knots
     description: Measurement of magnitude and direction of flow within a fluid
     title: water current
     examples:
@@ -14979,16 +14213,14 @@ slots:
     slot_uri: MIXS:0000203
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_cut:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: percent
+      Preferred_unit: percent
     description: Current amount of water (%) in a produced fluid stream; or the average
       of the combined streams
     title: water cut
@@ -15002,16 +14234,14 @@ slots:
     range: string
     required: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_feat_size:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: square meter
+      Preferred_unit: square meter
     description: The size of the water feature
     title: water feature size
     keywords:
@@ -15021,7 +14251,7 @@ slots:
     slot_uri: MIXS:0000223
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -15039,12 +14269,8 @@ slots:
     range: WaterFeatTypeEnum
   water_frequency:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: rate
-      Preferred_unit:
-        tag: Preferred_unit
-        value: per day, per week, per month
+      Expected_value: rate
+      Preferred_unit: per day, per week, per month
     description: Number of water delivery events within a given period of time
     title: water delivery frequency
     examples:
@@ -15066,9 +14292,7 @@ slots:
     range: float
   water_prod_rate:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: cubic meter per day
+      Preferred_unit: cubic meter per day
     description: Water production rates per well (e.g. 987 m3 / day)
     title: water production rate
     keywords:
@@ -15079,16 +14303,14 @@ slots:
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
       partial_match: true
   water_source_adjac:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: ENVO_01001110 or ENVO_00000070
+      Expected_value: ENVO_01001110 or ENVO_00000070
     description: Description of the environmental features that are adjacent to the
       farm water source. This field accepts terms under ecosystem (http://purl.obolibrary.org/obo/ENVO_01001110)
       and human construction (http://purl.obolibrary.org/obo/ENVO_00000070). Multiple
@@ -15102,14 +14324,12 @@ slots:
       - feature
       - source
       - water
-    slot_uri: MIXS:0001122
     range: string
+    slot_uri: MIXS:0001122
     multivalued: true
   water_source_shared:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: enumeration
+      Expected_value: enumeration
     description: Other users sharing access to the same water source. Multiple terms
       can be separated by one or more pipes
     title: water source shared
@@ -15118,19 +14338,16 @@ slots:
     keywords:
       - source
       - water
-    string_serialization: '[multiple users, agricutural|multiple users, other|no
-      sharing]'
+    string_serialization: '[multiple users, agricutural|multiple users, other|no sharing]'
     slot_uri: MIXS:0001176
     multivalued: true
   water_temp_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degree Celsius
-    description: Information about treatment involving an exposure to water with
-      varying degree of temperature, treatment regimen including how many times the
-      treatment was repeated, how long each treatment lasted, and the start and end
-      time of the entire treatment; can include multiple regimens
+      Preferred_unit: degree Celsius
+    description: Information about treatment involving an exposure to water with varying
+      degree of temperature, treatment regimen including how many times the treatment
+      was repeated, how long each treatment lasted, and the start and end time of
+      the entire treatment; can include multiple regimens
     title: water temperature regimen
     examples:
       - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -15139,17 +14356,15 @@ slots:
       - temperature
       - water
     slot_uri: MIXS:0000590
-    range: string
     multivalued: true
+    range: string
   watering_regm:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milliliter, liter
+      Preferred_unit: milliliter, liter
     description: Information about treatment involving an exposure to watering frequencies,
-      treatment regimen including how many times the treatment was repeated, how
-      long each treatment lasted, and the start and end time of the entire treatment;
-      can include multiple regimens
+      treatment regimen including how many times the treatment was repeated, how long
+      each treatment lasted, and the start and end time of the entire treatment; can
+      include multiple regimens
     title: watering regimen
     examples:
       - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
@@ -15157,8 +14372,8 @@ slots:
       - regimen
       - water
     slot_uri: MIXS:0000591
-    range: string
     multivalued: true
+    range: string
   weekday:
     description: The day of the week when sampling occurred
     title: weekday
@@ -15168,12 +14383,8 @@ slots:
     range: WeekdayEnum
   weight_loss_3_month:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: weight loss specification;measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: kilogram, gram
+      Expected_value: weight loss specification;measurement value
+      Preferred_unit: kilogram, gram
     description: Specification of weight loss in the last three months, if yes should
       be further specified to include amount of weight loss
     title: weight loss in last three months
@@ -15195,9 +14406,7 @@ slots:
     range: WgaAmpApprEnum
   wga_amp_kit:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: kit name
+      Expected_value: kit name
     description: Kit used to amplify genomic DNA in preparation for sequencing
     title: WGA amplification kit
     examples:
@@ -15206,14 +14415,13 @@ slots:
       - sequencing
     keywords:
       - kit
-    slot_uri: MIXS:0000006
     range: string
+    slot_uri: MIXS:0000006
   win:
-    description: 'A unique identifier of a well or wellbore. This is part of the
-      Global Framework for Well Identification initiative which is compiled by the
-      Professional Petroleum Data Management Association (PPDM) in an effort to improve
-      well identification systems. (Supporting information: https://ppdm.org/ and
-      http://dl.ppdm.org/dl/690)'
+    description: 'A unique identifier of a well or wellbore. This is part of the Global
+      Framework for Well Identification initiative which is compiled by the Professional
+      Petroleum Data Management Association (PPDM) in an effort to improve well identification
+      systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)'
     title: well identification number
     keywords:
       - identifier
@@ -15223,9 +14431,7 @@ slots:
     recommended: true
   wind_direction:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: degrees or cardinal direction
+      Preferred_unit: degrees or cardinal direction
     description: Wind direction is the direction from which a wind originates
     title: wind direction
     keywords:
@@ -15242,7 +14448,7 @@ slots:
     slot_uri: MIXS:0000118
     range: string
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -15305,12 +14511,8 @@ slots:
     range: integer
   window_size:
     annotations:
-      Expected_value:
-        tag: Expected_value
-        value: measurement value
-      Preferred_unit:
-        tag: Preferred_unit
-        value: inch, meter
+      Expected_value: measurement value
+      Preferred_unit: inch, meter
     description: The window's length and width
     title: window area/size
     keywords:
@@ -15386,16 +14588,14 @@ slots:
       partial_match: true
   xylene:
     annotations:
-      Preferred_unit:
-        tag: Preferred_unit
-        value: milligram per liter, parts per million
+      Preferred_unit: milligram per liter, parts per million
     description: Concentration of xylene in the sample
     title: xylene
     slot_uri: MIXS:0000156
     range: string
     recommended: true
     pattern: ^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)?
-      *.*$
+      *([^\s-]{1,2}|[^\s-]+.+[^\s-]+)$
     structured_pattern:
       syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
       interpolated: true
@@ -16786,21 +15986,12 @@ classes:
         recommended: true
     class_uri: MIXS:0010012
   Agriculture:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: Agricultural Microbiomes Research Coordination Network, model cropping
-          and plant systems focused on agricultural plant and soil microbe; microbiome
-          studies in agricultural sites; long-term ecological research in croplands;
-          eDNA in manure samples; describing agricultural microbiome studies
-    description: A collection of terms appropriate when sequencing samples obtained
-      in an agricultural environment.  Suitable to capture metadata appropriate to
-      enhance crop productivity and agroecosystem health  with the aim to facilitate
-      research of agricultural microbiomes and their relationships to plant productivity  and
-      sustainable crop production from diverse crop management contexts.
+    description: >-
+      A collection of terms appropriate when sequencing samples obtained in an agricultural environment. 
+      Suitable to capture metadata appropriate to enhance crop productivity and agroecosystem health 
+      with the aim to facilitate research of agricultural microbiomes and their relationships to plant productivity 
+      and sustainable crop production from diverse crop management contexts.
     title: agriculture
-    aliases:
-      - MIxS-Ag (agriculture)
     is_a: Extension
     slots:
       - plant_growth_med
@@ -17207,16 +16398,14 @@ classes:
         string_serialization: '{float} {unit};{period};{interval};{period}'
         recommended: true
     class_uri: MIXS:0016018
-  Air:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: bioaerosol samples, pathogen load in urban air, aerosols
-    description: A collection of terms appropriate when collecting and sequencing
-      samples obtained from a gaseous environment.
-    title: air
     aliases:
-      - MIxS-air
+      - MIxS-Ag (agriculture)
+    annotations:
+      use_cases: Agricultural Microbiomes Research Coordination Network, model cropping and plant systems focused on agricultural plant and soil microbe; microbiome studies in agricultural sites; long-term ecological research in croplands; eDNA in manure samples; describing agricultural microbiome studies
+  Air:
+    description: >-
+      A collection of terms appropriate when collecting and sequencing samples obtained from a gaseous environment.
+    title: air
     is_a: Extension
     slots:
       - samp_name
@@ -17269,19 +16458,16 @@ classes:
         examples:
           - value: 21 kilometer per hour
     class_uri: MIXS:0016000
-  BuiltEnvironment:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: microbiology studies of the built environment, NASA space station
-          sampling, MetaSUB transit system sampling, home, hospitals, office buildings
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples obtained in the  built-up environment, which includes terms for surface
-      material, humidity, temperature, moisture and  occupancy type along with specific
-      metadata terms describing the indoor air, building and sample properties.
-    title: built environment
     aliases:
-      - MIxS-BE (built environment)
+      - MIxS-air
+    annotations:
+      use_cases: bioaerosol samples, pathogen load in urban air, aerosols
+  BuiltEnvironment:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples obtained in the 
+      built-up environment, which includes terms for surface material, humidity, temperature, moisture and 
+      occupancy type along with specific metadata terms describing the indoor air, building and sample properties.
+    title: built environment
     is_a: Extension
     slots:
       - samp_name
@@ -17471,20 +16657,19 @@ classes:
       ventilation_type:
         required: true
     class_uri: MIXS:0016001
-  FoodAnimalAndAnimalFeed:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: Microbiome of farm animals, their feed, and pet food.
-    description: A collection of terms appropriate when collecting samples and performing
-      sequencing of samples  obtained from farm animals and their feed.
-    title: food-animal and animal feed
-    comments:
-      - This extension is intended to work alongside the other food extensions (farm
-        environment, food production facility, and human foods) for capturing contextual
-        data across the food supply-chain environment.
     aliases:
-      - MIxS-Food (animal and animal feed)
+      - MIxS-BE (built environment)
+    annotations:
+      use_cases: microbiology studies of the built environment, NASA space station sampling, MetaSUB transit system sampling, home, hospitals, office buildings
+  FoodAnimalAndAnimalFeed:
+    description: >-
+      A collection of terms appropriate when collecting samples and performing sequencing of samples 
+      obtained from farm animals and their feed.
+    comments:
+      - This extension is intended to work alongside the other food extensions
+        (farm environment, food production facility, and human foods) for capturing contextual data
+        across the food supply-chain environment.
+    title: food-animal and animal feed
     is_a: Extension
     slots:
       - samp_name
@@ -17622,22 +16807,19 @@ classes:
       samp_purpose:
         required: true
     class_uri: MIXS:0016019
-  FoodFarmEnvironment:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: Microbiome of farm and field crops as well as environmental samples
-          including irrigation, soil amendments, and farm equipment.
-    description: A collection of terms appropriate when collecting samples and performing
-      sequencing of samples  obtained from the farm environment, including soil,
-      manure, and food harvesting equipment.
-    title: food-farm environment
-    comments:
-      - This extension is intended to work alongside the other food extensions (animals
-        and animal feed, food production facility, and human foods) for capturing
-        contextual data across the food supply-chain environment.
     aliases:
-      - MIxS-Food (farm environment)
+      - MIxS-Food (animal and animal feed)
+    annotations:
+      use_cases: Microbiome of farm animals, their feed, and pet food.
+  FoodFarmEnvironment:
+    description: >-
+      A collection of terms appropriate when collecting samples and performing sequencing of samples 
+      obtained from the farm environment, including soil, manure, and food harvesting equipment.
+    comments:
+      - This extension is intended to work alongside the other food extensions
+        (animals and animal feed, food production facility, and human foods)
+        for capturing contextual data across the food supply-chain environment.
+    title: food-farm environment
     is_a: Extension
     slots:
       - samp_name
@@ -17855,20 +17037,19 @@ classes:
         examples:
           - value: 1.6 kilometers per hour
     class_uri: MIXS:0016020
-  FoodFoodProductionFacility:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: Microbiome of food production facilities/factories
-    description: A collection of terms appropriate when collecting samples and performing
-      sequencing of samples  obtained from food production facilities.
-    title: food-food production facility
-    comments:
-      - This extension is intended to work alongside the other food extensions (animals
-        and animal feed, farm environment, and human foods) for capturing contextual
-        data across the food supply-chain environment.
     aliases:
-      - MIxS-Food(food production facility)
+      - MIxS-Food (farm environment)
+    annotations:
+      use_cases: Microbiome of farm and field crops as well as environmental samples including irrigation, soil amendments, and farm equipment.
+  FoodFoodProductionFacility:
+    description: >-
+      A collection of terms appropriate when collecting samples and performing sequencing of samples 
+      obtained from food production facilities.
+    comments:
+      - This extension is intended to work alongside the other food extensions
+        (animals and animal feed, farm environment, and human foods)
+        for capturing contextual data across the food supply-chain environment.
+    title: food-food production facility
     is_a: Extension
     slots:
       - samp_name
@@ -18014,20 +17195,19 @@ classes:
       samp_stor_media:
         required: true
     class_uri: MIXS:0016021
-  FoodHumanFoods:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: Microbiome of foods intended for human consumption.
-    description: A collection of terms appropriate when collecting samples and performing
-      sequencing of samples  obtained from human food products.
-    title: food-human foods
-    comments:
-      - This extension is intended to work alongside the other food extensions (animals
-        and animal feed, farm environment, and food production facilities) for capturing
-        contextual data across the food supply-chain environment.
     aliases:
-      - MIxS-Food (human foods)
+      - MIxS-Food(food production facility)
+    annotations:
+      use_cases: Microbiome of food production facilities/factories
+  FoodHumanFoods:
+    description: >-
+      A collection of terms appropriate when collecting samples and performing sequencing of samples 
+      obtained from human food products.
+    comments:
+      - This extension is intended to work alongside the other food extensions
+        (animals and animal feed, farm environment, and food production facilities)
+        for capturing contextual data across the food supply-chain environment.
+    title: food-human foods
     is_a: Extension
     slots:
       - samp_name
@@ -18165,28 +17345,24 @@ classes:
         examples:
           - value: environmental swab sampling
     class_uri: MIXS:0016022
-  HostAssociated:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: elephant fecal matter or cat oral cavity
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a non-human host, to examine the host-associated microbiome
-      or genome.
-    title: host-associated
-    comments:
-      - This is a very broad package, intended to capture many kinds of sequences
-        derived from the bodies of or derived from an organism. Where possible, please
-        use a more specific package. For example, consider using food-animal and
-        animal feed extension for sampling of farm animals reared for consumption.
-        For human stool microbiomes, consider MIxS-human-gut. Incidental associations
-        of environmental material with an organism may also be better served by other
-        packages. For example, nucleic acids derived from soil that was sampled from
-        the hoof of a cow may be better described by terms from the soil extension;
-        however, soil embedded in a wound on a cow’s leg would be best described
-        by terms in this extension
     aliases:
-      - MIxS-host-associated
+      - MIxS-Food (human foods)
+    annotations:
+      use_cases: Microbiome of foods intended for human consumption.
+  HostAssociated:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a non-human host, to examine the host-associated microbiome or genome.
+    comments:
+      - This is a very broad package, intended to capture many kinds of sequences derived
+        from the bodies of or derived from an organism. Where possible, please use a more specific package.
+        For example, consider using food-animal and animal feed extension for sampling of farm animals reared for consumption.
+        For human stool microbiomes, consider MIxS-human-gut.
+        Incidental associations of environmental material with an organism may also be better served by other packages.
+        For example, nucleic acids derived from soil that was sampled from the hoof of a cow may be better described
+        by terms from the soil extension;
+        however, soil embedded in a wound on a cow’s leg would be best described by terms in this extension
+    title: host-associated
     is_a: Extension
     slots:
       - samp_name
@@ -18304,19 +17480,18 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016002
-  HumanAssociated:
+    aliases:
+      - MIxS-host-associated
     annotations:
-      use_cases:
-        tag: use_cases
-        value: blood samples or biopsy samples.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a person to examine their human-associated microbiome
-      or genome,  that does not have a specific extension (e.g., skin, gut, vaginal).
-    title: human-associated
+      use_cases: elephant fecal matter or cat oral cavity
+  HumanAssociated:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a person to examine their human-associated microbiome or genome, 
+      that does not have a specific extension (e.g., skin, gut, vaginal).
     comments:
       - For stool samples use MIxS-human-gut extension.
-    aliases:
-      - MIxS-human-associated
+    title: human-associated
     is_a: Extension
     slots:
       - samp_name
@@ -18416,17 +17591,15 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016003
-  HumanGut:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: human stool or fecal samples, or samples collected directly from the
-          gut.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a person to examine their gut-associated microbiome.
-    title: human-gut
     aliases:
-      - MIxS-human-gut
+      - MIxS-human-associated
+    annotations:
+      use_cases: blood samples or biopsy samples.
+  HumanGut:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a person to examine their gut-associated microbiome.
+    title: human-gut
     is_a: Extension
     slots:
       - samp_name
@@ -18510,17 +17683,15 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016004
-  HumanOral:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: mouth swab sampling, dental microbiome samples, microbiome of oral
-          swabs, nasal, mouth, throat, teeth, tongue microbiome studies
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a person to examine their oral-associated microbiome.
-    title: human-oral
     aliases:
-      - MIxS-human-oral
+      - MIxS-human-gut
+    annotations:
+      use_cases: human stool or fecal samples, or samples collected directly from the gut.
+  HumanOral:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a person to examine their oral-associated microbiome.
+    title: human-oral
     is_a: Extension
     slots:
       - samp_name
@@ -18603,16 +17774,16 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016005
-  HumanSkin:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: swab samples taken on a person’s skin surface.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a person to examine their skin-associated microbiome.
-    title: human-skin
     aliases:
-      - MIxS-human-skin
+      - MIxS-human-oral
+
+    annotations:
+      use_cases: mouth swab sampling, dental microbiome samples, microbiome of oral swabs, nasal, mouth, throat, teeth, tongue microbiome studies
+  HumanSkin:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a person to examine their skin-associated microbiome.
+    title: human-skin
     is_a: Extension
     slots:
       - samp_name
@@ -18696,16 +17867,15 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016006
-  HumanVaginal:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: vaginal swabbing
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a person to examine their vaginal-associated microbiome.
-    title: human-vaginal
     aliases:
-      - MIxS-human-vaginal
+      - MIxS-human-skin
+    annotations:
+      use_cases: swab samples taken on a person’s skin surface.
+  HumanVaginal:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a person to examine their vaginal-associated microbiome.
+    title: human-vaginal
     is_a: Extension
     slots:
       - samp_name
@@ -18796,19 +17966,15 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016007
-  HydrocarbonResourcesCores:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: The microbial characterization of hydrocarbon occurrences, defined
-          as the natural and artificial environmental features that are rich in hydrocarbons,
-          from hydrocarbon rich formations, such as reservoir cores.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from environments pertaining to hydrocarbon resources, specifically
-      core samples.
-    title: hydrocarbon resources-cores
     aliases:
-      - MIxS-HCR (hydrocarbon resources-cores)
+      - MIxS-human-vaginal
+    annotations:
+      use_cases: vaginal swabbing
+  HydrocarbonResourcesCores:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from environments pertaining to hydrocarbon resources, specifically core samples.
+    title: hydrocarbon resources-cores
     is_a: Extension
     slots:
       - samp_name
@@ -18926,19 +18092,15 @@ classes:
       vfa_fw:
         required: true
     class_uri: MIXS:0016015
-  HydrocarbonResourcesFluidsSwabs:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: The microbial characterization of hydrocarbon occurrences,  defined
-          as the natural and artificial environmental features that are rich in hydrocarbons,
-          from hydrocarbon resource fluids.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from environments pertaining to hydrocarbon resources, specifically
-      run-off liquids samples and swabs.
-    title: hydrocarbon resources-fluids/swabs
     aliases:
-      - MIxS-HCR (hydrocarbon resources-fluids/swabs)
+      - MIxS-HCR (hydrocarbon resources-cores)
+    annotations:
+      use_cases: The microbial characterization of hydrocarbon occurrences, defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon rich formations, such as reservoir cores.
+  HydrocarbonResourcesFluidsSwabs:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from environments pertaining to hydrocarbon resources, specifically run-off liquids samples and swabs.
+    title: hydrocarbon resources-fluids/swabs
     is_a: Extension
     slots:
       - samp_name
@@ -19060,16 +18222,15 @@ classes:
       vfa_fw:
         recommended: true
     class_uri: MIXS:0016016
-  MicrobialMatBiofilm:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: samples from microbial mats at cold seeps
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from biofilm environments including microbial mats.
-    title: microbial mat/biofilm
     aliases:
-      - MIxS-microbial mat/biofilm
+      - MIxS-HCR (hydrocarbon resources-fluids/swabs)
+    annotations:
+      use_cases: The microbial characterization of hydrocarbon occurrences,  defined as the natural and artificial environmental features that are rich in hydrocarbons, from hydrocarbon resource fluids.
+  MicrobialMatBiofilm:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from biofilm environments including microbial mats.
+    title: microbial mat/biofilm
     is_a: Extension
     slots:
       - samp_name
@@ -19152,13 +18313,15 @@ classes:
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016008
-  MiscellaneousNaturalOrArtificialEnvironment:
-    description: A collection of generic terms appropriate when collecting and sequencing
-      samples  obtained from environments, where there is no specific extension already
-      available.
-    title: miscellaneous natural or artificial environment
     aliases:
-      - MIxS-miscellaneous natural or artificial environment
+      - MIxS-microbial mat/biofilm
+    annotations:
+      use_cases: samples from microbial mats at cold seeps
+  MiscellaneousNaturalOrArtificialEnvironment:
+    description: >-
+      A collection of generic terms appropriate when collecting and sequencing samples 
+      obtained from environments, where there is no specific extension already available.
+    title: miscellaneous natural or artificial environment
     is_a: Extension
     slots:
       - samp_name
@@ -19220,17 +18383,13 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016009
-  PlantAssociated:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: plant surface swabs, root soil or rhizosphere, cultivated plants,
-          plant phenotyping
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from a plant to examine it’s plant-associated microbiome.
-    title: plant-associated
     aliases:
-      - MIxS-plant-associated
+      - MIxS-miscellaneous natural or artificial environment
+  PlantAssociated:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from a plant to examine it’s plant-associated microbiome.
+    title: plant-associated
     is_a: Extension
     slots:
       - samp_name
@@ -19377,19 +18536,17 @@ classes:
       watering_regm:
         string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     class_uri: MIXS:0016010
-  Sediment:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: river bed or sea floor.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from the sedimentary area of aquatic environments.
-    title: sediment
-    comments:
-      - Sedimentary layers in terrestrial environments will probably be better served
-        by the soil extension.
     aliases:
-      - MIxS-sediment
+      - MIxS-plant-associated
+    annotations:
+      use_cases: plant surface swabs, root soil or rhizosphere, cultivated plants, plant phenotyping
+  Sediment:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from the sedimentary area of aquatic environments.
+    comments:
+      - Sedimentary layers in terrestrial environments will probably be better served by the soil extension.
+    title: sediment
     is_a: Extension
     slots:
       - samp_name
@@ -19478,19 +18635,17 @@ classes:
       water_content:
         string_serialization: '{float} {unit}'
     class_uri: MIXS:0016011
-  Soil:
+    aliases:
+      - MIxS-sediment
     annotations:
-      use_cases:
-        tag: use_cases
-        value: soil collection, island microbiome sampling, farm land or forest floor.
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from the uppermost layer of Earth's crust, contributed by
-      the Terragenome Consortium.
-    title: soil
+      use_cases: river bed or sea floor.
+  Soil:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from the uppermost layer of Earth's crust, contributed by the Terragenome Consortium.
     see_also:
       - https://www.fao.org/agriculture/crops/thematic-sitemap/theme/spi/soil-biodiversity/research-into-soil-biodiversity/the-terragenome-project/en/
-    aliases:
-      - MIxS-soil
+    title: soil
     is_a: Extension
     slots:
       - samp_name
@@ -19568,17 +18723,15 @@ classes:
       water_content:
         string_serialization: '{float}'
     class_uri: MIXS:0016012
-  SymbiontAssociated:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: the microbiome sequence of a flea sampled from a farm animal
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from an organism that lives in close association with any
-      other organism(s).
-    title: symbiont-associated
     aliases:
-      - MIxS-SA (symbiont-associated)
+      - MIxS-soil
+    annotations:
+      use_cases: soil collection, island microbiome sampling, farm land or forest floor.
+  SymbiontAssociated:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from an organism that lives in close association with any other organism(s).
+    title: symbiont-associated
     is_a: Extension
     slots:
       - samp_name
@@ -19692,16 +18845,15 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016023
-  WastewaterSludge:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: sewerage or industrial wastewater
-    description: A collection of terms appropriate when collecting samples and sequencing
-      samples  obtained from any solid, semisolid or liquid waste.
-    title: wastewater/sludge
     aliases:
-      - MIxS-wastewater/sludge
+      - MIxS-SA (symbiont-associated)
+    annotations:
+      use_cases: the microbiome sequence of a flea sampled from a farm animal
+  WastewaterSludge:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing samples 
+      obtained from any solid, semisolid or liquid waste.
+    title: wastewater/sludge
     is_a: Extension
     slots:
       - samp_name
@@ -19753,18 +18905,15 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016013
-  Water:
-    annotations:
-      use_cases:
-        tag: use_cases
-        value: sea or river water, global ocean sampling day
-    description: A collection of terms appropriate when collecting samples and sequencing
-      water samples  obtained from any aquatic environment.
-    title: water
-    see_also:
-      - https://www.vliz.be/projects/assembleplus/research/ocean-sampling-day-2018.html
     aliases:
-      - MIxS-water
+      - MIxS-wastewater/sludge
+    annotations:
+      use_cases: sewerage or industrial wastewater
+  Water:
+    description: >-
+      A collection of terms appropriate when collecting samples and sequencing water samples 
+      obtained from any aquatic environment.
+    title: water
     is_a: Extension
     slots:
       - samp_name
@@ -19863,14 +19012,18 @@ classes:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
     class_uri: MIXS:0016014
+    aliases:
+      - MIxS-water
+    annotations:
+      use_cases: sea or river water, global ocean sampling day
+    see_also:
+      - https://www.vliz.be/projects/assembleplus/research/ocean-sampling-day-2018.html
   Checklist:
     description: A collection of metadata terms (slots) to minimally describe the
-      sampling and sequencing method of a specimen used to generate a nucleotide
-      sequence.
+      sampling and sequencing method of a specimen used to generate a nucleotide sequence.
   Extension:
-    description: A collection of recommended metadata terms (slots) developed by
-      community experts, describing the specific context under which a sample was
-      collected.
+    description: A collection of recommended metadata terms (slots) developed by community
+      experts, describing the specific context under which a sample was collected.
     aliases:
       - EnvironmentalPackage
   MixsCompliantData:
@@ -21391,8 +20544,7 @@ classes:
       - Mimag
     class_uri: MIXS:0010011_0016003
   MimagHumanGut:
-    description: MIxS Data that comply with the Mimag checklist and the HumanGut
-      Extension
+    description: MIxS Data that comply with the Mimag checklist and the HumanGut Extension
     title: Mimag combined with HumanGut
     in_subset:
       - combination_classes
@@ -21481,8 +20633,7 @@ classes:
       - Mimag
     class_uri: MIXS:0010011_0016010
   MimagSediment:
-    description: MIxS Data that comply with the Mimag checklist and the Sediment
-      Extension
+    description: MIxS Data that comply with the Mimag checklist and the Sediment Extension
     title: Mimag combined with Sediment
     in_subset:
       - combination_classes
@@ -21747,8 +20898,7 @@ classes:
       - MimarksC
     class_uri: MIXS:0010009_0016013
   MimarksCWater:
-    description: MIxS Data that comply with the MimarksC checklist and the Water
-      Extension
+    description: MIxS Data that comply with the MimarksC checklist and the Water Extension
     title: MimarksC combined with Water
     in_subset:
       - combination_classes
@@ -21975,8 +21125,7 @@ classes:
       - MimarksS
     class_uri: MIXS:0010008_0016013
   MimarksSWater:
-    description: MIxS Data that comply with the MimarksS checklist and the Water
-      Extension
+    description: MIxS Data that comply with the MimarksS checklist and the Water Extension
     title: MimarksS combined with Water
     in_subset:
       - combination_classes
@@ -22083,8 +21232,7 @@ classes:
       - Mims
     class_uri: MIXS:0010007_0016004
   MimsHumanOral:
-    description: MIxS Data that comply with the Mims checklist and the HumanOral
-      Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanOral Extension
     title: Mims combined with HumanOral
     in_subset:
       - combination_classes
@@ -22093,8 +21241,7 @@ classes:
       - Mims
     class_uri: MIXS:0010007_0016005
   MimsHumanSkin:
-    description: MIxS Data that comply with the Mims checklist and the HumanSkin
-      Extension
+    description: MIxS Data that comply with the Mims checklist and the HumanSkin Extension
     title: Mims combined with HumanSkin
     in_subset:
       - combination_classes
@@ -22299,8 +21446,7 @@ classes:
       - Misag
     class_uri: MIXS:0010010_0016003
   MisagHumanGut:
-    description: MIxS Data that comply with the Misag checklist and the HumanGut
-      Extension
+    description: MIxS Data that comply with the Misag checklist and the HumanGut Extension
     title: Misag combined with HumanGut
     in_subset:
       - combination_classes
@@ -22389,8 +21535,7 @@ classes:
       - Misag
     class_uri: MIXS:0010010_0016010
   MisagSediment:
-    description: MIxS Data that comply with the Misag checklist and the Sediment
-      Extension
+    description: MIxS Data that comply with the Misag checklist and the Sediment Extension
     title: Misag combined with Sediment
     in_subset:
       - combination_classes
@@ -22664,11 +21809,10 @@ classes:
       - Miuvig
     class_uri: MIXS:0010012_0016014
 settings:
-  agrochemical_name: .*
+  agrochemical_name: ".*"
   amount: '[-+]?[0-9]*\.?[0-9]+'
-  add_recov_methods: Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer
-    Addition|Surfactant Addition|Not Applicable|other
-  DOI: ^doi:10.\d{2,9}/.*$
+  add_recov_methods: 'Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer Addition|Surfactant Addition|Not Applicable|other'
+  DOI: '^doi:10.\d{2,9}/.*$'
   NCBItaxon_id: NCBITaxon:\d+
   PMID: ^PMID:\d+$
   URL: ^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$
@@ -22677,15 +21821,15 @@ settings:
   adapter_B_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
   ambiguous_nucleotides: '[ACGTRKSYMWBHDVN]+'
   country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  date_time_stamp: (\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$
+  date_time_stamp: '(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$'
   duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
   float: '[-+]?[0-9]*\.?[0-9]+'
   integer: '[1-9][0-9]*'
   lat: (-?((?:[0-8]?[0-9](?:\.\d{0,8})?)|90))
   lon: -?[0-9]+(?:\.[0-9]{0,8})?$|^-?(1[0-7]{1,2})
-  name: .*
+  name: '.*'
   parameters: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  particulate_matter_name: .*
+  particulate_matter_name: '.*'
   region: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   room_name: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   room_number: '[1-9][0-9]*'
@@ -22695,6 +21839,6 @@ settings:
   storage_condition_type: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   termID: '[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'
   termLabel: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
-  text: .*
+  text: '.*'
   unit: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   version: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)

--- a/src/scripts/describe_enums_by_slots_using.py
+++ b/src/scripts/describe_enums_by_slots_using.py
@@ -4,9 +4,19 @@ from linkml_runtime.dumpers import yaml_dumper
 
 
 @click.command()
-@click.option('--schema_file', type=str, default="../mixs/schema/mixs.yaml", help="Path to the input schema file.")
-@click.option('--output_file', type=str, default='../../mixs_with_enum_descriptions.yaml', show_default=True,
-              help="Path to the output schema file with updated enum descriptions.")
+@click.option(
+    "--schema_file",
+    type=str,
+    default="../mixs/schema/mixs.yaml",
+    help="Path to the input schema file.",
+)
+@click.option(
+    "--output_file",
+    type=str,
+    default="../../mixs_with_enum_descriptions.yaml",
+    show_default=True,
+    help="Path to the output schema file with updated enum descriptions.",
+)
 def update_enum_descriptions(schema_file: str, output_file: str) -> None:
     """
     Update enum descriptions in the given schema file.
@@ -15,7 +25,7 @@ def update_enum_descriptions(schema_file: str, output_file: str) -> None:
     by other terms (slots). The descriptions will indicate whether an enum is used by any term, and if so,
     by how many terms and which ones.
 
-    Does not overwrite existing descriptions
+    Note: Does not overwrite existing descriptions
 
     :param schema_file: Path to the input schema file.
     :param output_file: Path to the output schema file where the updated schema will be saved.
@@ -30,7 +40,7 @@ def update_enum_descriptions(schema_file: str, output_file: str) -> None:
 
         new_desc = ""
 
-        if ev.description is None or ev.description != "":
+        if ev.description is None or ev.description == "":
             if len(user_names) == 0:
                 new_desc = "Permissible values, not used by any term"
             elif len(user_names) == 1:
@@ -40,11 +50,12 @@ def update_enum_descriptions(schema_file: str, output_file: str) -> None:
             ev.description = new_desc
         else:
             click.echo(
-                f"Permissible value {ek} already has description '{ev.description}'. Refusing to overwrite with {new_desc}.")
+                f"Enum {ek} already has description '{ev.description}'. Do not overwrite with new description."
+            )
 
     yaml_dumper.dump(schema_view.schema, output_file)
     click.echo(f"Enum descriptions updated and saved to {output_file}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     update_enum_descriptions()

--- a/src/scripts/describe_enums_by_slots_using.py
+++ b/src/scripts/describe_enums_by_slots_using.py
@@ -15,6 +15,8 @@ def update_enum_descriptions(schema_file: str, output_file: str) -> None:
     by other terms (slots). The descriptions will indicate whether an enum is used by any term, and if so,
     by how many terms and which ones.
 
+    Does not overwrite existing descriptions
+
     :param schema_file: Path to the input schema file.
     :param output_file: Path to the output schema file where the updated schema will be saved.
     """
@@ -26,12 +28,19 @@ def update_enum_descriptions(schema_file: str, output_file: str) -> None:
         user_names = [u.name for u in users]
         user_names.sort()
 
-        if len(user_names) == 0:
-            ev.description = "Permissible values, not used by any term"
-        elif len(user_names) == 1:
-            ev.description = f"Permissible values, used by term {user_names[0]}"
-        else:  # len(user_names) > 1
-            ev.description = f"Permissible values, used by {len(user_names)} terms: {', '.join(user_names)}"
+        new_desc = ""
+
+        if ev.description is None or ev.description != "":
+            if len(user_names) == 0:
+                new_desc = "Permissible values, not used by any term"
+            elif len(user_names) == 1:
+                new_desc = f"Permissible values, used by term {user_names[0]}"
+            else:  # len(user_names) > 1
+                new_desc = f"Permissible values, used by {len(user_names)} terms: {', '.join(user_names)}"
+            ev.description = new_desc
+        else:
+            click.echo(
+                f"Permissible value {ek} already has description '{ev.description}'. Refusing to overwrite with {new_desc}.")
 
     yaml_dumper.dump(schema_view.schema, output_file)
     click.echo(f"Enum descriptions updated and saved to {output_file}")


### PR DESCRIPTION
This PR adds a mechanism for 
- normalizing the YAML format of mixs.yaml
- using a succinct LinkML for for dictionaries like `prefixes`
- omitting inferrable meatslots like the `text` of permissible values

It also inherits auto-describing of any enum that lacks a description from
- #872

For future discussion:

- [ ] do we want empty curly brackets for keys without values?
- [ ] be careful about patterns that are longer than the current max line length , 79
     -what technology should we use to check that?
- [ ]  how to visualize the changes from yamlfmt (or the previous steps?)
