### PR TITLE
Set the schema version string to 6.3.1 (was stale v6.2.0)

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -6,7 +6,7 @@ comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
-version: v6.2.0
+version: 6.3.0
 imports:
   - linkml:types
 prefixes:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -6,7 +6,7 @@ comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
-version: 6.3.0
+version: 6.3.1
 imports:
   - linkml:types
 prefixes:


### PR DESCRIPTION
`mixs.yaml` declared `version: v6.2.0` while `pyproject.toml`, `CITATION.cff`, and `.zenodo.json` are at 6.3.0. Since these ontology-metadata fixes ship together in the next release, this sets the schema version to `6.3.1` and drops the `v` prefix so it matches the others. The schema version becomes the OWL `pav:version` shown in EBI OLS, so this also fixes the stale version there.

## How this relates to the other PRs

This is one of a set of small single-purpose PRs for https://github.com/GenomicsStandardsConsortium/mixs/issues/1220, meant to ship together in the 6.3.1 release:

- https://github.com/GenomicsStandardsConsortium/mixs/pull/1246 sets the current version value to 6.3.1 (one-time correction of the stale v6.2.0)
- https://github.com/GenomicsStandardsConsortium/mixs/pull/1248 makes the release workflow bump the schema version every release, so it never drifts again (the process fix behind the one-time correction)
- https://github.com/GenomicsStandardsConsortium/mixs/pull/1245 (description), https://github.com/GenomicsStandardsConsortium/mixs/pull/1247 (remove note), and https://github.com/GenomicsStandardsConsortium/mixs/pull/1249 (remove source) fix the other ontology-header fields OLS renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
