### PR TITLE
Assign MIxS IDs to the 45 terms that have none

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -11240,7 +11240,7 @@ slots:
       - value: free range
     keywords:
       - production
-    slot_uri: MIXS:prod_label_claims
+    slot_uri: MIXS:0001337
     multivalued: true
     range: string
   prod_rate:
@@ -15278,7 +15278,7 @@ slots:
     keywords:
     - environment
     - sample
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001356
     multivalued: true
     range: string
     required: false
@@ -15297,7 +15297,7 @@ slots:
     keywords:
     - location
     - site
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001357
     multivalued: false
     range: string
     required: false
@@ -15315,7 +15315,7 @@ slots:
     examples:
     - value: '50.586825'
     - value: '-0.123'
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001358
     multivalued: false
     required: false
     recommended: false
@@ -15335,7 +15335,7 @@ slots:
     - value: '-12.12'
     in_subset:
     - environment
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001359
     multivalued: false
     required: false
     recommended: false
@@ -15359,7 +15359,7 @@ slots:
     - context
     - environmental
     - ancient
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001360
     range: string
     required: false
     recommended: true
@@ -15388,7 +15388,7 @@ slots:
     - environmental
     - ancient
     string_serialization: '{termLabel} [{termID}]'
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001361
     required: false
     recommended: true
   stratigraph_context:
@@ -15411,7 +15411,7 @@ slots:
     keywords:
     - identifiers
     - excavation
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001362
     multivalued: true
     range: string
     required: false
@@ -15427,7 +15427,7 @@ slots:
     - value: '2001-09-25'
     in_subset:
     - environment
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001363
     range: datetime
     required: false
     recommended: true
@@ -15440,7 +15440,7 @@ slots:
     - nucleic acid sequence source
     keywords:
     - ethics
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001364
     multivalued: true
     range: string
     required: false
@@ -15458,7 +15458,7 @@ slots:
     keywords:
     - ethics
     - location
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001365
     close_mappings:
     - "dc:rightsHolder"
     multivalued: true
@@ -15472,7 +15472,7 @@ slots:
     - value: '2023-12-01'
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001366
     multivalued: true
     range: datetime
     required: false
@@ -15488,7 +15488,7 @@ slots:
     - nucleic acid sequence source
     keywords:
     - ethics
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001367
     close_mappings:
     - "dc:accessRights"
     - "dc:license"
@@ -15510,7 +15510,7 @@ slots:
     - nucleic acid sequence source
     keywords:
     - ethics
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001368
     multivalued: true
     range: BioCulturalLabelEnum
     required: false
@@ -15524,7 +15524,7 @@ slots:
     - value: "Museum ID: NHM_AR_123, Drilling ID: DRL_001, Extraction ID: ABC_24"
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001369
     multivalued: true
     range: string
     string_serialization: '{text}'
@@ -15537,7 +15537,7 @@ slots:
     - value: "doi:10.1016/j.jas.2015.02.0181"
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001370
     multivalued: true
     range: string
     pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
@@ -15560,7 +15560,7 @@ slots:
     - nucleic acid sequence source
     keywords:
     - ancient
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001371
     multivalued: false
     range: string
     string_serialization: '{text}'
@@ -15577,7 +15577,7 @@ slots:
     - nucleic acid sequence source
     keywords:
     - ancient
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001372
     multivalued: true
     range: string
     string_serialization: '{text}'
@@ -15599,7 +15599,7 @@ slots:
     - age
     range: string
     string_serialization: '{termLabel} [{termID}]|{text}'
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001373
     multivalued: false
     required: false
     recommended: false
@@ -15618,7 +15618,7 @@ slots:
     - ancient
     - age
     range: GeolEpochEnum
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001374
     multivalued: false
     required: false
     recommended: false
@@ -15632,7 +15632,7 @@ slots:
     - value: '1900'
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001375
     broad_mappings:
     - "chrono:earliestChronometricAge"
     multivalued: false
