### PR TITLE
Replace misrepresented `string_serialization` with `structured_pattern` – batch 1

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -9907,7 +9907,9 @@ slots:
     keywords:
       - classification
       - otu
-    structured_pattern: ^{integer}%\s*ANI;\s*{integer}%\s*AF;\s*{text}$ # constrain based on Leiden algorithm
+    structured_pattern:
+      syntax: ^{integer}%\s*ANI;\s*{integer}%\s*AF;\s*{text}$ # constrain based on Leiden algorithm
+      interpolated: true
     slot_uri: MIXS:0000085
   otu_db:
     annotations:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -7590,7 +7590,7 @@ slots:
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
-      slot_uri: MIXS:0000859
+    slot_uri: MIXS:0000859
   geo_loc_name:
     description: The geographical origin of the sample as defined by the country or
       sea name followed by specific region name. Country or sea names should be chosen

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12967,7 +12967,7 @@ slots:
     keywords:
       - status
     structured_pattern:
-      syntax: ^{boolean};(?:adverse event|non-compliance|lost to followup|other-specify)$
+      syntax: ^{boolean};(?:adverse event|non-compliance|lost to follow up|other)$
       interpolated: true
     slot_uri: MIXS:0000898
   study_design:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -15,6 +15,7 @@ prefixes:
   xsd: http://www.w3.org/2001/XMLSchema#
   shex: http://www.w3.org/ns/shex#
   schema: http://schema.org/
+  SO: http://purl.obolibrary.org/obo/SO_  # Sequence Ontology
 default_prefix: MIXS
 default_range: string
 subsets:
@@ -417,20 +418,20 @@ enums:
     description: Types of viral genomes based on Baltimore classification
     permissible_values:
       DNA:
-        meaning: http://purl.obolibrary.org/obo/SO_0000352    # 'DNA'
+        meaning: SO:0000352    # 'DNA'
       dsDNA:
-        meaning: http://purl.obolibrary.org/obo/SO_0001198    # 'ds_DNA_viral_sequence'
+        meaning: SO:0001198    # 'ds_DNA_viral_sequence'
       ssDNA:
       RNA:
-        meaning: http://purl.obolibrary.org/obo/SO_0000356    # 'RNA'
+        meaning: SO:0000356    # 'RNA'
       dsRNA:
-        meaning: http://purl.obolibrary.org/obo/SO_0001169    # 'ds_RNA_viral_sequence'
+        meaning: SO:0001169    # 'ds_RNA_viral_sequence'
       ssRNA:
-        meaning: http://purl.obolibrary.org/obo/SO_0001199    # 'ss_RNA_viral_sequence'
+        meaning: SO:0001199    # 'ss_RNA_viral_sequence'
       "ssRNA (+)":
-        meaning: http://purl.obolibrary.org/obo/SO_0001201    # 'positive_sense_ssRNA_viral_sequence'
+        meaning: SO:0001201    # 'positive_sense_ssRNA_viral_sequence'
       "ssRNA (-)":
-        meaning: http://purl.obolibrary.org/obo/SO_0001200    # 'negative_sense_ssRNA_viral_sequence'
+        meaning: SO:0001200    # 'negative_sense_ssRNA_viral_sequence'
       mixed:
       uncharacterized:
   GrowthHabitEnum:
@@ -7585,7 +7586,7 @@ slots:
       transfection
     title: genetic modification
     examples:
-      - value: aox1A transgenic
+      - value: PMID:19497774  # PMID for review of infection in sickle cell disease
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -4562,7 +4562,6 @@ slots:
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
-      partial_match: true
     slot_uri: MIXS:0000091
     multivalued: true
     recommended: true
@@ -5622,7 +5621,6 @@ slots:
     structured_pattern:
       syntax: ^{text}|{PMID}|{DOI}|{URL}$
       interpolated: true
-      partial_match: true
     slot_uri: MIXS:0001041
   cult_target:
     annotations:
@@ -7591,8 +7589,7 @@ slots:
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
-      partial_match: true
-    slot_uri: MIXS:0000859
+      slot_uri: MIXS:0000859
   geo_loc_name:
     description: The geographical origin of the sample as defined by the country or
       sea name followed by specific region name. Country or sea names should be chosen
@@ -12593,7 +12590,6 @@ slots:
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
-      partial_match: true
     slot_uri: MIXS:0000090
     multivalued: true
   sort_tech:
@@ -18758,7 +18754,6 @@ classes:
         structured_pattern:
           syntax: ^{PMID}|{DOI}|{URL}$
           interpolated: true
-          partial_match: true
       pool_dna_extracts:
         string_serialization: '{boolean};{integer}'
       soil_type:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -413,6 +413,26 @@ enums:
       male:
       male and female:
       unisex:
