### PR TITLE
Remove the stale source assertion from the ontology header

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -4,7 +4,6 @@ description: >-
   This file contains a YAML-formatted specification of the Minimum Information about any (x) Sequence (MIxS) standard, generated using LinkML (https://linkml.io/linkml/). This file is released by the Genomic Standards Consortium (GSC; https://www.gensc.org/) for use by anyone handling data or information about biological sequences. This file is also used as an authoritative 'source of truth' to generate downstream GSC artifacts, available here: https://github.com/GenomicsStandardsConsortium/mixs/tree/main/project
 comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
-source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
 version: v6.2.0
 imports:


### PR DESCRIPTION
The schema-level `source:` pointed at an Excel file on a dead temporary branch (`issue-610-temp-mixs-xlsx-home`) and became the ontology `dcterms:source` that EBI OLS renders. Removing it (rather than repointing at a moving target) is cleaner: where OLS loads MIxS from belongs in the OLS config, not baked into the OWL.

Part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)