@@ -15649,7 +15649,7 @@ slots:
     - value: ka
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001376
     broad_mappings:
     - "chrono:earliestChronometricAgeReferenceSystem"
     multivalued: false
@@ -15666,7 +15666,7 @@ slots:
     - value: '1700'
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001377
     broad_mappings:
     - "chrono:latestChronometricAge"
     multivalued: false
@@ -15683,7 +15683,7 @@ slots:
     - value: ka
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001378
     broad_mappings:
     - "chrono:latestChronometricAgeReferenceSystem"
     multivalued: false
@@ -15700,7 +15700,7 @@ slots:
     - value: historical records
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001379
     broad_mappings:
     - "chrono:chronometricAgeProtocol"
     multivalued: true
@@ -15718,7 +15718,7 @@ slots:
     - value: "radiocarbon age ID: OxA-12345"
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001380
     close_mappings:
     - "chrono:chronometricAgeRemarks"
     multivalued: false
@@ -15740,7 +15740,7 @@ slots:
     - palaeopathology
     - host health
     - ancient
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001381
     multivalued: false
     range: string
     string_serialization: '{text}'
@@ -15760,7 +15760,7 @@ slots:
     - nucleic acid sequence source
     keywords:
     - identifiers
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001382
     multivalued: true
     range: string
     required: false
@@ -15776,7 +15776,7 @@ slots:
     - control
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001383
     range: SampCategoryEnum
     required: true
     recommended: true
@@ -15787,7 +15787,7 @@ slots:
     - value: "doi:10.1016/j.jas.2015.02.0181"
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001384
     multivalued: true
     range: string
     pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
@@ -15807,7 +15807,7 @@ slots:
     - sequencing
     keywords:
     - ancient
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001385
     multivalued: false
     range: DamageTreatmentEnum
     recommended: true
@@ -15819,7 +15819,7 @@ slots:
     - value: '2023-12-01'
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001386
     range: datetime
     required: false
     recommended: false
@@ -15830,7 +15830,7 @@ slots:
     - value: "doi:10.1093/nar/gkr771"
     in_subset:
     - nucleic acid sequence source
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001387
     multivalued: true
     range: string
     pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
@@ -15853,7 +15853,7 @@ slots:
     keywords:
     - library
     - preparation
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001388
     multivalued: true
     range: string
     string_serialization: '{text}'
@@ -15872,7 +15872,7 @@ slots:
     - sequencing
     keywords:
     - sequencing
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001389
     multivalued: true
     range: string
     required: false
@@ -15893,7 +15893,7 @@ slots:
     - library
     - preparation
     string_serialization: '{text}'
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001390
     range: string
     required: false
     recommended: true
@@ -15910,7 +15910,7 @@ slots:
     keywords:
     - library
     - preparation
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001391
     multivalued: true
     range: LibStrandEnum
     required: true
@@ -15931,7 +15931,7 @@ slots:
     keywords:
     - library
     - preparation
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001392
     range: LibTypeEnum
     required: false
     recommended: true
@@ -15942,7 +15942,7 @@ slots:
     - value: "doi:10.1093/nar/gkr771"
     in_subset:
     - sequencing
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001393
     multivalued: true
     range: string
     pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
@@ -15959,7 +15959,7 @@ slots:
     - value: '12'
     in_subset:
     - sequencing
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001394
     range: integer
   capt_pcr_cyc_tot:
     description: Amplification cycles after capture enrichment total. Provide additional information about PCR conditions in pcr_cond
@@ -15968,7 +15968,7 @@ slots:
     - value: '12'
     in_subset:
     - sequencing
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001395
     range: integer
     multivalued: true
     required: false
@@ -15989,7 +15989,7 @@ slots:
     - library
     - enrichment
     - capture
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001396
     multivalued: true
     range: integer
     string_serialization:
@@ -16008,7 +16008,7 @@ slots:
     keywords:
     - library
     - enrichment
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001397
     multivalued: true
     range: string
     string_serialization: '{text}'
