### PR TITLE
Set the schema version to 7.0.0

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12,7 +12,7 @@ comments:
 id: https://w3id.org/mixs
 see_also:
   - https://doi.org/10.1038/nbt.1823
-version: 6.3.1
+version: 7.0.0
 imports:
   - linkml:types
 prefixes:


### PR DESCRIPTION
One line: `version: 6.3.1` becomes `version: 7.0.0` in `src/mixs/schema/mixs.yaml`.

This is step 1 of "Cutting a release" in `src/docs/edit_workflow.md`, and the one version string no workflow updates. "Create Release PR" bumps `CITATION.cff`, `.zenodo.json` and `release/README.md`; the Python package version comes from the git tag through poetry-dynamic-versioning. The schema version is deliberately left as a single manual edit, following the pattern `biolink-model` uses, decided in https://github.com/GenomicsStandardsConsortium/mixs/pull/1265.

It matters more than the other three because it flows into the generated OWL as `pav:version`, which EBI OLS reads, and into the JSON Schema and the datamodel. Leaving it stale is what https://github.com/GenomicsStandardsConsortium/mixs/issues/1220 was opened about, and the same drift is part of why v6.3.1 exists at all.

## On timing

Merging this to `main` before the release actually goes ahead would leave `main` advertising 7.0.0 while the newest tag is still v6.3.1, which is the drift described above in the other direction. If the release slips, this is better merged into the `release/v7.0.0` branch that "Create Release PR" produces, rather than into `main` ahead of it.
