### PR TITLE
Set the schema version to 7.0.0-rc1

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12,7 +12,7 @@ comments:
 id: https://w3id.org/mixs
 see_also:
   - https://doi.org/10.1038/nbt.1823
-version: 7.0.0
+version: 7.0.0-rc1
 imports:
   - linkml:types
 prefixes:


### PR DESCRIPTION
One line: `version: 7.0.0` becomes `version: 7.0.0-rc1` in `src/mixs/schema/mixs.yaml`.

Step 1 of "Cutting a release" in `src/docs/edit_workflow.md`, for a release candidate. "Create Release PR" builds from `main`, so the schema version has to match the version being released before it is dispatched. Without this, the release branch would carry `version: 7.0.0` in the schema while `CITATION.cff`, `.zenodo.json` and `release/README.md` all say `7.0.0-rc1`, and the schema version is the one consumers read.

## This moves main backwards, on purpose

`7.0.0-rc1` sorts before `7.0.0` in semver, so `main` will briefly advertise a lower version than it did an hour ago. That is the cost of building a release candidate from `main` rather than from a branch.

It is temporary. Cutting the real v7.0.0 means bumping this back to `7.0.0` before dispatching again.

Worth noting for anyone reading later: this is the second version bump today. https://github.com/GenomicsStandardsConsortium/mixs/pull/1315 set it to `7.0.0`, and this steps it back for the candidate.
