### PR TITLE
Skip the lint-comment step on fork PRs so they don't false-red

### DIFF
--- a/.github/workflows/lint-linkml.yaml
+++ b/.github/workflows/lint-linkml.yaml
@@ -51,9 +51,11 @@ jobs:
           cat linting-results.md
 
       - name: Comment linting results on PR
-        # Skip on fork PRs: they get a read-only token, so createComment fails
-        # with "Resource not accessible by integration" and reddens the job even
-        # though the lint passed. Same guard used in test_pages_build.yaml.
+        # Only the PR-comment is skipped on fork PRs, NOT the lint. A fork PR gets
+        # a read-only token, so createComment fails with "Resource not accessible
+        # by integration" and reddens the job even though the lint passed. The
+        # "Run LinkML Linting" step above still runs on forks; its output is in the
+        # Actions log for this job. Same guard as test_pages_build.yaml.
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/lint-linkml.yaml
+++ b/.github/workflows/lint-linkml.yaml
@@ -51,7 +51,10 @@ jobs:
           cat linting-results.md
 
       - name: Comment linting results on PR
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: they get a read-only token, so createComment fails
+        # with "Resource not accessible by integration" and reddens the job even
+        # though the lint passed. Same guard used in test_pages_build.yaml.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ Please review GitHub's overview article,
 Please review GitHub's article, ["About Pull Requests"][about-pulls],
 and make your changes on a [new branch][about-branches].
 
+If your pull request comes from a fork, the LinkML Linting check still runs the linter on your schema, but it reports the result in the workflow's Actions log rather than as a pull request comment. A fork pull request has a read-only token and cannot post the comment, so only the comment is skipped, not the lint. A green check means the lint ran; open the "LinkML Linting" job to read the details.
+
 [about-branches]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches
 [about-issues]: https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues
 [about-pulls]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests


### PR DESCRIPTION
A PR from a fork gets a read-only `GITHUB_TOKEN`, regardless of the `pull-requests: write` the workflow declares (GitHub strips write access for fork PRs on purpose). So the "Comment linting results on PR" step, which calls `createComment`, fails with `Resource not accessible by integration` and reddens the whole job even though the lint passed with 0 errors. This is what shows on #1230.

Fix: guard that step to same-repo PRs, the same condition `test_pages_build.yaml` already uses. On a fork PR the step is skipped (skipped is not failed), so the job passes; the lint still runs and its output is in the Actions log. Same-repo PRs comment as before.

This is the minimal fix for the false red. Two related follow-ups are tracked separately: giving fork PRs the comment too (via `workflow_run`), and making the lint actually gate merges rather than being informational.

Closes #1271.

This PR also documents the behavior so it is not mistaken for the lint being skipped: an extended comment on the guarded step, and a note in `CONTRIBUTING.md` telling fork contributors the lint runs and its output is in the Actions log.