### PR TITLE
Stop the regeneration job running on pushes to main, and correct what the docs claim it does

### DIFF
--- a/.github/workflows/regenerate-artifacts.yaml
+++ b/.github/workflows/regenerate-artifacts.yaml
@@ -19,11 +19,11 @@ name: Regenerate and verify generated artifacts
 # The push-to-main trigger is disabled as an interim measure, pending the decision
 # on #1303. The regenerate job below runs only on push, so it no longer runs.
 #
-# It never succeeded in committing anything: pushing to main is refused because the
-# branch requires a pull request, and when the JSON Schema comparison finds no
-# difference the job exits without attempting a push at all. Disabling it changes no
-# outcome, and stops it failing on every schema merge. Restore by putting the push
-# trigger back.
+# It never succeeded in committing anything. Its pushes to main were rejected by
+# branch protection, which is configured outside this file and can change, and when
+# the JSON Schema comparison finds no difference the job exits without attempting a
+# push at all. Disabling it changes no outcome, and stops it failing on every schema
+# merge. Restore by putting the push trigger back.
 #
 # This is not a decision to stop regenerating artifacts. #1303 has the options.
 on:

--- a/.github/workflows/regenerate-artifacts.yaml
+++ b/.github/workflows/regenerate-artifacts.yaml
@@ -1,32 +1,36 @@
 name: Regenerate and verify generated artifacts
 
-# The generated artifacts committed under project/, src/mixs/datamodel/, and contrib/ are
-# consumed by downstream tools; EBI OLS loads project/owl/mixs.owl.ttl from raw main, so the
-# committed artifacts must not lag src/mixs/schema/mixs.yaml (#1240).
+# The generated files committed under project/, src/mixs/datamodel/, and contrib/ are read
+# directly by downstream consumers; EBI OLS loads project/owl/mixs.owl.ttl from raw main.
+# Keeping them matching src/mixs/schema/mixs.yaml is the intent (#1240). This workflow does
+# not achieve that, and #1303 tracks what to do about it.
 #
 # The OWL is not byte-reproducible: RDF/Turtle serialization reorders triples and relabels
 # blank nodes on every run (same 46k triples, different text), so it cannot be verified by a
 # text diff. project/jsonschema/mixs.schema.json IS fully deterministic and carries no
-# generation timestamp, and it is a complete representation of the schema, so it is used as the
-# canary for whether the schema content actually changed:
+# generation timestamp, so it is compared to decide whether the schema content changed:
 #   - pull_request / manual dispatch: regenerate and FAIL if the committed JSON Schema differs.
-#   - push to main: regenerate everything and, only when the JSON Schema changed, commit the
-#     refreshed artifacts (including the reordered OWL) so the committed OWL stays current.
+#   - push to main: regenerate everything and commit only when the JSON Schema differs.
+#
+# That comparison does not detect every change. The JSON Schema carries no class_uri values,
+# so a change confined to identifiers leaves it identical, the commit step is skipped, and the
+# committed OWL keeps the previous identifiers. Observed on the merge of #1347.
 
+# The push-to-main trigger is disabled as an interim measure, pending the decision
+# on #1303. The regenerate job below runs only on push, so it no longer runs.
+#
+# It never succeeded in committing anything: pushing to main is refused because the
+# branch requires a pull request, and when the JSON Schema comparison finds no
+# difference the job exits without attempting a push at all. Disabling it changes no
+# outcome, and stops it failing on every schema merge. Restore by putting the push
+# trigger back.
+#
+# This is not a decision to stop regenerating artifacts. #1303 has the options.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/mixs/schema/mixs.yaml'
-      - 'src/sparql/**'
-      - 'project-generator-config.yaml'
-      - 'Makefile'
   pull_request:
-    # Deliberately narrower than the push trigger: a pull request that only edits
-    # the schema is not checked, because the push job below regenerates and commits
-    # the artifacts as soon as it merges. Failing such a pull request would put a
-    # local build and a large generated diff on a contributor for no gain. Build
-    # inputs are still checked here, where regenerating catches a real regression.
+    # Deliberately narrower than the push trigger was: a pull request that only edits
+    # the schema is not checked here. Build inputs are still checked, where
+    # regenerating catches a real regression.
     paths:
       - 'src/sparql/**'
       - 'project-generator-config.yaml'
@@ -63,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: make install
 
