### PR TITLE
Run the tests on release pull requests, just not the rebuild

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -62,6 +62,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Labels are managed through the Issues API, so adding one to a pull
+      # request needs this as well as pull-requests: write. Same reason as
+      # lint-yaml.yaml.
+      issues: write
 
     steps:
       - name: Validate version format
@@ -222,6 +226,7 @@ jobs:
           DIFF_OLD: ${{ inputs.diff_old }}
           DIFF_NEW: ${{ inputs.diff_new }}
           REPOSITORY: ${{ github.repository }}
+          SKIP_TESTS: ${{ inputs.skip_tests }}
         run: |
           # The body is written with placeholders inside a quoted heredoc, then
           # filled in by python. A quoted heredoc does not expand $VAR, and an
@@ -283,3 +288,13 @@ jobs:
             --body-file /tmp/release-pr-body.md \
             --base main \
             --head "release/v${VERSION}"
+
+          # "Build and test mixs" skips release pull requests because this
+          # workflow has already built and tested the branch. With skip_tests it
+          # has not, so label the pull request and let that job run instead.
+          if [ "${SKIP_TESTS}" = "true" ]; then
+            gh label create tests-skipped \
+              --description "Release pull request created without running tests" \
+              --color D93F0B 2>/dev/null || true
+            gh pr edit "release/v${VERSION}" --add-label tests-skipped
+          fi

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -62,10 +62,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      # Labels are managed through the Issues API, so adding one to a pull
-      # request needs this as well as pull-requests: write. Same reason as
-      # lint-yaml.yaml.
-      issues: write
 
     steps:
       - name: Validate version format
@@ -226,7 +222,6 @@ jobs:
           DIFF_OLD: ${{ inputs.diff_old }}
           DIFF_NEW: ${{ inputs.diff_new }}
           REPOSITORY: ${{ github.repository }}
-          SKIP_TESTS: ${{ inputs.skip_tests }}
         run: |
           # The body is written with placeholders inside a quoted heredoc, then
           # filled in by python. A quoted heredoc does not expand $VAR, and an
@@ -288,13 +283,3 @@ jobs:
             --body-file /tmp/release-pr-body.md \
             --base main \
             --head "release/v${VERSION}"
-
-          # "Build and test mixs" skips release pull requests because this
-          # workflow has already built and tested the branch. With skip_tests it
-          # has not, so label the pull request and let that job run instead.
-          if [ "${SKIP_TESTS}" = "true" ]; then
-            gh label create tests-skipped \
-              --description "Release pull request created without running tests" \
-              --color D93F0B 2>/dev/null || true
-            gh pr edit "release/v${VERSION}" --add-label tests-skipped
-          fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,17 +14,6 @@ permissions:
 
 jobs:
   test:
-    # Skip release pull requests, which "Create Release PR" has already built and
-    # tested with `make install clean all test`. Re-running the slowest job in the
-    # repository on identical content proves nothing. See #1332.
-    #
-    # Unless that workflow was dispatched with skip_tests, in which case it built
-    # without testing and labels the pull request `tests-skipped`. Skipping here
-    # too would publish a release nothing had tested.
-    if: >-
-      !startsWith(github.head_ref, 'release/')
-      || contains(github.event.pull_request.labels.*.name, 'tests-skipped')
-
     runs-on: ubuntu-latest
     strategy:
       # 3.13 is the version MIxS uses and recommends everywhere. 3.10 is only
@@ -48,4 +37,15 @@ jobs:
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
 
       - name: Run release SOP
-        run: make install clean all test
+        # On a release branch the artifacts were just built by "Create Release
+        # PR", and they are committed, so `test` finds them up to date. Rebuilding
+        # them is the duplicate work in #1332. The tests themselves always run,
+        # including when that workflow was dispatched with skip_tests.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" == release/* ]]; then
+            make install test
+          else
+            make install clean all test
+          fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,11 @@ permissions:
 
 jobs:
   test:
+    # Skip release pull requests. "Create Release PR" builds the release branch
+    # with `make install clean all test` before opening the pull request, so it
+    # only exists if that build passed. Re-running the slowest job in the repo on
+    # identical content proves nothing. See #1332.
+    if: "!startsWith(github.head_ref, 'release/')"
 
     runs-on: ubuntu-latest
     strategy:
@@ -38,4 +43,4 @@ jobs:
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
 
       - name: Run release SOP
-        run: make install clean all all-contrib test
+        run: make install clean all test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,11 +14,16 @@ permissions:
 
 jobs:
   test:
-    # Skip release pull requests. "Create Release PR" builds the release branch
-    # with `make install clean all test` before opening the pull request, so it
-    # only exists if that build passed. Re-running the slowest job in the repo on
-    # identical content proves nothing. See #1332.
-    if: "!startsWith(github.head_ref, 'release/')"
+    # Skip release pull requests, which "Create Release PR" has already built and
+    # tested with `make install clean all test`. Re-running the slowest job in the
+    # repository on identical content proves nothing. See #1332.
+    #
+    # Unless that workflow was dispatched with skip_tests, in which case it built
+    # without testing and labels the pull request `tests-skipped`. Skipping here
+    # too would publish a release nothing had tested.
+    if: >-
+      !startsWith(github.head_ref, 'release/')
+      || contains(github.event.pull_request.labels.*.name, 'tests-skipped')
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,10 +41,17 @@ jobs:
         # PR", and they are committed, so `test` finds them up to date. Rebuilding
         # them is the duplicate work in #1332. The tests themselves always run,
         # including when that workflow was dispatched with skip_tests.
+        #
+        # Restricted to branches in this repository. A branch name is chosen by
+        # whoever opens the pull request, so without this a fork could call its
+        # branch release/anything and get the shorter build. Release branches are
+        # only ever created here, by that workflow.
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
         run: |
-          if [[ "$HEAD_REF" == release/* ]]; then
+          if [[ "$HEAD_REF" == release/* && "$HEAD_REPO" == "$THIS_REPO" ]]; then
             make install test
           else
             make install clean all test


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1332

"Create Release PR" builds the release branch with `make install clean all test` and commits the artifacts. "Build and test mixs" then ran `make install clean all test` again on that pull request, rebuilding artifacts that had just been built.

On a release branch this now runs `make install test` instead. The artifacts are committed, so `test` finds them up to date and the tests run without the rebuild. Everything else is unchanged.

**The tests always run**, which is the part an earlier version of this pull request got wrong. It skipped the job entirely on release branches, on the assumption that the release workflow had already tested the branch. That workflow has a `skip_tests` input, so it may not have, and skipping would then have published a release nothing had tested. Copilot caught it.

The fix for that was a `tests-skipped` label written by the release workflow and read here, which needed `issues: write` on the most privileged workflow in the repository. That is gone. Nothing now has to know whether the branch was tested, because it is tested here either way.

`github.head_ref` is read through `env` rather than interpolated into the script, since a branch name is attacker controlled. zizmor reports no findings on the file.

**On https://github.com/GenomicsStandardsConsortium/mixs/issues/1275**, the other half of the pair, I am not proposing a change, and the measurement is why: the duplicate lint costs almost nothing because `make all` runs anyway, while removing it would give up the named checks https://github.com/GenomicsStandardsConsortium/mixs/issues/1352 needs. Detail on that issue.