### PR TITLE
Fix env_medium in the multivalued example after it became multivalued

### DIFF
--- a/src/data/examples/valid/MixsCompliantData-MimsSoil-multivalued-example.yaml
+++ b/src/data/examples/valid/MixsCompliantData-MimsSoil-multivalued-example.yaml
@@ -10,7 +10,8 @@ mims_soil_data:
   - chisel
   - ridge till
   env_local_scale: agricultural soil [ENVO:00002259]
-  env_medium: soil [ENVO:00001998]
+  env_medium:
+  - soil [ENVO:00001998]
   samp_taxon_id: soil metagenome [NCBITaxon:410658]
   geo_loc_name: 'USA: Iowa, Ames'
   collection_date: '2024-05-20T09:15:00-05:00'
@@ -31,7 +32,8 @@ mims_soil_data:
   - chisel
   - ridge till
   env_local_scale: grassland soil [ENVO:00005750]
-  env_medium: soil [ENVO:00001998]
+  env_medium:
+  - soil [ENVO:00001998]
   samp_taxon_id: soil metagenome [NCBITaxon:410658]
   geo_loc_name: 'USA: Kansas, Topeka'
   collection_date: '2024-04-10T00:00:00+00:00'
@@ -52,7 +54,8 @@ mims_soil_data:
   - chisel
   - ridge till
   env_local_scale: forest soil [ENVO:00002261]
-  env_medium: soil [ENVO:00001998]
+  env_medium:
+  - soil [ENVO:00001998]
   samp_taxon_id: soil metagenome [NCBITaxon:410658]
   geo_loc_name: 'Germany: Bavaria, Munich'
   collection_date: '2024-03-01T08:00:00+01:00'
@@ -71,7 +74,8 @@ mims_soil_data:
   tillage:
   - chisel
   env_local_scale: wetland [ENVO:00000043]
-  env_medium: soil [ENVO:00001998]
+  env_medium:
+  - soil [ENVO:00001998]
   samp_taxon_id: soil metagenome [NCBITaxon:410658]
   geo_loc_name: 'Brazil: Amazonas, Manaus'
   collection_date: '2024-01-15T12:00:00-03:00'


### PR DESCRIPTION
https://github.com/GenomicsStandardsConsortium/mixs/pull/1261 made env_medium multivalued. This example still supplied it as a scalar in all four records, so once both merged, `make examples/output` (part of the release SOP) failed on main. This converts the four records to single-element lists.

Verified locally: make test passes, every valid example validates, the scalar counter-example still fails as intended, and the YAML -> TSV -> YAML round-trip is equivalent.