### PR TITLE
Document release candidates, workflow approval, and MIxS ID requests

### DIFF
--- a/src/docs/SCHEMA_DIFFING.md
+++ b/src/docs/SCHEMA_DIFFING.md
@@ -132,9 +132,14 @@ poetry run diff-releases \
 
 ## Which releases can be compared
 
-The tool takes a path per side, so it can reach any release. The **release
-workflow** cannot: it hardcodes `src/mixs/schema/mixs.yaml` for both sides, so
-its oldest usable base is v6.2.0.
+The tool takes a path per side, so it can reach any release that has a LinkML
+schema, which means v6.0.0 onward. `MIxS5` predates LinkML entirely and cannot
+be compared with this tool at all; the v5 to v6.0.0 comparison was produced by a
+separate one-time script with an Excel reader.
+
+The **release workflow** is more limited still: it hardcodes
+`src/mixs/schema/mixs.yaml` for both sides, so its oldest usable base is
+v6.2.0.
 
 | tag | released | `src/mixs/schema/mixs.yaml` | usable in the release workflow |
 | --- | --- | --- | --- |

--- a/src/docs/SCHEMA_DIFFING.md
+++ b/src/docs/SCHEMA_DIFFING.md
@@ -115,9 +115,41 @@ poetry run diff-releases \
 
 ```bash
 poetry run diff-releases \
-  --old "GenomicsStandardsConsortium/mixs@v6.1.0:src/mixs/schema/mixs.yaml" \
-  --new "GenomicsStandardsConsortium/mixs@v6.2.0:src/mixs/schema/mixs.yaml"
+  --old "GenomicsStandardsConsortium/mixs@v6.2.0:src/mixs/schema/mixs.yaml" \
+  --new "GenomicsStandardsConsortium/mixs@v6.3.1:src/mixs/schema/mixs.yaml"
 ```
+
+**A release from before v6.2.0.** The path differs on the old side, because the
+single-file schema only exists from v6.2.0 onward. Earlier releases keep the
+schema under `model/schema/`, reached through a small root file that imports the
+rest, and the tool resolves those imports itself:
+
+```bash
+poetry run diff-releases \
+  --old "GenomicsStandardsConsortium/mixs@mixs6.0.0:model/schema/mixs.yaml" \
+  --new "GenomicsStandardsConsortium/mixs@main:src/mixs/schema/mixs.yaml"
+```
+
+## Which releases can be compared
+
+The tool takes a path per side, so it can reach any release. The **release
+workflow** cannot: it hardcodes `src/mixs/schema/mixs.yaml` for both sides, so
+its oldest usable base is v6.2.0.
+
+| tag | released | `src/mixs/schema/mixs.yaml` | usable in the release workflow |
+| --- | --- | --- | --- |
+| `MIxS5` | 2022-02-27 | absent (v5 was an Excel workbook) | no |
+| `mixs6.0.0` | 2022-03-24 | absent, schema under `model/schema/` | no |
+| `mixs6.1.0` | 2022-07-05 | absent, schema under `model/schema/` | no |
+| `mixs6.1.1` | 2023-10-09 | absent, schema under `model/schema/` | no |
+| `v6.2.0` | 2023-10-18 | present | yes |
+| `v6.2.2` | 2025-12-15 | present | yes |
+| `v6.2.3` | 2026-01-21 | present | yes |
+| `v6.3.0` | 2026-02-06 | present | yes |
+| `v6.3.1` | 2026-07-14 | present | yes |
+
+Note the tag naming changes at v6.2.0: earlier releases are `mixs6.x` and `MIxS5`,
+not `v6.x`. There is no `v6.2.1`; the sequence skips from v6.2.0 to v6.2.2.
 
 **Your fork against upstream** (review a branch before opening a PR):
 

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -6,6 +6,23 @@ Please try to follow this document. First read the [policies](policy.md) documen
 
 ## Requesting and creating a new term
 
