### PR TITLE
Correct what the docs say about the diff summaries, in both files that say it

### DIFF
--- a/src/docs/SCHEMA_DIFFING.md
+++ b/src/docs/SCHEMA_DIFFING.md
@@ -75,7 +75,7 @@ poetry run python src/scripts/v5_to_v6_onetime_diff.py
 ```
 
 Step 4 writes `assets/diff_results/v5_to_v6.0.0/schema_comparison_results.yaml`
-(the structured diff) and `tool_summary.md` (a short summary). Then, in Claude
+(the structured diff) and `tool_summary.md` (a short summary of the counts). Then, in Claude
 Code, write the readable summary with the skill:
 
 ```
@@ -174,6 +174,8 @@ per-release folder; pass `--output-dir` to override):
   classes, enums, prefixes, settings) splits into `key_comparison` (added or
   removed names) and `definition_changes` (same name, changed body, field by
   field).
+- `tool_summary.md`: a short summary of the counts, how many elements were added,
+  removed and changed in each collection, derived from the structured diff.
 
 The structured output reports every change equally, including cosmetic ones. For
 example, a one-line edit to a templated description can show as a change on every

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -184,9 +184,13 @@ reviewed, add a readable summary to the release branch and put it on the docs
 site:
 
 1. Check out the `release/vX.Y.Z` branch.
-2. The release action already wrote the diff into a per-release folder,
-   `assets/diff_results/<old>_to_<new>/`, for example `v6.2.0_to_v6.3.0/`. Work
-   in that folder; the docs build publishes summaries only from these folders.
+2. The release action already wrote the diff into a folder under
+   `assets/diff_results/`, named from the two refs you gave it rather than from
+   the release. Dispatching with `diff_old` `mixs6.0.0` and `diff_new` `main`
+   produces `mixs6.0.0_to_main/`. Rename it to the versions it compares, such as
+   `v6.0.0_to_v7.0.0/`, so the published page is named for releases rather than
+   for a branch that keeps moving. Work in that folder; the docs build publishes
+   summaries only from folders under `assets/diff_results/`.
 3. Write `agent_summary.md` next to the structured diff. The repository carries
    a Claude Code skill for this, invoked as
    `/mixs-diff-summary assets/diff_results/<old>_to_<new>/schema_comparison_results.yaml`,
@@ -194,15 +198,14 @@ site:
    a requirement: it lives in `.claude/skills/mixs-diff-summary/SKILL.md`, and
    anyone not using Claude Code can read that file and write the summary the
    same way by hand, or with another assistant.
-4. Commit `agent_summary.md`. Comparisons made before mid-2026 also carry a
-   `tool_summary.md` of raw counts, but the reusable `diff-releases` tool does
-   not write one, so a new comparison will not have it. Do not write one by
-   hand: it would look like tool output that cannot be regenerated. See
-   [issue 1318](https://github.com/GenomicsStandardsConsortium/mixs/issues/1318).
-5. Add the page to the site nav. In `mkdocs.yml`, under the `Version changes`
-   group, add one line for this release:
+4. Commit both `agent_summary.md`, the readable summary you just wrote, and
+   `tool_summary.md`, the counts the tool wrote alongside the structured diff.
+   Do not write `tool_summary.md` by hand; if it is missing, rerun the tool.
+5. Add both pages to the site nav. In `mkdocs.yml`, under the `Version changes`
+   group, add two lines for this release:
    ```yaml
      - <old> to <new>: version-changes/<old>_to_<new>.md
+     - <old> to <new> (counts): version-changes/<old>_to_<new>-counts.md
    ```
    Older releases have a second `(counts)` line pointing at a `-counts.md` page,
    generated from `tool_summary.md`. Add one only if the comparison actually has

--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -185,9 +185,10 @@ site:
 
 1. Check out the `release/vX.Y.Z` branch.
 2. The release action already wrote the diff into a folder under
-   `assets/diff_results/`, named from the two refs you gave it rather than from
-   the release. Dispatching with `diff_old` `mixs6.0.0` and `diff_new` `main`
-   produces `mixs6.0.0_to_main/`. Rename it to the versions it compares, such as
+   `assets/diff_results/`, named from the two refs you gave it. If both were
+   release refs the name is already what you want. If either was a moving ref,
+   the name follows it: dispatching with `diff_new` `main` produces
+   `mixs6.0.0_to_main/`, which should be renamed to the versions it compares,
    `v6.0.0_to_v7.0.0/`, so the published page is named for releases rather than
    for a branch that keeps moving. Work in that folder; the docs build publishes
    summaries only from folders under `assets/diff_results/`.


### PR DESCRIPTION
All of it found by running the v7.0.0 release and watching the steps not match.

**The tool does write `tool_summary.md`.** Two files said otherwise. `edit_workflow.md` said the reusable `diff-releases` tool does not write one and told you not to create one by hand, citing https://github.com/GenomicsStandardsConsortium/mixs/issues/1318 as a live limitation. `SCHEMA_DIFFING.md` listed the outputs of that tool and simply left it out. https://github.com/GenomicsStandardsConsortium/mixs/pull/1343 added the output, 1318 is closed, and the v7.0.0 run produced `assets/diff_results/mixs6.0.0_to_main/tool_summary.md`. I wrote both the code and the text that contradicted it.

Following the old text would have published one page where two exist, and left the counts out of the release.

**The output folder is named from the refs, not the release.** Dispatching with `diff_old` `mixs6.0.0` and `diff_new` `main` produces `mixs6.0.0_to_main/`. That needs renaming before publishing so the page is named for two releases rather than for a branch that keeps moving. The rename was done by hand for the candidate and never written down. It is only needed when a ref moves: two release refs already give the name you want.

**Terminology.** `SCHEMA_DIFFING.md` called `tool_summary.md` "a short summary" in one place; both mentions now say a summary of the counts.

The last two points came from the review of https://github.com/GenomicsStandardsConsortium/mixs/pull/1363, which was opened independently against the same paragraphs. That pull request carries the same `edit_workflow.md` change as this one, so only one of the two should merge.

No behaviour changes.