### PR TITLE
Match dependency updates before the ecosystem categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,6 +5,12 @@
 # Categories are matched in order, and an entry appears in the first category
 # whose labels it matches. The catch-all at the end means nothing is dropped
 # silently.
+#
+# Dependency updates must stay above Build, tooling and CI. Dependabot labels its
+# pull requests with both `dependencies` and an ecosystem label, `github_actions`
+# or `python`, so with the other order every version bump matched Build first.
+# That is what happened in v7.0.0: eight bumps under Build, and the category
+# meant for them empty.
 changelog:
   categories:
     - title: Schema changes
@@ -16,15 +22,15 @@ changelog:
       labels:
         - documentation-external
         - documentation-internal
+    - title: Dependency updates
+      labels:
+        - dependencies
     - title: Build, tooling and CI
       labels:
         - 5-TechnicalUpdates
         - github_actions
         - python
         - python package inc. PyPI
-    - title: Dependency updates
-      labels:
-        - dependencies
     - title: Other changes
       labels:
         - "*"


### PR DESCRIPTION
Half of https://github.com/GenomicsStandardsConsortium/mixs/issues/1362, the half that is a config bug rather than a process question.

Categories in `.github/release.yml` are matched in order, and Dependabot labels its pull requests with **both** `dependencies` and an ecosystem label:

```
1301  [dependencies, github_actions]
1302  [dependencies, python]
1267  [dependencies, python]
```

"Build, tooling and CI" listed `github_actions` and `python` above "Dependency updates", so it claimed every version bump first. That is exactly what the v7.0.0 notes did: eight bumps under Build, tooling and CI, and the category meant for them empty.

Swapping the two blocks fixes it. Checked against the labels those pull requests actually carry, all three now land in Dependency updates.

Added a comment saying why the order matters, since the fix looks like an arbitrary reordering and would be easy to undo while tidying.

**This does not fix the other half.** Unlabelled pull requests still fall to the catch-all, which is why the v7.0.0 notes had thirty entries under "Other changes" and I sorted them by hand. Both `1347` and `1230` still land there. That needs either labelling discipline at merge time or a path-based labeler, and it needs a decision about labels, so it stays on the issue.