+## Requesting a MIxS ID
+
+MIxS IDs are allocated by the CIG from a registry maintained outside this
+repository. **Do not assign one yourself, and do not reuse a number that looks
+free in the schema.** Request one on the GitHub issue for the term, and a CIG
+member with registry access will allocate it and record it there.
+
+Terms and structural elements come from different ranges: terms use the
+`slot_uri` range, and checklists, extensions and combinations use the
+`class_uri` range. A CIG member will tell you which applies and what the next
+number is.
+
+The order matters. The ID is added after the term is approved and before the
+pull request is merged. Placeholder values such as `MIXS:XXXXXXXXX` must not
+reach `main`; 44 terms did in 2026 and had to be corrected afterwards.
+
+
 ## Requesting and implementing a term update
 
 
@@ -35,10 +52,29 @@ MIxS carries two version numbers, managed differently. Both use bare `X.Y.Z` val
 1. Bump the schema version by editing the `version:` field near the top of `src/mixs/schema/mixs.yaml` to the new release number (bare `X.Y.Z`). Commit it to `main` via the normal PR process. Pushing this to `main` triggers the "Regenerate and verify generated artifacts" workflow, which regenerates the OWL and other `project/` artifacts so they carry the new version.
 2. Run the "Create Release PR" GitHub Action (manual dispatch) with the same version. It bumps `CITATION.cff`, `.zenodo.json`, and `release/README.md`, generates the schema diff, and opens a `release/vX.Y.Z` PR. It does not touch `pyproject.toml` (dynamic) or `mixs.yaml` (already bumped in step 1).
 3. Add the schema-diff summaries to the release branch (see below).
