### PR TITLE
Document system prerequisites for building and testing (yq, Poetry, Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Below are descriptions for the various user-facing directories in this repositor
 
 ## Developer Documentation
 Note: Developer documention is specifically included here for the use of members of the GSC's CIG and TWG committees.
+
+### Prerequisites
+
+Building and testing MIxS locally requires these tools on your `PATH`:
+
+* **Python 3.10+** and **[Poetry](https://python-poetry.org/)** for the Python dependencies. `make install` runs `poetry install --all-extras`.
+* **[yq](https://github.com/mikefarah/yq) v4, the Go implementation by mikefarah.** The build uses `yq` extensively to transform the schema (the `contrib/` pipeline and the TSV round-trip test). This is **not** the Python `yq` (`pip install yq`, the kislyuk wrapper); the two have incompatible syntax, and the Python one causes build errors. Install with `brew install yq` (macOS) or see the [yq install docs](https://github.com/mikefarah/yq#install).
+* **make** and **bash**.
+
+`npm`/`node` are needed only for the experimental `make create-data-harmonizer` target, not for the normal build. CI relies on the `yq` preinstalled on the GitHub `ubuntu-latest` runner.
+
 <details>
 Use the `make` command to generate project artefacts:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Building and testing MIxS locally requires these tools on your `PATH`:
 * **[yq](https://github.com/mikefarah/yq) v4, the Go implementation by mikefarah.** The build uses `yq` extensively to transform the schema (the `contrib/` pipeline and the TSV round-trip test). This is **not** the Python `yq` (`pip install yq`, the kislyuk wrapper); the two have incompatible syntax, and the Python one causes build errors. Install with `brew install yq` (macOS) or see the [yq install docs](https://github.com/mikefarah/yq#install).
 * **make** and **bash**.
 
-`npm`/`node` are needed only for the experimental `make create-data-harmonizer` target, not for the normal build. CI relies on the `yq` preinstalled on the GitHub `ubuntu-latest` runner.
+`npm`/`node` are needed only for the experimental `make create-data-harmonizer` target, not for the normal build. As of this writing, CI does not install `yq` itself; it relies on the `yq` v4 that ships preinstalled on the GitHub `ubuntu-latest` runner. That is an assumption about the current runner image, not a guarantee: if a future image drops or changes `yq`, the workflows will need to install a pinned version (see [#1242](https://github.com/GenomicsStandardsConsortium/mixs/issues/1242)).
 
 <details>
 Use the `make` command to generate project artefacts:


### PR DESCRIPTION
Adds a Prerequisites subsection to the README developer docs.

The build hard-depends on mikefarah `yq` v4 (used throughout the `contrib/` transformation pipeline and the TSV round-trip test), but this was documented nowhere. Anyone who installs the Python `yq` (`pip install yq`) instead of the Go one hits cryptic Makefile failures, because the two have incompatible syntax. This spells out the real prerequisites (Python 3.10+, Poetry, mikefarah `yq` v4) and warns which `yq` to avoid.

Addresses the prerequisites part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
