### PR TITLE
Remove duplicate titles appearing on Enum documentation pages

### DIFF
--- a/src/doc-templates/enum.md.jinja2
+++ b/src/doc-templates/enum.md.jinja2
@@ -1,7 +1,5 @@
 # Enum: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 
-# Enum: {{ gen.name(element) }}
-
 {% if element.description %}
 {% set element_description_lines = element.description.split('\n') %}
 {% for element_description_line in element_description_lines %}


### PR DESCRIPTION
<img width="1792" alt="Screenshot 2025-01-28 at 10 41 02 AM" src="https://github.com/user-attachments/assets/7e93848b-9776-4035-afd0-46494d5a905c" />