+  ViralGenomeTypeEnum:
+    description: Types of viral genomes based on Baltimore classification
+    permissible_values:
+      DNA:
+        meaning: http://purl.obolibrary.org/obo/SO_0000352    # 'DNA'
+      dsDNA:
+        meaning: http://purl.obolibrary.org/obo/SO_0001198    # 'ds_DNA_viral_sequence'
+      ssDNA:
+      RNA:
+        meaning: http://purl.obolibrary.org/obo/SO_0000356    # 'RNA'
+      dsRNA:
+        meaning: http://purl.obolibrary.org/obo/SO_0001169    # 'ds_RNA_viral_sequence'
+      ssRNA:
+        meaning: http://purl.obolibrary.org/obo/SO_0001199    # 'ss_RNA_viral_sequence'
+      "ssRNA (+)":
+        meaning: http://purl.obolibrary.org/obo/SO_0001201    # 'positive_sense_ssRNA_viral_sequence'
+      "ssRNA (-)":
+        meaning: http://purl.obolibrary.org/obo/SO_0001200    # 'negative_sense_ssRNA_viral_sequence'
+      mixed:
+      uncharacterized:
   GrowthHabitEnum:
     permissible_values:
       erect:
@@ -9870,7 +9890,7 @@ slots:
   otu_class_appr:
     annotations:
       Expected_value: cutoffs and method used
-    description: Cutoffs and approach used when clustering  species-level  OTUs. Note
+    description: Cutoffs and approach used when clustering species-level OTUs. Note
       that results from standard 95% ANI / 85% AF clustering should be provided alongside
       OTUS defined from another set of thresholds, even if the latter are the ones
       primarily used during the analysis
@@ -10067,7 +10087,9 @@ slots:
       - sequencing
     keywords:
       - pcr
-    string_serialization: FWD:{dna};REV:{dna}
+    structured_pattern:
+      syntax: FWD:{dna};REV:{dna}
+      interpolated: true
     slot_uri: MIXS:0000046
   permeability:
     annotations:
@@ -10497,7 +10519,7 @@ slots:
     keywords:
       - predict
       - type
-    string_serialization: '[DNA|dsDNA|ssDNA|RNA|dsRNA|ssRNA|ssRNA (+)|ssRNA (-)|mixed|uncharacterized]'
+    range: ViralGenomeTypeEnum
     slot_uri: MIXS:0000082
   pregnancy:
     description: Date due of pregnancy
@@ -12931,8 +12953,9 @@ slots:
       - value: no;non-compliance
     keywords:
       - status
-    string_serialization: '{boolean};[adverse event|non-compliance|lost to follow
-      up|other-specify]'
+    structured_pattern:
+      syntax: ^{boolean};(?:adverse event|non-compliance|lost to followup|other-specify)$
+      interpolated: true
     slot_uri: MIXS:0000898
   study_design:
     annotations:
@@ -21824,8 +21847,10 @@ settings:
   adapter_A_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
   adapter_B_DNA_sequence: '[ACGTRKSYMWBHDVN]+'
   ambiguous_nucleotides: '[ACGTRKSYMWBHDVN]+'
+  boolean: '(?:yes|no)' # a non-capturing group matching either 'yes' or 'no'
   country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   date_time_stamp: '(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?$'
+  dna: '^[ACGT]+$'
   duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
   float: '[-+]?[0-9]*\.?[0-9]+'
   integer: '[1-9][0-9]*'

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -4559,7 +4559,10 @@ slots:
       - sequencing
     keywords:
       - resource
-    string_serialization: '{PMID}|{DOI}|{URL}'
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000091
     multivalued: true
     recommended: true
@@ -5607,8 +5610,6 @@ slots:
       interpolated: true
       partial_match: true
   cult_root_med:
-    annotations:
-      Expected_value: name, PMID,DOI or url
     description: Name or reference for the hydroponic or in vitro culture rooting
       medium; can be the name of a commonly used medium or reference to a specific
       medium, e.g. Murashige and Skoog medium. If the medium has not been formally
@@ -5618,7 +5619,10 @@ slots:
       - value: http://himedialabs.com/TD/PT158.pdf
     keywords:
       - culture
