### PR TITLE
Detect renames in the comparison instead of leaving them to the summarizer

### DIFF
--- a/.claude/skills/mixs-diff-summary/SKILL.md
+++ b/.claude/skills/mixs-diff-summary/SKILL.md
@@ -7,6 +7,18 @@ allowed-tools: Read, Write, Bash
 
 # Summarize a MIxS schema diff
 
+## Working in this repository
+
+Run Python with `poetry run python`. This is a poetry project, and `uv run`
+creates a `.venv` and a `uv.lock` inside it that then have to be cleaned up.
+
+The two schemas being compared are cached under `assets/releases_for_diffing/`,
+one directory per ref, if you need to check something the diff does not record.
+
+Read the diff once into a script rather than shelling out repeatedly; it is
+around a megabyte of YAML and reparsing it per question is slow.
+
+
 Produce a short, readable Markdown summary of a MIxS schema-diff YAML.
 
 The input file is `$ARGUMENTS`. If that is empty, ask which diff file to

--- a/src/scripts/diff_two_linkml_mixs_releases.py
+++ b/src/scripts/diff_two_linkml_mixs_releases.py
@@ -71,6 +71,11 @@ class KeyComparison:
     shared: Set[str]
     expected_mappings: Set[str] = None
     inter_type_refactoring: Set[str] = None
+    #: Old name to new name, for elements that kept their MIxS identifier but
+    #: changed name and are not in the mapping files. These are renames the
+    #: mapping files have missed, reported so they are not read as one element
+    #: removed and another added.
+    rename_candidates: Dict[str, str] = None
 
 
 @dataclass
@@ -273,6 +278,48 @@ class LinkMLComparator:
             expected_mappings=expected_mappings
         )
     
+    def _find_rename_candidates(self, only_in_old: Set[str], only_in_new: Set[str],
+                                element_type: str) -> Dict[str, str]:
+        """Pair a removed element with an added one that carries the same MIxS identifier.
+
+        A rename keeps the identifier and changes the name. Without this, the
+        comparison reports the old name as removed and the new one as added, so
+        a term that survived reads as a term that was dropped.
+
+        Only slots and classes carry an identifier to match on. Elements whose
+        rename is already recorded in the mapping files never reach here,
+        because they are filtered out of only_in_old and only_in_new first.
+        """
+        field = {'slots': 'slot_uri', 'classes': 'class_uri'}.get(element_type)
+        if not field or not only_in_old or not only_in_new:
+            return {}
+
+        def identifier(view, name):
+            getter = view.get_slot if field == 'slot_uri' else view.get_class
+            try:
+                element = getter(name)
+            except Exception:
+                return None
+            value = getattr(element, field, None) if element is not None else None
+            # Container slots carry a name-based identifier, which cannot
+            # distinguish one element from another after a rename.
+            text = str(value) if value else ''
+            return text if re.match(r'^MIXS:[0-9]', text) else None
+
+        new_by_identifier = {}
+        for name in only_in_new:
+            key = identifier(self.new_schema, name)
+            if key:
+                new_by_identifier.setdefault(key, []).append(name)
+
+        candidates = {}
+        for old_name in sorted(only_in_old):
+            key = identifier(self.old_schema, old_name)
+            # Ambiguous matches are left alone; a maintainer should look.
+            if key and len(new_by_identifier.get(key, [])) == 1:
+                candidates[old_name] = new_by_identifier[key][0]
+        return candidates
+
     def _compare_dict_values(self, old_dict: Dict, new_dict: Dict,
                            mappings: Dict[str, str] = None, 
                            element_type: str = None) -> CollectionComparison:
@@ -282,6 +329,9 @@ class LinkMLComparator:
         
         # First compare keys
         key_comparison = self._compare_keys(old_keys, new_keys, mappings)
+        key_comparison.rename_candidates = self._find_rename_candidates(
+            key_comparison.only_in_old, key_comparison.only_in_new, element_type
+        )
         
         # Then compare values for shared keys with cascading
         value_comparisons = {}
@@ -832,7 +882,11 @@ def schema_comparison_to_dict(comparison: SchemaComparison) -> dict:
             result['shared'] = sorted([clean_key(k) for k in key_comp.shared])
         if key_comp.expected_mappings:
             result['expected_mappings'] = sorted(list(key_comp.expected_mappings))
