### PR TITLE
 Add automatic LinkML linting of schema on each PR changing schema

### DIFF
--- a/.github/workflows/lint-linkml.yml
+++ b/.github/workflows/lint-linkml.yml
@@ -33,7 +33,7 @@ jobs:
           printf "$(linkml --version) linting found the following issues. \n\n" >> linting-results.md
           printf "_For more information about the linting rule categories, see the [LinkML linter documentation](https://linkml.io/linkml/schemas/linter.html#rules)._\n" >> linting-results.md
           ## Lint the schema, and further format
-          poetry run linkml lint --config linkml-lint-config.yml --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md
+          poetry run linkml lint --config .linkml-lint-config.yml --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md
       - name: Reformat log
         run: |
           sed -i -e 's/#### Errors/> [!CAUTION]/' -e 's/#### Warnings/> [!WARNING]/' -e 's/^*/> */' -e '/###.*yaml/ s/$/\n/' -e '/###.*yaml/ s/^###/**File**:/' linting-results.md

--- a/.github/workflows/lint-linkml.yml
+++ b/.github/workflows/lint-linkml.yml
@@ -1,0 +1,45 @@
+---
+name: LinkML Linting GitHub Action
+on:
+  push:
+    paths:
+      - "src/mixs/schema/mixs.yaml"
+jobs:
+  linkml:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: LinkML Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Run LinkML Linting
+        run: |
+          ## Results file header and basic formatting
+          printf '# LinkML Linting Results \n\n' > linting-results.md
+          printf "$(linkml --version) linting found the following issues. \n\n" >> linting-results.md
+          printf "_For more information about the linting rule categories, see the [LinkML linter documentation](https://linkml.io/linkml/schemas/linter.html#rules)._\n" >> linting-results.md
+          ## Lint the schema, and further format
+          poetry run linkml lint --config linkml-lint-config.yml --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md
+      - name: Reformat log
+        run: |
+          sed -i -e 's/#### Errors/> [!CAUTION]/' -e 's/#### Warnings/> [!WARNING]/' -e 's/^*/> */' -e '/###.*yaml/ s/$/\n/' -e '/###.*yaml/ s/^###/**File**:/' linting-results.md
+      - name: Post PR comment
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
+        with:
+          message-path: linting-results.md
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: true

--- a/.github/workflows/lint-linkml.yml
+++ b/.github/workflows/lint-linkml.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   linkml:
     permissions:
-      contents: write
       pull-requests: write
     name: LinkML Linting
     runs-on: ubuntu-latest
@@ -16,12 +15,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        run: pipx install poetry
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
@@ -38,7 +38,7 @@ jobs:
         run: |
           sed -i -e 's/#### Errors/> [!CAUTION]/' -e 's/#### Warnings/> [!WARNING]/' -e 's/^*/> */' -e '/###.*yaml/ s/$/\n/' -e '/###.*yaml/ s/^###/**File**:/' linting-results.md
       - name: Post PR comment
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
+        uses: mshick/add-pr-comment@v2 # v2
         with:
           message-path: linting-results.md
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 project/excel
 
 .DS_Store
+
+.vscode/
+linting-results*

--- a/.linkml-lint-config.yml
+++ b/.linkml-lint-config.yml
@@ -1,0 +1,4 @@
+extends: recommended
+rules:
+  standard_naming:
+    level: disabled

--- a/.linkml-lint-config.yml
+++ b/.linkml-lint-config.yml
@@ -1,1 +1,0 @@
-extends: recommended

--- a/.linkml-lint-config.yml
+++ b/.linkml-lint-config.yml
@@ -1,4 +1,1 @@
 extends: recommended
-rules:
-  standard_naming:
-    level: disabled

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -8501,8 +8501,7 @@ slots:
       discovery rates should be included, either computed de novo or from the literature
     title: host prediction estimated accuracy
     examples:
-      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
-        genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
+      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
     in_subset:
       - sequencing
     keywords:


### PR DESCRIPTION
This adds a github action that runs the LinkML linting if the schema changes, and posts a nicely formatted comment listing all the issues.

Note it currently configures the linting to ignore warnings related to 'standard naming'.