### PR TITLE
Describe MIxS (from GSC) in the ontology description, not the file

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -1,7 +1,7 @@
 ---
 name: mixs
 description: >-
-  This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project
+  MIxS, the Minimum Information about any (x) Sequence, is a standard from the Genomic Standards Consortium (GSC, https://www.gensc.org/) for reporting contextual metadata about sequenced samples. It defines checklists for genomic sequence types (for example genomes, metagenomes, and marker genes), environmental extensions, and the terms that populate them. See https://genomicsstandardsconsortium.github.io/mixs/.
 comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -1,7 +1,12 @@
 ---
 name: mixs
 description: >-
-  MIxS, the Minimum Information about any (x) Sequence, is a standard from the Genomic Standards Consortium (GSC, https://www.gensc.org/) for reporting contextual metadata about sequenced samples. It defines checklists for genomic sequence types (for example genomes, metagenomes, and marker genes), environmental extensions, and the terms that populate them. See https://genomicsstandardsconsortium.github.io/mixs/.
+  MIxS, the Minimum Information about any (x) Sequence, is a standard from the
+  Genomic Standards Consortium (GSC, https://www.gensc.org/) for reporting
+  contextual metadata about sequenced samples. It defines checklists for genomic
+  sequence types (for example genomes, metagenomes, and marker genes),
+  environmental extensions, and the terms that populate them. See
+  https://genomicsstandardsconsortium.github.io/mixs/.
 comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx


### PR DESCRIPTION
The schema `description:` becomes the ontology `skos:definition` that EBI OLS renders in the Ontology Information panel (see https://www.ebi.ac.uk/ols4/ontologies/gscmixs). The current text describes the YAML file and its build; this rewrites it to describe the MIxS standard and lead with the GSC as its source.

## Where the description comes from

The wording paraphrases how MIxS is defined in its foundational paper, which is already listed in this repo's `CITATION.cff`:

Yilmaz P, Kottmann R, Field D, Knight R, et al. "Minimum information about a marker gene sequence (MIMARKS) and minimum information about any (x) sequence (MIxS) specifications." Nature Biotechnology 29(5):415-420, 2011. doi:10.1038/nbt.1823

That paper introduces MIxS as the GSC framework unifying the MIGS (genomes), MIMS (metagenomes), and MIMARKS (marker genes) checklists plus environmental packages (now called extensions), which is exactly what the new description states.

Part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1220. Kept as a single-purpose change; the OWL is regenerated at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
