### PR TITLE
Set the schema version to 7.0.0

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -12,7 +12,7 @@ comments:
 id: https://w3id.org/mixs
 see_also:
   - https://doi.org/10.1038/nbt.1823
-version: 7.0.0-rc1
+version: 7.0.0
 imports:
   - linkml:types
 prefixes:


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1322

One line: `version: 7.0.0-rc1` becomes `version: 7.0.0` in `src/mixs/schema/mixs.yaml`.

This is the last change that should merge before the release, because "Create Release PR" reads whatever is on `main` at the moment it is dispatched.

The schema version is content, not build metadata. It travels into everything generated from the schema, including the OWL that EBI OLS loads and the JSON Schema that validators use, so what is written here is what downstream consumers report as their MIxS version.

**Next steps after this merges**

Dispatch "Create Release PR" with version `7.0.0`, `diff_old` `mixs6.0.0`, and `diff_old_path` `model/schema/mixs.yaml`. The old path matters: releases before v6.2.0 keep the schema somewhere else, and leaving the default fails at the diff step rather than immediately.

The release pull request it opens shows no checks at all until a maintainer clicks "Approve and run workflows", which reads as passing rather than as not started.

Before merging that pull request, confirm `project/owl/mixs.owl.ttl` is in its commit and no longer contains `9999903`. Eight `class_uri` values were corrected in https://github.com/GenomicsStandardsConsortium/mixs/pull/1347 and the copy committed on `main` still carries the old ones, because the job that used to refresh generated files on pushes to `main` is disabled (https://github.com/GenomicsStandardsConsortium/mixs/pull/1354). The release build is now the only thing that refreshes them. It does work: the rc1 release commit `3fb3f1d` regenerated 695 files including the OWL.
