### PR TITLE
Remove the internal slot-title note from the ontology header

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -2,8 +2,6 @@
 name: mixs
 description: >-
   This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project
-comments:
-  - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
 version: v6.2.0


### PR DESCRIPTION
The schema-level `comments:` entry becomes the ontology `skos:note` that EBI OLS renders in the Ontology Information panel ("slot titles that are associated with more than one slot name/SCN: host sex"). That is an internal note, not something end users should see, so this removes it.

Part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1220. The underlying cause (a slot title shared by more than one slot) is tracked separately in https://github.com/GenomicsStandardsConsortium/mixs/issues/1223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)