-      - name: Regenerate the JSON Schema (the deterministic canary)
+      - name: Regenerate the JSON Schema, which is deterministic
         run: make gen-project
 
       - name: Fail if the committed JSON Schema is out of sync

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -228,15 +228,14 @@ Four things can update them, and it is worth knowing which is which:
   usually nothing. This is deliberate: it keeps a local build and a diff of
   several hundred generated files off contributors.
 - **A pull request that edits a build input** (`Makefile`, `src/sparql/**`,
-  `project-generator-config.yaml`) does run the workflow, which regenerates and
-  fails if the committed files no longer match.
-- **A push to `main`** runs the workflow, which regenerates and then commits only
-  when `project/jsonschema/mixs.schema.json` differs from what is committed.
-  That file is used to decide because it regenerates deterministically, while
-  RDF/Turtle reorders triples and relabels blank nodes on every run, so the OWL
-  differs textually even when the schema has not changed. Anything the JSON
-  Schema does not represent, including `class_uri` values, does not register as
-  a change.
+  `project-generator-config.yaml`) runs the workflow, which runs `make
+  gen-project` and fails if `project/jsonschema/` no longer matches what is
+  committed. That is the whole check: it does not regenerate or compare the OWL,
+  `contrib/`, or the Python datamodel, so a build-input change that affects only
+  those passes.
+- **A push to `main`** runs nothing. The workflow's push trigger is disabled
+  while [issue 1303](https://github.com/GenomicsStandardsConsortium/mixs/issues/1303)
+  is open, so merging a schema change refreshes no generated files.
 - **The "Create Release PR" action** runs `make install clean all` on the branch
   it creates and commits everything that produces, so a release cut this way
   carries generated files built from the schema it ships. This is the action
@@ -247,7 +246,7 @@ Four things can update them, and it is worth knowing which is which:
 
 Merging a pull request that changes only the schema leaves the committed
 generated files describing the state before your change. Nothing refreshes them
-on merge unless the JSON Schema differs, and nothing warns you either way. The
+on merge, and nothing warns you either way. The
 committed files on `main` are not guaranteed to match
 `src/mixs/schema/mixs.yaml` at any given moment.
 

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -213,7 +213,7 @@ site:
 This is done on the branch by a maintainer, not in CI. It needs no API keys, and
 it is reviewed like any other change before merge.
 
-## Keeping generated artifacts current
+## Generated files, and when they are refreshed
 
 The files under `project/`, `src/mixs/datamodel/` and `contrib/` are generated
 from `src/mixs/schema/mixs.yaml` by `make`, and they are committed because
@@ -243,8 +243,29 @@ Four things can update them, and it is worth knowing which is which:
   doing it, not the branch: a release branch assembled by hand gets no rebuild,
   and would carry whatever `main` had at the time.
 
-Building locally and committing the result in your own pull request is
-supported, and is the only way to see the generated diff before merge.
+### What this means if you merge a schema change
+
+Merging a pull request that changes only the schema leaves the committed
+generated files describing the state before your change. Nothing refreshes them
+on merge unless the JSON Schema differs, and nothing warns you either way. The
+committed files on `main` are not guaranteed to match
+`src/mixs/schema/mixs.yaml` at any given moment.
+
+This matters because consumers read those files rather than building the schema
+themselves, so a stale file is what they get.
+
+If you merge a schema change and the published files need to match it, one of
+these has to happen:
+
+- cut a release, which rebuilds everything from the schema, or
+- build locally with `make install clean all` and commit the result in a pull
+  request, which also lets a reviewer see the generated diff.
+
+Do not assume the committed files match `main`. Check the file you care about.
+
+Whether this should stay as it is, and what to do instead, is open in
+[issue 1303](https://github.com/GenomicsStandardsConsortium/mixs/issues/1303).
+Nothing here describes a settled decision.
 
 Do not hand-edit generated artifacts.
 

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -254,12 +254,16 @@ committed files on `main` are not guaranteed to match
 This matters because consumers read those files rather than building the schema
 themselves, so a stale file is what they get.
 
-If you merge a schema change and the published files need to match it, one of
-these has to happen:
+Cutting a release is what brings them back into agreement, because the release
+action rebuilds everything from the schema and commits the result.
 
-- cut a release, which rebuilds everything from the schema, or
-- build locally with `make install clean all` and commit the result in a pull
-  request, which also lets a reviewer see the generated diff.
+Do not commit generated files built on your own machine. Building locally to
+check something is fine, and `make install clean all` is how, but the output is
+not identical to what the release action produces: a local build of an unchanged
+schema still differs from the committed copy in the JSON-LD context and in
+generation timestamps. Committing that replaces files built by the release with
+files built somewhere else, in a diff of several hundred files that no reviewer
+can meaningfully read.
 
 Do not assume the committed files match `main`. Check the file you care about.
 

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -215,16 +215,36 @@ it is reviewed like any other change before merge.
 
 ## Keeping generated artifacts current
 
-The committed artifacts under `project/`, `src/mixs/datamodel/` and `contrib/`
-are generated from the schema, and the "Regenerate and verify generated
-artifacts" workflow keeps them in sync. On a pull request it regenerates and
-fails if the committed artifacts are stale. On a push to `main` that changes the
-schema or its build inputs, it regenerates everything and commits the result.
+The files under `project/`, `src/mixs/datamodel/` and `contrib/` are generated
+from `src/mixs/schema/mixs.yaml` by `make`, and they are committed because
+downstream consumers fetch them directly. EBI OLS reads
+`project/owl/mixs.owl.ttl` from raw `main`.
 
-The check uses `project/jsonschema/mixs.schema.json` as its signal, because that
-file regenerates deterministically. The OWL (`project/owl/mixs.owl.ttl`) is not
-byte-reproducible: RDF/Turtle serialization reorders triples and relabels blank
-nodes on every run, so it is regenerated and committed but not compared by diff.
+Four things can update them, and it is worth knowing which is which:
+
+- **A pull request that edits only the schema** does neither. The "Regenerate
+  and verify generated artifacts" workflow does not run on it, so the generated
+  files in such a pull request are whatever its author put there, which is
+  usually nothing. This is deliberate: it keeps a local build and a diff of
+  several hundred generated files off contributors.
+- **A pull request that edits a build input** (`Makefile`, `src/sparql/**`,
+  `project-generator-config.yaml`) does run the workflow, which regenerates and
+  fails if the committed files no longer match.
+- **A push to `main`** runs the workflow, which regenerates and then commits only
+  when `project/jsonschema/mixs.schema.json` differs from what is committed.
+  That file is used to decide because it regenerates deterministically, while
+  RDF/Turtle reorders triples and relabels blank nodes on every run, so the OWL
+  differs textually even when the schema has not changed. Anything the JSON
+  Schema does not represent, including `class_uri` values, does not register as
+  a change.
+- **The "Create Release PR" action** runs `make install clean all` on the branch
+  it creates and commits everything that produces, so a release cut this way
+  carries generated files built from the schema it ships. This is the action
+  doing it, not the branch: a release branch assembled by hand gets no rebuild,
+  and would carry whatever `main` had at the time.
+
+Building locally and committing the result in your own pull request is
+supported, and is the only way to see the generated diff before merge.
 
 Do not hand-edit generated artifacts.
 


### PR DESCRIPTION
Relates to https://github.com/GenomicsStandardsConsortium/mixs/issues/1303 and https://github.com/GenomicsStandardsConsortium/mixs/issues/1240

Two things: one change in behaviour, and the documentation that described the old behaviour incorrectly anyway.

## Behaviour: the regeneration job no longer runs on pushes to main

`.github/workflows/regenerate-artifacts.yaml` has two jobs. `verify` runs on pull requests that touch build inputs. `regenerate` ran on pushes to `main` and was meant to commit refreshed generated files. This disables the push trigger, so `regenerate` no longer runs. `verify` is unchanged.

It has never committed anything. Pushing to `main` is refused because the branch requires a pull request, and when its JSON Schema comparison finds no difference it exits without attempting a push at all. Both outcomes leave the committed files untouched, so disabling it changes no result.

The reason to do it now rather than after the release: the schema version appears in the JSON Schema, so bumping `7.0.0-rc1` to `7.0.0` would make the comparison differ, the job would attempt a push, and that push would fail. That puts a red run on `main` during the release for nothing.

This is an interim measure, not a decision to stop regenerating artifacts. Five options are on 1303 and that decision belongs to the group.

## Documentation

"Keeping generated artifacts current" asserted something untrue and then stopped short of the part that matters.

It said the workflow keeps the generated files in sync, and that a pull request regenerates and fails when they are stale. A pull request that edits only `src/mixs/schema/mixs.yaml` does not trigger the workflow at all, by design. The build-input check runs `make gen-project` and compares `project/jsonschema/` only, so it does not cover the OWL, `contrib/`, or the Python datamodel.

The omission was worse than the inaccuracy. A maintainer reading it would conclude the generated files were handled for them. The section now says the committed files are not guaranteed to match the schema, that nothing warns you either way, and that consumers read those files rather than building the schema themselves.

It also now discourages committing generated files built locally. Local output is not the same as the release action's output: a local build of an unchanged schema still differs from the committed copy in the JSON-LD context and in generation timestamps. Cutting a release is what brings them back into agreement.

The section is renamed, since "Keeping generated artifacts current" asserted the thing that is not true.