-            
+        if key_comp.rename_candidates:
+            result['rename_candidates'] = {
+                clean_key(old): clean_key(new)
+                for old, new in sorted(key_comp.rename_candidates.items())}
+
         return result
 
     def collection_comparison_to_dict(coll_comp: CollectionComparison) -> dict:

--- a/src/scripts/diff_two_linkml_mixs_releases.py
+++ b/src/scripts/diff_two_linkml_mixs_releases.py
@@ -312,12 +312,21 @@ class LinkMLComparator:
             if key:
                 new_by_identifier.setdefault(key, []).append(name)
 
+        old_by_identifier = {}
+        for name in only_in_old:
+            key = identifier(self.old_schema, name)
+            if key:
+                old_by_identifier.setdefault(key, []).append(name)
+
+        # Report only a one-to-one match. Two old names sharing an identifier is
+        # not hypothetical: v6.0.0 carried both texture_meth and
+        # soil_texture_meth on MIXS:0000336. Pairing either with a single new
+        # name would be a guess, so ambiguity on either side is left alone.
         candidates = {}
-        for old_name in sorted(only_in_old):
-            key = identifier(self.old_schema, old_name)
-            # Ambiguous matches are left alone; a maintainer should look.
-            if key and len(new_by_identifier.get(key, [])) == 1:
-                candidates[old_name] = new_by_identifier[key][0]
+        for key, old_names in sorted(old_by_identifier.items()):
+            new_names = new_by_identifier.get(key, [])
+            if len(old_names) == 1 and len(new_names) == 1:
+                candidates[old_names[0]] = new_names[0]
         return candidates
 
     def _compare_dict_values(self, old_dict: Dict, new_dict: Dict,

--- a/tests/test_diff_rename_candidates.py
+++ b/tests/test_diff_rename_candidates.py
@@ -65,6 +65,19 @@ class TestRenameCandidates(unittest.TestCase):
         self.assertEqual(
             c._find_rename_candidates({"old_name"}, {"new_a", "new_b"}, "slots"), {})
 
+    def test_two_old_names_on_one_identifier_are_left_alone(self):
+        """v6.0.0 carried texture_meth and soil_texture_meth on MIXS:0000336.
+
+        If a single new name arrived carrying that identifier, pairing it with
+        either old name would be a guess.
+        """
+        c = comparator({"texture_meth": "MIXS:0000336",
+                        "soil_texture_meth": "MIXS:0000336"},
+                       {"soil_texture_method": "MIXS:0000336"})
+        self.assertEqual(
+            c._find_rename_candidates({"texture_meth", "soil_texture_meth"},
+                                      {"soil_texture_method"}, "slots"), {})
+
     def test_name_based_identifiers_are_ignored(self):
         """Container slots carry a name-based identifier, useless for matching."""
         c = comparator({"soil_data": "MIXS:soil_data"},

--- a/tests/test_diff_rename_candidates.py
+++ b/tests/test_diff_rename_candidates.py
@@ -1,0 +1,88 @@
+"""Rename detection in the release comparison tool.
+
+A rename keeps an element's MIxS identifier and changes its name. Without
+detection, the comparison reports the old name as removed and the new one as
+added, so a term that survived reads as a term that was dropped. That happened
+to ``estimated_size`` across 144 classes in the v6.0.0 to v7.0.0 comparison.
+
+Two cases must not be reported, because they are not renames:
+
+* a duplicate being resolved, where both names existed before and one was
+  dropped, as with ``texture_meth`` and ``soil_texture_meth`` sharing
+  ``MIXS:0000336`` in v6.0.0
+* an ambiguous match, where one identifier arrives on more than one new name
+"""
+import importlib.util
+import os
+import unittest
+from unittest.mock import Mock
+
+ROOT = os.path.join(os.path.dirname(__file__), '..')
+SCRIPT = os.path.join(ROOT, "src", "scripts", "diff_two_linkml_mixs_releases.py")
+
+_spec = importlib.util.spec_from_file_location("diff_releases", SCRIPT)
+diff_releases = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(diff_releases)
+
+
+def comparator(old_uris, new_uris, field="slot_uri"):
+    """A comparator whose two schemas return the given identifiers."""
+    def view(uris):
+        v = Mock()
+        def get(name):
+            if name not in uris:
+                return None
+            element = Mock()
+            setattr(element, field, uris[name])
+            return element
+        v.get_slot = get
+        v.get_class = get
+        return v
+
+    c = diff_releases.LinkMLComparator.__new__(diff_releases.LinkMLComparator)
+    c.old_schema = view(old_uris)
+    c.new_schema = view(new_uris)
+    return c
+
+
+class TestRenameCandidates(unittest.TestCase):
+
+    def test_shared_identifier_is_reported_as_a_rename(self):
+        c = comparator({"estimated_size": "MIXS:0000024"},
+                       {"estimated_genome_size": "MIXS:0000024"})
+        self.assertEqual(
+            c._find_rename_candidates({"estimated_size"}, {"estimated_genome_size"}, "slots"),
+            {"estimated_size": "estimated_genome_size"})
+
+    def test_a_resolved_duplicate_is_not_a_rename(self):
+        """The surviving name is not new, so it never reaches only_in_new."""
+        c = comparator({"texture_meth": "MIXS:0000336"}, {})
+        self.assertEqual(c._find_rename_candidates({"texture_meth"}, set(), "slots"), {})
+
+    def test_an_ambiguous_identifier_is_left_alone(self):
+        c = comparator({"old_name": "MIXS:0000001"},
+                       {"new_a": "MIXS:0000001", "new_b": "MIXS:0000001"})
+        self.assertEqual(
+            c._find_rename_candidates({"old_name"}, {"new_a", "new_b"}, "slots"), {})
+
+    def test_name_based_identifiers_are_ignored(self):
+        """Container slots carry a name-based identifier, useless for matching."""
+        c = comparator({"soil_data": "MIXS:soil_data"},
+                       {"soil_data_2": "MIXS:soil_data"})
+        self.assertEqual(
+            c._find_rename_candidates({"soil_data"}, {"soil_data_2"}, "slots"), {})
+
+    def test_collections_without_identifiers_are_skipped(self):
+        c = comparator({"a": "MIXS:0000001"}, {"b": "MIXS:0000001"})
+        self.assertEqual(c._find_rename_candidates({"a"}, {"b"}, "enums"), {})
+
+    def test_classes_match_on_class_uri(self):
+        c = comparator({"OldClass": "MIXS:0010002"},
+                       {"NewClass": "MIXS:0010002"}, field="class_uri")
+        self.assertEqual(
+            c._find_rename_candidates({"OldClass"}, {"NewClass"}, "classes"),
+            {"OldClass": "NewClass"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1366

`.claude/skills/mixs-diff-summary/SKILL.md` tells the summarizer to report a `rename_candidates` section and says these are "likely missed renames that a maintainer should confirm". The tool never emitted one. The summary shipped with v7.0.0 says so itself:

> This diff has no `rename_candidates` section, so the following are my own findings, each confirmed by MIXS URI identity between the v6 and v7 schema sources.

So each release the agent rediscovered renames by hand. On the v7.0.0 run that was eleven of forty shell calls, cross-referencing both schemas, and the result was neither reproducible nor complete.

A rename keeps the MIxS identifier and changes the name, so a removed element and an added element sharing one is a rename. Mechanical, and it belongs in the tool.

Against v6.0.0 to v7.0.0 it reports one candidate:

```
estimated_size -> estimated_genome_size
```

That is a real rename affecting 144 classes, currently presented as one term dropped and another added.

**It is deliberately conservative**, and the tests pin each restriction:

- **Name-based identifiers are ignored.** Container slots carry `MIXS:soil_data` rather than a number, which cannot distinguish one element from another.
- **Ambiguous matches are left alone.** One identifier arriving on two new names is for a person to look at.
- **A resolved duplicate is not a rename.** v6.0.0 carried two slots on `MIXS:0000336`, `texture_meth` and `soil_texture_meth`, and v7 dropped one. The survivor is not new, so nothing is reported. Same for `soil_depth` and `depth` on `MIXS:0000018`. I had this wrong in https://github.com/GenomicsStandardsConsortium/mixs/issues/1361 and have corrected it there.

**Two smaller fixes to the skill**, both from watching the v7.0.0 run: it now says to use `poetry run python`, because `uv run` created a `.venv` and a `uv.lock` inside this project and had to be cleaned up mid-task, and it says where the compared schemas are cached, which is where the manual cross-referencing had to look.

19 tests pass, 6 of them new.