### PR TITLE
Automated linkml linter run

### DIFF
--- a/.github/workflows/lint-linkml.yml
+++ b/.github/workflows/lint-linkml.yml
@@ -33,7 +33,7 @@ jobs:
           printf "$(linkml --version) linting found the following issues. \n\n" >> linting-results.md
           printf "_For more information about the linting rule categories, see the [LinkML linter documentation](https://linkml.io/linkml/schemas/linter.html#rules)._\n" >> linting-results.md
           ## Lint the schema, and further format
-          poetry run linkml lint --config .linkml-lint-config.yml --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md
+          poetry run linkml lint --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md
       - name: Reformat log
         run: |
           sed -i -e 's/#### Errors/> [!CAUTION]/' -e 's/#### Warnings/> [!WARNING]/' -e 's/^*/> */' -e '/###.*yaml/ s/$/\n/' -e '/###.*yaml/ s/^###/**File**:/' linting-results.md

--- a/.github/workflows/lint-linkml.yml
+++ b/.github/workflows/lint-linkml.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           ## Results file header and basic formatting
           printf '# LinkML Linting Results \n\n' > linting-results.md
-          printf "$(linkml --version) linting found the following issues. \n\n" >> linting-results.md
+          printf "$(poetry run linkml --version) linting found the following issues. \n\n" >> linting-results.md
           printf "_For more information about the linting rule categories, see the [LinkML linter documentation](https://linkml.io/linkml/schemas/linter.html#rules)._\n" >> linting-results.md
           ## Lint the schema, and further format
           poetry run linkml lint --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md

--- a/.github/workflows/lint-linkml.yml
+++ b/.github/workflows/lint-linkml.yml
@@ -1,0 +1,45 @@
+---
+name: LinkML Linting GitHub Action
+on:
+  push:
+    paths:
+      - "src/mixs/schema/mixs.yaml"
+jobs:
+  linkml:
+    permissions:
+      pull-requests: write
+    name: LinkML Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Run LinkML Linting
+        run: |
+          ## Results file header and basic formatting
+          printf '# LinkML Linting Results \n\n' > linting-results.md
+          printf "$(linkml --version) linting found the following issues. \n\n" >> linting-results.md
+          printf "_For more information about the linting rule categories, see the [LinkML linter documentation](https://linkml.io/linkml/schemas/linter.html#rules)._\n" >> linting-results.md
+          ## Lint the schema, and further format
+          poetry run linkml lint --config .linkml-lint-config.yml --ignore-warnings -f markdown src/mixs/schema/mixs.yaml >> linting-results.md
+      - name: Reformat log
+        run: |
+          sed -i -e 's/#### Errors/> [!CAUTION]/' -e 's/#### Warnings/> [!WARNING]/' -e 's/^*/> */' -e '/###.*yaml/ s/$/\n/' -e '/###.*yaml/ s/^###/**File**:/' linting-results.md
+      - name: Post PR comment
+        uses: mshick/add-pr-comment@v2 # v2
+        with:
+          message-path: linting-results.md
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: true

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 project/excel
 
 .DS_Store
+
+.vscode/
+linting-results*

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -8501,8 +8501,7 @@ slots:
       discovery rates should be included, either computed de novo or from the literature
     title: host prediction estimated accuracy
     examples:
-      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host
-        genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
+      - value: 'CRISPR spacer match: 0 or 1 mismatches, estimated 8% FDR at the host genus rank (Edwards et al. 2016 doi:10.1093/femsre/fuv048)'
     in_subset:
       - sequencing
     keywords:


### PR DESCRIPTION
This is the same PR from @jfy133 as #896 but instead the PR is now being merged into `main` as base. It essentially adds a GitHub Action that creates a linkml linter run report and dumps the results of the report run as a comment on a PR, if the PR modifies the main `mixs.yaml` source schema.