### PR TITLE
Set the schema version to 7.0.0

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12,7 +12,7 @@ comments:
 id: https://w3id.org/mixs
 see_also:
   - https://doi.org/10.1038/nbt.1823
-version: 7.0.0-rc2
+version: 7.0.0
 imports:
   - linkml:types
 prefixes:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12,7 +12,7 @@ comments:
 id: https://w3id.org/mixs
 see_also:
   - https://doi.org/10.1038/nbt.1823
-version: 7.0.0-rc1
+version: 7.0.0-rc2
 imports:
   - linkml:types
 prefixes:


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1322

One line: `version: 7.0.0-rc1` becomes `version: 7.0.0` in `src/mixs/schema/mixs.yaml`.

No second release candidate. The group agreed on a full release, and the candidates serve as a maintainer sanity check rather than as the review artifact `policy.md` describes.

`main` differs from the `v7.0.0-rc1` tag in eight `class_uri` values that identified no class, corrected in https://github.com/GenomicsStandardsConsortium/mixs/pull/1347, and in the title of `urobiom_sex`. Whether the release build carries those corrections through to the published OWL is checkable on the `release/v7.0.0` branch before anything is merged or tagged, which is what a second candidate would otherwise have been for.

That check is worth running, because since rc1 the regeneration job no longer runs on pushes to `main` (https://github.com/GenomicsStandardsConsortium/mixs/pull/1354), leaving the release build as the only thing that refreshes generated files. The rc1 release commit `3fb3f1d` shows the mechanism working: it regenerated 695 files including `project/owl/mixs.owl.ttl`.

After this merges, dispatch "Create Release PR" with version `7.0.0`, `diff_old` `mixs6.0.0`, and `diff_old_path` `model/schema/mixs.yaml`. Before merging the release pull request it opens, confirm `project/owl/mixs.owl.ttl` is in its commit and no longer contains `9999903`.
