### PR TITLE
Fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ This section will be update or deleted after the release of MIxS 7.
 <a id="contributions"></a>
 ## Guidelines for Contributions and Requests
 
-Please review the [MIxS editing policies](policy.md) before making contributions to this repo.
+Please review the [MIxS editing policies](src/docs/policy.md) before making contributions to this repo.
 
-For guidance on how to request a new checklist or package, request a new term or update to an existing term, or report an issue with the MIxS code, please see [the workflows document](worklow.md).
+For guidance on how to request a new checklist or package, request a new term or update to an existing term, or report an issue with the MIxS code, please see [the workflows document](src/docs/edit_workflow.md).
 
 For guidance on how to use LinkML or contribute to the core LinkML code, please see [the LinkML documentation](https://linkml.io/linkml/).
 


### PR DESCRIPTION
## Summary

Fixes two broken links in CONTRIBUTING.md:

| Line | Before | After |
|------|--------|-------|
| 43 | `policy.md` | `src/docs/policy.md` |
| 45 | `worklow.md` | `src/docs/edit_workflow.md` |

The second link also had a typo ("worklow" missing 'f').

## Related

Partial fix for #1105 (the remaining items in that issue require decisions or involve external Google Docs)