@@ -16028,7 +16028,7 @@ slots:
     keywords:
     - data analysis
     - data
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001398
     multivalued: false
     range: string
     required: false
@@ -16045,7 +16045,7 @@ slots:
     - sequencing
     keywords:
     - data analysis
-    slot_uri: "MIXS:XXXXXXXXX"
+    slot_uri: MIXS:0001399
     multivalued: false
     range: boolean
     required: false

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -18353,7 +18353,7 @@ classes:
       reads_removed:
         slot_group: Data analysis
         rank: 45
-    class_uri: "MIXS:9999903"
+    class_uri: "MIXS:0010016"
     annotations:
       use_cases: ancient dna samples
   BuiltEnvironment:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -18167,56 +18167,58 @@ classes:
       use_cases: bioaerosol samples, pathogen load in urban air, aerosols
   Ancient:
     description: A collection of terms appropriate when collecting samples and sequencing samples  of data containing ancient nucleic acids, i.e., degraded molecules not from living organisms.
+    aliases:
+      - minas
     comments:
-    - This extension that is intended to be used in very specific cases but almost always in conjunction with other MIxS checklists and extensions. It does not therefore (currently) include additional common terms from checklists.
+      - This extension that is intended to be used in very specific cases but almost always in conjunction with other MIxS checklists and extensions. It does not therefore (currently) include additional common terms from checklists.
     title: ancient
     is_a: Extension
     slots:
-    - orig_site_name
-    - orig_site_loc
-    - orig_site_lat
-    - orig_site_lon
-    - past_env_broad
-    - past_env_local
-    - stratigraph_context
-    - context_retrieval_date
-    - permit_id
-    - permit_authority
-    - permit_date
-    - permit_scope
-    - biocultural_label
-    - samp_alt_lab_ids
-    - prev_pubs
-    - host_preserv_state
-    - store_cond
-    - samp_preserv_treatm
-    - cultural_era
-    - geological_epoch
-    - earliest_chrono_age
-    - earliest_chrono_sys
-    - latest_chrono_age
-    - latest_chrono_sys
-    - chrono_age_protocol
-    - chrono_age_remarks
-    - palaeopath_status
-    - batch_ids
-    - samp_category
-    - samp_decont_pretreat
-    - damage_treatment
-    - nucl_acid_extr_date
-    - sop_experimental
-    - lib_mid_desc
-    - library_name
-    - lib_polymerase
-    - lib_strandedness
-    - lib_gener_technique
-    - sop_lib_preparation
-    - reamp_pcr_cyc_tot
-    - capt_pcr_cyc_tot
-    - capt_probe_src_taxid
-    - capt_probe_desc
-    - data_preproc_desc
-    - reads_removed
+      - orig_site_name
+      - orig_site_loc
+      - orig_site_lat
+      - orig_site_lon
+      - past_env_broad
+      - past_env_local
+      - stratigraph_context
+      - context_retrieval_date
+      - permit_id
+      - permit_authority
+      - permit_date
+      - permit_scope
+      - biocultural_label
+      - samp_alt_lab_ids
+      - prev_pubs
+      - host_preserv_state
+      - store_cond
+      - samp_preserv_treatm
+      - cultural_era
+      - geological_epoch
+      - earliest_chrono_age
+      - earliest_chrono_sys
+      - latest_chrono_age
+      - latest_chrono_sys
+      - chrono_age_protocol
+      - chrono_age_remarks
+      - palaeopath_status
+      - batch_ids
+      - samp_category
+      - samp_decont_pretreat
+      - damage_treatment
+      - nucl_acid_extr_date
+      - sop_experimental
+      - lib_mid_desc
+      - library_name
+      - lib_polymerase
+      - lib_strandedness
+      - lib_gener_technique
+      - sop_lib_preparation
+      - reamp_pcr_cyc_tot
+      - capt_pcr_cyc_tot
+      - capt_probe_src_taxid
+      - capt_probe_desc
+      - data_preproc_desc
+      - reads_removed
     slot_usage:
       orig_site_name:
         slot_group: Environment
