### PR TITLE
Remove generation of graphql, protobuf, shacl, shex, and sqlschema formats

### DIFF
--- a/project-generator-config.yaml
+++ b/project-generator-config.yaml
@@ -1,16 +1,11 @@
 directory: project
 includes:
-  - graphql # warnings about re-encoding
   - jsonld
   - jsonldcontext
   - jsonschema
   - owl
   - prefixmap
-  - proto
   - python
-  - shacl
-  - shex
-  - sqltable # slow
 excludes:
   - csv # no default output? # not widely used # largely supplanted by schemasheets
   - doc # handled separately
@@ -18,15 +13,20 @@ excludes:
   - excel # handled separately
   - golang # no default output?
   - golr-views # no default output?
+  - graphql # warnings about re-encoding
   - graphviz # would need customization
   - java # no default output?
   - markdown # redundant with docs
   - namespaces # no default output?
   - plantuml # would need customization
+  - proto
   - pydantic # no default output?
   - rdf # no default output?
+  - shacl
+  - shex
   - sparql # no default output?
   - sqla # no default output?
+  - sqltable # slow
   - sssom # no default output?
   - summary # no default output?
   - terminusdb # no default output?


### PR DESCRIPTION
Moved these formats from includes to excludes in project-generator-config.yaml to streamline LinkML generation to only Python, jsonld, jsonschema, owl, and prefixmap formats.

🤖 Generated with [Claude Code](https://claude.ai/code)