-    string_serialization: '{text}|{PMID}|{DOI}|{URL}'
+    structured_pattern:
+      syntax: ^{text}|{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0001041
   cult_target:
     annotations:
@@ -7577,8 +7581,6 @@ slots:
     slot_uri: MIXS:0000808
     range: GenderRestroomEnum
   genetic_mod:
-    annotations:
-      Expected_value: PMID, DOI, URL or text
     description: Genetic modifications of the genome of an organism, which may occur
       naturally by spontaneous mutation, or be introduced by some experimental means,
       e.g. specification of a transgene or the gene knocked-out or details of transient
@@ -7586,7 +7588,10 @@ slots:
     title: genetic modification
     examples:
       - value: aox1A transgenic
-    string_serialization: '{PMID}|{DOI}|{URL}'
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000859
   geo_loc_name:
     description: The geographical origin of the sample as defined by the country or
@@ -9892,7 +9897,7 @@ slots:
       Expected_value: cutoffs and method used
     description: Cutoffs and approach used when clustering species-level OTUs. Note
       that results from standard 95% ANI / 85% AF clustering should be provided alongside
-      OTUS defined from another set of thresholds, even if the latter are the ones
+      OTUs defined from another set of thresholds, even if the latter are the ones
       primarily used during the analysis
     title: OTU classification approach
     examples:
@@ -9902,7 +9907,7 @@ slots:
     keywords:
       - classification
       - otu
-    string_serialization: '{ANI cutoff};{AF cutoff};{clustering method}'
+    structured_pattern: ^{integer}%\s*ANI;\s*{integer}%\s*AF;\s*{text}$ # constrain based on Leiden algorithm
     slot_uri: MIXS:0000085
   otu_db:
     annotations:
@@ -10074,8 +10079,6 @@ slots:
       elongation:degrees_minutes;total cycles
     slot_uri: MIXS:0000049
   pcr_primers:
-    annotations:
-      Expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
     description: PCR primers that were used to amplify the sequence of the targeted
       gene, locus or subfragment. This field should contain all the primers used for
       a single PCR reaction if multiple forward or reverse primers are present in
@@ -11361,7 +11364,12 @@ slots:
       - value: 4th floor
     keywords:
       - floor
-    string_serialization: '[1st floor|2nd floor|{integer} floor|basement|lobby]'
+    # \d*1[1-3]th –> 11th, 12th, 13th, 111th, etc.
+    # \d*1st –> 1st, 21st, 31st, 101st, etc.
+    # \d*2nd –> 2nd, 22nd, 32nd, 102nd, etc.
+    # \d*3rd –> 3rd, 23rd, 33rd, 103rd, etc.
+    # \d*[04-9]th –> 4th, 5th, 6th, 10th, 11th, 14th, 20th, etc.
+    pattern: ^(?:(?:\d*1[1-3]th|\d*1st|\d*2nd|\d*3rd|\d*[04-9]th) floor|basement|lobby)$
     slot_uri: MIXS:0000828
   samp_loc_condition:
     description: The condition of the sample location at the time of sampling
@@ -12580,7 +12588,10 @@ slots:
       - sequencing
     keywords:
       - procedures
-    string_serialization: '{PMID}|{DOI}|{URL}'
+    structured_pattern:
+      syntax: ^{PMID}|{DOI}|{URL}$
+      interpolated: true
+      partial_match: true
     slot_uri: MIXS:0000090
     multivalued: true
   sort_tech:
@@ -18742,7 +18753,10 @@ classes:
       elev:
         required: true
       heavy_metals_meth:
-        string_serialization: '{PMID}|{DOI}|{URL}'
+        structured_pattern:
+          syntax: ^{PMID}|{DOI}|{URL}$
+          interpolated: true
+          partial_match: true
       pool_dna_extracts:
         string_serialization: '{boolean};{integer}'
       soil_type:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -10091,7 +10091,7 @@ slots:
     keywords:
       - pcr
     structured_pattern:
-      syntax: FWD:{dna};REV:{dna}
+      syntax: FWD:{ambiguous_nucleotides};REV:{ambiguous_nucleotides}
       interpolated: true
     slot_uri: MIXS:0000046
   permeability:


### PR DESCRIPTION
This PR contains fixes for misrepresented `string_serialization` by replacing them with appropriate `structured_pattern` patterns.

Since there are many terms that need to be fixed, we will be carrying this out in batches. This PR seeks to fix the following patterns:

Sujay's pattern assignments:

- [x] `FWD:{dna};REV:{dna}`
    - `pcr_primers`
    - no usage in NCBI Biosamples as of 2025-01-08
    - Expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
    - see also more complex slot `org_count_qpcr_info`
- [x] `[1st floor|2nd floor|{integer} floor|basement|lobby]`
    - `samp_floor`
    - no usage in NCBI Biosamples as of 2025-01-08
    - see related slot `room_type`
- [x] `[DNA|dsDNA|ssDNA|RNA|dsRNA|ssRNA|ssRNA (+)|ssRNA (-)|mixed|uncharacterized]`
    - `pred_genome_type`
    - no usage in NCBI Biosamples as of 2025-01-08
    - Expected_value: enumeration
- [x] `{ANI cutoff};{AF cutoff};{clustering method}` (might need a full regex pattern instead of structured_pattern)
    - `otu_class_appr`
    - no usage in NCBI Biosamples as of 2025-01-08
- [x] `{PMID}|{DOI}|{URL}` (exists)
    - [x] still lingering in `associated_resource`
        - no usage in NCBI Biosamples as of 2025-01-08 
    - [x] still lingering in `genetic_mod`
        - poor compliance in NCBI Biosamples as of 2025-01-08
    - [x] still lingering as a `slot_usage` for `heavy_metals_meth` in `Agriculture`
        - poor compliance in NCBI Biosamples as of 2025-01-08
    - see also more complex slot `cult_root_med`
- [x] `{boolean};[adverse event|non-compliance|lost to follow up|other-specify]`
    - `study_complt_stat`
    - @turbomam changed "other-specify" to "other"