@@ -18353,7 +18355,7 @@ classes:
       reads_removed:
         slot_group: Data analysis
         rank: 45
-    class_uri: "MIXS:0010016"
+    class_uri: MIXS:0016024
     annotations:
       use_cases: ancient dna samples
   BuiltEnvironment:


### PR DESCRIPTION
## Do not merge until the IDs are reserved in the registry

The numbers in this pull request are **not yet recorded in the MIxS ID registry spreadsheet**. Nothing in this branch can put them there, because the registry lives outside the repository and only people with edit access to it can update it.

Merging before the registry is updated would leave the schema claiming IDs the registry does not know about, which is a worse state than the placeholders it replaces. This is filed as a draft for that reason. Someone with edit access needs to add the 45 term-to-ID mappings below to the registry, and confirm here, before it is marked ready.

## What it changes

45 slots had a `slot_uri` that was not a MIxS ID.

44 MInAS terms carried the literal string `MIXS:XXXXXXXXX`, identical on all 44, so they failed the uniqueness requirement as well as the format one. They arrived via https://github.com/GenomicsStandardsConsortium/mixs/pull/1230 and have never been released, so no published identifier changes here. They take **MIXS:0001356 through MIXS:0001399**, assigned in schema document order.

`prod_label_claims` carried `MIXS:prod_label_claims`. The registry had already allocated **MIXS:0001337** to it, so this restores an existing allocation rather than making a new one.

The range was chosen because the highest number allocated anywhere in the registry is MIXS:0001355, and nothing at or above MIXS:0001356 is used by any slot in the schema. 0001356 to 0001399 is exactly 44.

One registry inconsistency worth fixing at the same time: MIXS:0001338 is used by the `isotope` slot in the schema but does not appear in the registry.

Closes part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1304, which asks for a check so this cannot happen again.

<details>
<summary>The 45 mappings, tab separated, for pasting into the registry</summary>

```
prod_label_claims	MIXS:0001337
orig_site_name	MIXS:0001356
orig_site_loc	MIXS:0001357
orig_site_lat	MIXS:0001358
orig_site_lon	MIXS:0001359
past_env_broad	MIXS:0001360
past_env_local	MIXS:0001361
stratigraph_context	MIXS:0001362
context_retrieval_date	MIXS:0001363
permit_id	MIXS:0001364
permit_authority	MIXS:0001365
permit_date	MIXS:0001366
permit_scope	MIXS:0001367
biocultural_label	MIXS:0001368
samp_alt_lab_ids	MIXS:0001369
prev_pubs	MIXS:0001370
host_preserv_state	MIXS:0001371
samp_preserv_treatm	MIXS:0001372
cultural_era	MIXS:0001373
geological_epoch	MIXS:0001374
earliest_chrono_age	MIXS:0001375
earliest_chrono_sys	MIXS:0001376
latest_chrono_age	MIXS:0001377
latest_chrono_sys	MIXS:0001378
chrono_age_protocol	MIXS:0001379
chrono_age_remarks	MIXS:0001380
palaeopath_status	MIXS:0001381
batch_ids	MIXS:0001382
samp_category	MIXS:0001383
samp_decont_pretreat	MIXS:0001384
damage_treatment	MIXS:0001385
nucl_acid_extr_date	MIXS:0001386
sop_experimental	MIXS:0001387
lib_mid_desc	MIXS:0001388
library_name	MIXS:0001389
lib_polymerase	MIXS:0001390
lib_strandedness	MIXS:0001391
lib_gener_technique	MIXS:0001392
sop_lib_preparation	MIXS:0001393
reamp_pcr_cyc_tot	MIXS:0001394
capt_pcr_cyc_tot	MIXS:0001395
capt_probe_src_taxid	MIXS:0001396
capt_probe_desc	MIXS:0001397
data_preproc_desc	MIXS:0001398
reads_removed	MIXS:0001399
```

</details>
