### PR TITLE
Cite the MIxS paper via a schema see_also (DOI)

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -6,6 +6,8 @@ comments:
   - 'slot titles that are associated with more than one slot name/SCN: host sex'
 source: https://github.com/GenomicsStandardsConsortium/mixs/raw/issue-610-temp-mixs-xlsx-home/mixs/excel/mixs_v6.xlsx
 id: https://w3id.org/mixs
+see_also:
+  - https://doi.org/10.1038/nbt.1823
 version: v6.2.0
 imports:
   - linkml:types


### PR DESCRIPTION
Adds a schema-level `see_also` pointing at the foundational MIxS paper (Yilmaz et al. 2011, [doi:10.1038/nbt.1823](https://doi.org/10.1038/nbt.1823)), which is already listed in `CITATION.cff`. This gives the ontology a machine-readable citation for its definition (`rdfs:seeAlso` on the ontology node) without embedding a DOI in the description prose.

Complements https://github.com/GenomicsStandardsConsortium/mixs/pull/1245, which rewrites the description based on that same paper. Part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)