### PR TITLE
Repo hygiene: broken links, a phony target, the Python ceiling

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by [contacting the project team](contact.md). All complaints will be
+reported by contacting the project team. All complaints will be
 reviewed and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is obligated
 to maintain confidentiality with regard to the reporter of an incident. Further

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ For a more detailed guide to MIxS editing and contributing policies, see the [co
 
 * [Introduction](#introduction)
 * [Code of Conduct](#code-of-conduct)
-* [MIxS transition to LinkML](#mixs-transition-to-linkml)
+* [MIxS transition to LinkML](#linkml)
 * [Guidelines for Contributions and Requests](#contributions)
 * [Best Practices](#best-practices)
   * [How to write a great issue](#great-issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ For a more detailed guide to MIxS editing and contributing policies, see the [co
 
 * [Introduction](#introduction)
 * [Code of Conduct](#code-of-conduct)
-* [MIxS transition to LinkML ](linkml)
+* [MIxS transition to LinkML](#mixs-transition-to-linkml)
 * [Guidelines for Contributions and Requests](#contributions)
 * [Best Practices](#best-practices)
   * [How to write a great issue](#great-issues)

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ help: status
 	@echo "  testdoc       -- build & serve docs locally (calls gendoc, serve)"
 	@echo "  serve         -- serve existing docs locally via mkdocs (called by testdoc)"
 	@echo "  yamlfmt-beta  -- experimental YAML formatter"
-	@echo "  create-data-harmonizer -- experimental npm tool"
+	@echo "  create-data-harmonizer -- experimental; currently broken, see issue 1244"
 	@echo ""
 
-.PHONY: all all-contrib clean install help status linkml-lint yaml-lint fix-whitespace yamlfmt-beta test testdoc serve gen-project gendoc test-schema test-python test-examples ensure-dirs clean-contrib
+.PHONY: all all-contrib clean install help status linkml-lint yaml-lint fix-whitespace yamlfmt-beta test testdoc serve gen-project gendoc test-schema test-python test-examples ensure-dirs clean-contrib project/class-model-tsvs-organized
 
 ensure-dirs:
 	mkdir -p contrib
@@ -95,7 +95,11 @@ status:
 install:
 	poetry install --all-extras
 
-# EXPERIMENTAL
+# EXPERIMENTAL, and currently broken. The upstream create-data-harmonizer npm
+# package is frozen at 0.0.3 (2023-03-23) and crashes in its own readline before
+# it produces anything, so this cannot succeed from a Make target regardless of
+# how it is invoked. Kept rather than deleted pending a decision: see issue 1244
+# for removal and issue 648 for generating a DataHarmonizer interface properly.
 create-data-harmonizer:
 	npm init data-harmonizer $(SOURCE_SCHEMA_PATH)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Documentation about the contents of the developer-focussed folders/directories i
   * [src/doc-templates/](src/doc-templates/) - jinja2 files that are responsible for the customization of layout and content of web documentation pages
   * [src/scripts](src/scripts) - Python scripts for specific discovery/exploration/inference based on the MIxS YAML schema
 * [tests/](tests/) - test data files
-* [project-generator-config.yaml](project-generator-config.yaml) - config file to custom specify arguments for the LinkML project generator
+* [project-generator-config.yaml](project-generator-config.yaml) - configuration file specifying the arguments passed to the LinkML project generator
 * [Makefile](Makefile) - Makefile containing pre-defined linkml-project-cookiecutter targets/rules
 * [contrib.Makefile](contrib.Makefile) - file that can be modified to extend pre-defined rules in [Makefile](Makefile)
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Documentation about the contents of the developer-focussed folders/directories i
   * [src/doc-templates/](src/doc-templates/) - jinja2 files that are responsible for the customization of layout and content of web documentation pages
   * [src/scripts](src/scripts) - Python scripts for specific discovery/exploration/inference based on the MIxS YAML schema
 * [tests/](tests/) - test data files
-* [config.yaml](config.yaml) - config file to custom specify arguments for the LinkML project generator
+* [project-generator-config.yaml](project-generator-config.yaml) - config file to custom specify arguments for the LinkML project generator
 * [Makefile](Makefile) - Makefile containing pre-defined linkml-project-cookiecutter targets/rules
-* [project.Makefile](project.Makefile) - file that can be modified to extend pre-defined rules in [Makefile](Makefile)
+* [contrib.Makefile](contrib.Makefile) - file that can be modified to extend pre-defined rules in [Makefile](Makefile)
 
 ## LinkML:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1059,7 +1059,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
+markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
 files = [
     {file = "greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c"},
     {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590"},
@@ -4354,5 +4354,5 @@ docs = []
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.10"
-content-hash = "30f0ee1008e338aa7ce2c1cc92a52afd62bfb55d3fec536540f0555635309a98"
+python-versions = ">=3.10,<3.14"
+content-hash = "f03c72d19a3ce8672dd0b202b6c8fc9855e94caabf4156adb48eb3fbf721c620"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ vcs = "git"
 style = "pep440"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+# 3.14 is excluded: some dependencies do not resolve on it, and a fresh
+# `poetry install` on a machine whose python3 is 3.14 otherwise builds an
+# environment the tooling cannot use.
+python = ">=3.10,<3.14"
 # 1.11 is the first release with linkml's pipe-delimited multivalued TSV
 # serialization (linkml #3134), which the dense TSV round-trip below depends on.
 # The empty-cell load fix #3251 is not yet in a released linkml-runtime, so the


### PR DESCRIPTION
Small, independent fixes. Nothing here touches the schema.

**Four broken relative links.** `CONTRIBUTING.md`'s table of contents pointed at `linkml`, which is not a file; every other entry is an anchor, and this one now matches its own section. `README.md` named `config.yaml` and `project.Makefile`, which are `project-generator-config.yaml` and `contrib.Makefile`.

**`CODE_OF_CONDUCT.md` linked its harassment-reporting route to `contact.md`**, which does not exist anywhere in the repository. The link is removed rather than redirected. Who receives a code of conduct report is a governance decision, and pointing it at a general website or a security-reporting form would be worse than saying "contact the project team" plainly. Filed separately as its own issue.

**`project/class-model-tsvs-organized` is declared phony.** Its recipe ends by moving that directory to `project/class-model-tsvs`, so the path make checks never exists afterwards and the target rebuilds on every run, including inside `all`. Declaring it phony documents what it already does, with no behaviour change. Renaming the target to the surviving directory is the other fix in the issue and would give real dependency behaviour, but it changes *when* the target runs, which is not a change to make just before a release.

**`pyproject.toml` allowed Python 3.14.** `^3.10` means anything below 4.0, so a fresh `poetry install` on a machine whose `python3` is 3.14 builds an environment where the entry points fail to import, with an error that never mentions Python. This happened twice today. Now `>=3.10,<3.14`.

**`create-data-harmonizer` is annotated, not removed.** It cannot work: the upstream npm package is frozen at 0.0.3 from 2023-03-23 and crashes in its own readline before producing anything, so no Make-side change fixes it. Removing it is the group's call, so `make help` now says it is broken and the comment points at the two relevant issues. https://github.com/GenomicsStandardsConsortium/mixs/issues/1244 stays open.

## Closes

- https://github.com/GenomicsStandardsConsortium/mixs/issues/1105 broken links (the two original items were already fixed; these are the four found by a full sweep)
- https://github.com/GenomicsStandardsConsortium/mixs/issues/1307 the self-deleting make target
- https://github.com/GenomicsStandardsConsortium/mixs/issues/1316 Python 3.14 admitted by the constraint

Leaves open: https://github.com/GenomicsStandardsConsortium/mixs/issues/1244 and https://github.com/GenomicsStandardsConsortium/mixs/issues/648.
