### PR TITLE
Fix strange characters and typos in slot descriptions

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -4532,8 +4532,8 @@ slots:
   aromatics_pc:
     annotations:
       Preferred_unit: percent
-    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
-      method that divides  crude oil  components according to their polarizability
+    description: 'Saturate, Aromatic, Resin and Asphaltene (SARA) is an analysis
+      method that divides crude oil components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
       popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
       https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
@@ -4548,8 +4548,8 @@ slots:
   asphaltenes_pc:
     annotations:
       Preferred_unit: percent
-    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
-      method that divides  crude oil  components according to their polarizability
+    description: 'Saturate, Aromatic, Resin and Asphaltene (SARA) is an analysis
+      method that divides crude oil components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
       popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
       https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
@@ -8278,7 +8278,7 @@ slots:
       (e.g. intestines, heart).MIxS . Terms from other OBO ontologies are permissible
       as long as they reference mass/volume nouns (e.g. air, water, blood) and not
       discrete, countable entities (e.g. intestines, heart)'
-    title: host of the symbiotic host environemental medium
+    title: host of the symbiotic host environmental medium
     examples:
       - value: feces[uberon:0001988]
     keywords:
@@ -10321,9 +10321,9 @@ slots:
     annotations:
       Preferred_unit: degree Celsius
     description: 'Temperature at which a liquid becomes semi solid and loses its flow
-      characteristics. In crude oil a high  pour point  is generally associated with
+      characteristics. In crude oil a high pour point is generally associated with
       a high paraffin content, typically found in crude deriving from a larger proportion
-      of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
+      of plant material. (source: https://en.wikipedia.org/wiki/pour_point)'
     title: pour point
     slot_uri: MIXS:0000127
     range: string
@@ -10739,8 +10739,8 @@ slots:
   resins_pc:
     annotations:
       Preferred_unit: percent
-    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
-      method that divides  crude oil  components according to their polarizability
+    description: 'Saturate, Aromatic, Resin and Asphaltene (SARA) is an analysis
+      method that divides crude oil components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
       popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
       https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
@@ -11682,8 +11682,8 @@ slots:
   saturates_pc:
     annotations:
       Preferred_unit: percent
-    description: 'Saturate, Aromatic, Resin and Asphaltene  (SARA) is an analysis
-      method that divides  crude oil  components according to their polarizability
+    description: 'Saturate, Aromatic, Resin and Asphaltene (SARA) is an analysis
+      method that divides crude oil components according to their polarizability
       and polarity. There are three main methods to obtain SARA results. The most
       popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source:
       https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
@@ -13021,9 +13021,9 @@ slots:
   tan:
     annotations:
       Preferred_unit: milligram per liter
-    description: 'Total Acid Number  (TAN) is a measurement of acidity that is determined
-      by the amount of  potassium hydroxide  in milligrams that is needed to neutralize
-      the acids in one gram of oil.  It is an important quality measurement of  crude
+    description: 'Total Acid Number (TAN) is a measurement of acidity that is determined
+      by the amount of potassium hydroxide in milligrams that is needed to neutralize
+      the acids in one gram of oil. It is an important quality measurement of crude
       oil. (source: https://en.wikipedia.org/wiki/Total_acid_number)'
     title: total acid number
     keywords:
@@ -13742,8 +13742,8 @@ slots:
     annotations:
       Expected_value: measurement value;measurement value
       Preferred_unit: cP at degree Celsius
-    description: A measure of oil's resistance  to gradual deformation by  shear stress  or  tensile
-      stress (e.g. 3.5 cp; 100   C)
+    description: A measure of oil's resistance to gradual deformation by shear stress or tensile
+      stress (e.g. 3.5 cp; 100 °C)
     title: viscosity
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000126
@@ -18070,7 +18070,7 @@ classes:
   PlantAssociated:
     description: >-
       A collection of terms appropriate when collecting samples and sequencing samples 
-      obtained from a plant to examine it’s plant-associated microbiome.
+      obtained from a plant to examine its plant-associated microbiome.
     title: plant-associated
     is_a: Extension
     slots:


### PR DESCRIPTION
## Summary

Addresses #707 - cleanup of encoding artifacts and typos that remained from previous character encoding issues.

**Fixes:**
- `environemental` → `environmental` in host_symbiont_host_env_med title
- `soure` → `source` in pour_point description  
- `it's` → `its` (possessive) in PlantAssociated description
- Added missing degree symbol in viscosity example (`100 °C`)
- Removed double spaces (encoding artifacts from old non-breaking space cleanup) in:
  - aromatics_pc, asphaltenes_pc, resins_pc, saturates_pc (SARA descriptions)
  - tan (Total Acid Number description)
  - pour_point description
  - viscosity description

## Test plan

- [ ] Verify YAML is valid
- [ ] Review that descriptions read correctly without extra spaces

🤖 Generated with [Claude Code](https://claude.ai/code)