### PR TITLE
Bump the schema version during release so it stops drifting

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -93,6 +93,10 @@ jobs:
         run: |
           sed -i 's/"version": ".*"/"version": "${{ inputs.version }}"/' .zenodo.json
 
+      - name: Bump version in the schema
+        run: |
+          sed -i 's/^version: .*/version: ${{ inputs.version }}/' src/mixs/schema/mixs.yaml
+
       - name: Update version references in documentation
         run: |
           # Update release/README.md - update the "Current version" link


### PR DESCRIPTION
The release workflow bumps `pyproject.toml`, `CITATION.cff`, `.zenodo.json`, and `release/README.md`, but never `src/mixs/schema/mixs.yaml`. That is why the schema version (and the OWL `pav:version` shown in EBI OLS) fell behind. This adds a step to set the schema `version:` to the release version too, matching the no-`v`-prefix convention.

## How this relates to the other PRs

This is one of a set of small single-purpose PRs for https://github.com/GenomicsStandardsConsortium/mixs/issues/1220, meant to ship together in the 6.3.1 release:

- https://github.com/GenomicsStandardsConsortium/mixs/pull/1246 sets the current version value to 6.3.1 (one-time correction of the stale v6.2.0)
- https://github.com/GenomicsStandardsConsortium/mixs/pull/1248 makes the release workflow bump the schema version every release, so it never drifts again (the process fix behind the one-time correction)
- https://github.com/GenomicsStandardsConsortium/mixs/pull/1245 (description), https://github.com/GenomicsStandardsConsortium/mixs/pull/1247 (remove note), and https://github.com/GenomicsStandardsConsortium/mixs/pull/1249 (remove source) fix the other ontology-header fields OLS renders.

Longer term, enabling poetry-dynamic-versioning would remove manual bumps, though the schema/OWL version would still need to be injected at build time (poetry-dynamic-versioning sets the Python package version only, not this schema field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
