### PR TITLE
Give the ancient DNA classes a way into a MIxS document

### DIFF
--- a/src/docs/edit_workflow.md
+++ b/src/docs/edit_workflow.md
@@ -92,7 +92,31 @@ from them; it does not create the classes.
 
 ## Requesting and creating a new checklist or extension
 
-TBD.
+TBD, except for one step that is easy to miss.
+
+### Give it a way into a MIxS document
+
+A checklist, extension or combination is not usable until something can hold its
+records. `MixsCompliantData` is the root of a MIxS file, and each class reaches a
+document through one container slot listed on it. Adding a class means adding
+that slot too, in two places:
+
+1. Define the slot in the `slots` section, named after the class with a `_data`
+   suffix. Copy an existing one, such as `soil_data`, which sets `domain:
+   MixsCompliantData`, `range` to the class, `multivalued: true`, a
+   `slot_uri` of `MIXS:<slot name>`, a description and a title.
+2. **Add the slot name to the `slots:` list on the `MixsCompliantData` class.**
+   This is the step that attaches it. Setting `domain: MixsCompliantData` on the
+   slot does not.
+
+Miss the second step and nothing complains: the schema builds, the class is
+generated, and it simply cannot appear in a file. That is what happened to the
+nine ancient-DNA classes in v7.0.0, found only after release
+([issue 1365](https://github.com/GenomicsStandardsConsortium/mixs/issues/1365)).
+
+`tests/test_schema_constraints.py` now checks both directions, that every slot
+declaring the container domain is attached, and that every class is reachable
+from a document, so the same omission fails the build rather than shipping.
 
 ## Updating an existing checklist or extension
 

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -21258,6 +21258,15 @@ classes:
       - miuvig_symbiont_associated_data
       - miuvig_wastewater_sludge_data
       - miuvig_water_data
+      - ancient_data
+      - mims_hostassociated_ancient_data
+      - mims_humanassociated_ancient_data
+      - mims_humangut_ancient_data
+      - mims_humanoral_ancient_data
+      - mims_humanskin_ancient_data
+      - mims_plantassociated_ancient_data
+      - mims_sediment_ancient_data
+      - mims_soil_ancient_data
     tree_root: true
   MigsBaAgriculture:
     description: MIxS Data that comply with the MigsBa checklist and the Agriculture

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -196,6 +196,45 @@ class TestCombinationUri(unittest.TestCase):
             f"<mixed-in class>_<extended class>: {wrong}")
 
 
+class TestContainerSlots(unittest.TestCase):
+    """A class that no container slot points at cannot appear in a MIxS document.
+
+    ``MixsCompliantData`` is the root of a MIxS file, and each checklist,
+    extension and combination reaches a document through one ``*_data`` slot
+    listed on that class. Declaring ``domain: MixsCompliantData`` on the slot is
+    not enough; a slot missing from the class's own list is silently
+    unreachable, which is how the nine ancient-DNA slots shipped in v7.0.0
+    without anywhere to put ancient data. See issue 1365.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        view = SchemaView(SCHEMA_PATH)
+        cls.view = view
+        cls.attached = set(view.class_slots(CONTAINER_DOMAIN))
+
+    def test_every_container_slot_is_attached_to_the_class(self):
+        declared = {name for name, slot in self.view.all_slots().items()
+                    if slot.domain == CONTAINER_DOMAIN}
+        orphaned = sorted(declared - self.attached)
+        self.assertEqual(
+            orphaned, [],
+            f"{len(orphaned)} slots declare domain {CONTAINER_DOMAIN} but are not "
+            f"listed on it, so nothing can reach their classes: {orphaned}")
+
+    def test_every_class_is_reachable_from_a_document(self):
+        """Every checklist, extension and combination has a way into a file."""
+        reachable = {str(self.view.get_slot(s).range)
+                     for s in self.attached if self.view.get_slot(s)}
+        unreachable = sorted(
+            name for name in self.view.all_classes()
+            if name not in UNIDENTIFIED_CLASSES and name not in reachable)
+        self.assertEqual(
+            unreachable, [],
+            f"{len(unreachable)} classes cannot appear in a MIxS document because "
+            f"no container slot has them as its range: {unreachable}")
+
+
 class TestDescriptions(unittest.TestCase):
     """Descriptions are universal in the schema, so a missing one is a regression.
 


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1365
Relates to https://github.com/GenomicsStandardsConsortium/mixs/issues/1230, which added the MInAS extension

`Ancient` and its eight combinations are fully defined in v7.0.0 and cannot appear in a MIxS file. Their nine container slots were written correctly, with domain, range, title, description and a `slot_uri`, but never added to the `slots:` list on `MixsCompliantData`, which is the part that attaches them. Setting `domain: MixsCompliantData` on a slot does not.

Nothing complained. The schema builds, the classes generate, and the shipped `project/jsonschema/mixs.schema.json` simply has 335 top-level properties instead of 344. `soil_data` and `mims_soil_data` are there; `ancient_data` and `mims_soil_ancient_data` are not.

This adds the nine names to the class. No slot definitions change, because they were already right.

**Two tests, both of which fail on the schema as released:**

```
FAILED test_every_container_slot_is_attached_to_the_class
FAILED test_every_class_is_reachable_from_a_document
```

The first names all nine missing slots. The second catches the same thing from the other direction, a class no container slot points at, which is the failure a submitter would actually hit.

**Documentation.** Nothing anywhere said that adding a checklist or extension means adding a container slot, or that listing it on the class is the step that counts. That is now written under "Requesting and creating a new checklist or extension", which was previously TBD.

This is the third defect found in the MInAS contribution, after eight combination identifiers that resolved to nothing and quoted identifier values inconsistent with the rest of the schema, both fixed in https://github.com/GenomicsStandardsConsortium/mixs/pull/1347. All three shared a cause: no test asserted the invariant, so a plausible-looking addition passed review.

Worth deciding separately whether this warrants a 7.0.1, since ancient DNA submission is not possible in v7.0.0 as released.