-4. Review and merge the release PR.
-5. Create a GitHub Release with tag `vX.Y.Z` and generate release notes.
+4. **Approve the workflows on the release pull request.** It is opened by the
+   workflow itself, so GitHub does not run any checks on it until a maintainer
+   clicks "approve and run workflows". Until then the pull request has no checks
+   at all, rather than failing ones, which is easy to miss.
+5. Review and merge the release pull request.
+6. Create a GitHub Release. Tag `vX.Y.Z`, target `main` so the tag lands on the
+   merge commit rather than the release branch, and generate release notes
+   against the previous release as the "Previous tag". For a release candidate,
+   see [Publishing a release candidate](#publishing-a-release-candidate) below.
 
-The structured diff in step 2 is produced by the reusable `diff-releases` tool; see [SCHEMA_DIFFING.md](SCHEMA_DIFFING.md).
+The structured diff in step 2 is produced by the reusable `diff-releases` tool; see [SCHEMA_DIFFING.md](SCHEMA_DIFFING.md). Note that it can only reach back to v6.2.0, because the workflow asks for `src/mixs/schema/mixs.yaml` on both sides and that path does not exist in earlier releases.
+
+The release notes cover the span between two tags, which is not necessarily the span the schema comparisons cover. If they differ, say so in the release body, or a reader will assume the pull requests listed produced the schema changes reported.
+
+## Publishing a release candidate
+
+`policy.md` requires a release candidate before every major and minor release. A candidate goes through the same steps above, with three differences:
+
+- Use a version of the form `X.Y.Z-rcN`, for example `7.0.0-rc1`. The workflow accepts a semver pre-release suffix, and the schema version in step 1 must match it.
+- Tick **Set as a pre-release** when creating the GitHub Release. This keeps the candidate off `/releases/latest`, so anything resolving "the current MIxS" continues to get the last full release.
+- Do not tick **Set as the latest release**.
+
+The schema version on `main` will read `X.Y.Z-rcN` for as long as the candidate stands. Before cutting the real release, bump it back to `X.Y.Z` and merge that first, or the release will ship a schema declaring itself a candidate.
 
 ## Adding the schema-diff summaries and publishing them
 
@@ -53,8 +89,11 @@ readable summaries to the release branch and put them on the docs site:
 3. Run the `mixs-diff-summary` skill on the structured diff, for example
    `/mixs-diff-summary assets/diff_results/<old>_to_<new>/schema_comparison_results.yaml`.
    It writes `agent_summary.md` next to the structured diff.
-4. Commit both `agent_summary.md` (the readable summary) and `tool_summary.md`
-   (the counts) in that folder.
+4. Commit `agent_summary.md` (the readable summary). Older comparisons also
+   carry a `tool_summary.md` with raw counts, but the reusable `diff-releases`
+   tool does not write one, so a new comparison will not have it. Do not write
+   one by hand: it would claim to be tool output that cannot be regenerated.
+   See issue 1318.
 5. Add the two pages to the site nav. In `mkdocs.yml`, under the `Version changes`
    group, add two lines for this release:
    ```yaml

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -19,8 +19,9 @@ Terms and structural elements come from different ranges: terms use the
 number is.
 
 The order matters. The ID is added after the term is approved and before the
-pull request is merged. Placeholder values such as `MIXS:XXXXXXXXX` must not
-reach `main`; 44 terms did in 2026 and had to be corrected afterwards.
+pull request is merged. Placeholder values must not reach `main`. Nothing
+currently checks this, and terms carrying placeholders have been merged and
+corrected afterwards; see issue 1304.
 
 
 ## Requesting and implementing a term update
@@ -62,7 +63,7 @@ MIxS carries two version numbers, managed differently. Both use bare `X.Y.Z` val
    against the previous release as the "Previous tag". For a release candidate,
    see [Publishing a release candidate](#publishing-a-release-candidate) below.
 
-The structured diff in step 2 is produced by the reusable `diff-releases` tool; see [SCHEMA_DIFFING.md](SCHEMA_DIFFING.md). Note that it can only reach back to v6.2.0, because the workflow asks for `src/mixs/schema/mixs.yaml` on both sides and that path does not exist in earlier releases.
+The structured diff in step 2 is produced by the reusable `diff-releases` tool; see [SCHEMA_DIFFING.md](SCHEMA_DIFFING.md). The tool itself can compare any release that has a LinkML schema, but it needs the right path for each side, and releases before v6.2.0 keep the schema somewhere else. Check the table in SCHEMA_DIFFING.md before choosing a base older than v6.2.0.
 
 The release notes cover the span between two tags, which is not necessarily the span the schema comparisons cover. If they differ, say so in the release body, or a reader will assume the pull requests listed produced the schema changes reported.
 


### PR DESCRIPTION
Documentation for the parts of the release process that turned out not to be written down, discovered by cutting v7.0.0-rc1.

Nothing here is new policy. Every statement describes what the tooling already does, or what `policy.md` already requires but never explained how to do.

## `edit_workflow.md`

**Cutting a release** gains two steps. A release pull request is opened by the workflow, so GitHub runs no checks on it until a maintainer approves them; until then it has no checks at all rather than failing ones, which is easy to miss on a 695-file diff. And the GitHub Release should target `main`, so the tag lands on the merge commit rather than the release branch.

**Publishing a release candidate** is a new section. `policy.md` requires a candidate before every major and minor release and never said how to make one. It covers the `X.Y.Z-rcN` version form, ticking "Set as a pre-release" so the candidate stays off `/releases/latest`, and bumping the schema version back before the real release.

**The schema-diff step** said to commit `tool_summary.md`. The reusable tool does not write one, so that instruction cannot be followed for any new comparison. It now says so, and says not to hand-write one.

**Requesting a MIxS ID** is a new section, and deliberately names neither the registry nor a person: request one on the issue, and a CIG member with access allocates it, after approval and before merge.

## `SCHEMA_DIFFING.md`

The two-tagged-releases example could not work. It used `v6.1.0`, which is not a tag, with a path that does not exist in that release. Replaced with a working pair, plus a worked example for pre-v6.2.0 releases and a table of which tags the release workflow can use.

## Closes

- https://github.com/GenomicsStandardsConsortium/mixs/issues/1336 release candidates undocumented
- https://github.com/GenomicsStandardsConsortium/mixs/issues/1329 release pull requests get no checks until approved
- https://github.com/GenomicsStandardsConsortium/mixs/issues/1323 the broken SCHEMA_DIFFING example
- https://github.com/GenomicsStandardsConsortium/mixs/issues/1324 which releases can be diffed

Addresses https://github.com/GenomicsStandardsConsortium/mixs/issues/1320 and part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1004 by documenting the ID request route, though neither is closed: 1004 also covers registry inconsistencies, and 1320 asks for a Claude prompt as well.

## Not touched

The empty headings under Terms and Checklists (https://github.com/GenomicsStandardsConsortium/mixs/issues/1293), because those are term-proposal content and belong with https://github.com/GenomicsStandardsConsortium/mixs/pull/1054. The "Content copied over" block at the end of the file, which duplicates `policy.md` and has a repeated pair of bullets. No file here is touched by pull requests 943, 944 or 1054, so this should not conflict with any of them.
