### PR TITLE
Resolve the diff baseline at run time, and give the summary skill the release history

### DIFF
--- a/.claude/skills/mixs-diff-summary/SKILL.md
+++ b/.claude/skills/mixs-diff-summary/SKILL.md
@@ -7,6 +7,38 @@ allowed-tools: Read, Write, Bash
 
 # Summarize a MIxS schema diff
 
+## Why a change was made, not just what changed
+
+The structured diff describes the schema and nothing else, so on its own it can
+say that 409 slots were added but never that 44 of them are the MInAS ancient DNA
+extension. The release history says that, and you can read it.
+
+Use it to attribute changes and to explain removals, and cite rather than assert.
+A pull request title is written by whoever opened it and is sometimes wrong or
+vague, so link the pull request and let a reader judge. Where a title does not
+support a claim, leave the claim out rather than inferring intent.
+
+The pull requests merged between the two refs being compared:
+
+```bash
+gh pr list --state merged --search "merged:<old date>..<new date>" \
+   --limit 200 --json number,title,author,labels,url
+```
+
+That is 50 for v6.3.1 to v7.0.0 and around 200 for a comparison reaching back to
+v6.0.0, which is small enough to read.
+
+Two other sources already at hand:
+
+- **`deprecated:` strings in the schema itself**, which carry the reason a term
+  was retired and often an issue link. They explain a removal better than a diff
+  can infer, and they are in the file you are already reading.
+- **Labels on the pull requests**, such as `2-NewTerm` and `3-CIG`, which show
+  whether a change went through term review.
+
+Attribution will sometimes be wrong. Prefer "added by" with a link over "in order
+to", and do not describe motivation the history does not state.
+
 ## Working in this repository
 
 Run Python with `poetry run python`. This is a poetry project, and `uv run`

--- a/.claude/skills/mixs-diff-summary/SKILL.md
+++ b/.claude/skills/mixs-diff-summary/SKILL.md
@@ -26,7 +26,8 @@ gh pr list --state merged --search "merged:<old date>..<new date>" \
 ```
 
 That is 50 for v6.3.1 to v7.0.0 and around 200 for a comparison reaching back to
-v6.0.0, which is small enough to read.
+MIxS 6.0.0, whose tag is `mixs6.0.0` rather than `v6.0.0`. Either is small enough
+to read.
 
 Two other sources already at hand:
 

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -25,12 +25,16 @@ on:
         required: true
         type: string
       diff_old:
+        # Left empty on purpose. A hardcoded default has to be bumped after every
+        # release and was stale within a day of the last one, so it is resolved
+        # below instead. See #1326.
+        #
         # For a base earlier than v6.2.0, diff_old_path must be changed from its
         # default as well: that path does not exist in those releases, and
         # leaving it unchanged fails at the diff step rather than here.
-        description: 'Old version for diff comparison (tag or branch)'
-        required: true
-        default: 'v6.3.1'
+        description: 'Old version for diff comparison. Leave empty for the most recent full release.'
+        required: false
+        default: ''
         type: string
       diff_old_path:
         # Releases before v6.2.0 keep the schema under model/schema/, reached
@@ -152,13 +156,40 @@ jobs:
         if: ${{ inputs.skip_tests }}
         run: make install clean all
 
+      - name: Resolve the diff baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          DIFF_OLD_INPUT: ${{ inputs.diff_old }}
+        run: |
+          set -euo pipefail
+          if [ -n "$DIFF_OLD_INPUT" ]; then
+            echo "DIFF_OLD=$DIFF_OLD_INPUT" >> "$GITHUB_ENV"
+            echo "Using the baseline given: $DIFF_OLD_INPUT"
+            exit 0
+          fi
+
+          # The most recent full release, excluding pre-releases and anything
+          # before v6.2.0. Earlier tags keep the schema at model/schema/mixs.yaml,
+          # so they need diff_old_path changed as well and cannot be a default.
+          baseline=$(gh release list --limit 100 --exclude-pre-releases \
+                       --json tagName --jq '.[].tagName' \
+                     | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                     | sort -V | tail -1 || true)
+
+          if [ -z "$baseline" ]; then
+            echo "::error::Could not resolve a baseline release. Pass diff_old explicitly."
+            exit 1
+          fi
+          echo "DIFF_OLD=$baseline" >> "$GITHUB_ENV"
+          echo "Resolved the baseline to the most recent full release: $baseline"
+
       - name: Generate schema diff report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Pass the workflow inputs through the environment rather than
           # templating them into the script, so their values cannot be
           # interpreted as shell syntax or path segments.
-          DIFF_OLD: ${{ inputs.diff_old }}
           DIFF_NEW: ${{ inputs.diff_new }}
           DIFF_OLD_PATH: ${{ inputs.diff_old_path }}
           DIFF_NEW_PATH: ${{ inputs.diff_new_path }}
@@ -198,7 +229,6 @@ jobs:
       - name: Commit changes
         env:
           VERSION: ${{ inputs.version }}
-          DIFF_OLD: ${{ inputs.diff_old }}
           DIFF_NEW: ${{ inputs.diff_new }}
         run: |
           git add -A
@@ -219,7 +249,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
-          DIFF_OLD: ${{ inputs.diff_old }}
           DIFF_NEW: ${{ inputs.diff_new }}
           REPOSITORY: ${{ github.repository }}
         run: |

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -32,7 +32,7 @@ on:
         # For a base earlier than v6.2.0, diff_old_path must be changed from its
         # default as well: that path does not exist in those releases, and
         # leaving it unchanged fails at the diff step rather than here.
-        description: 'Old version for diff comparison. Leave empty for the most recent full release.'
+        description: 'Old version: a tag, or a branch whose name has no "/". Leave empty for the most recent full release.'
         required: false
         default: ''
         type: string
@@ -45,7 +45,7 @@ on:
         default: 'src/mixs/schema/mixs.yaml'
         type: string
       diff_new:
-        description: 'New version for diff comparison (tag or branch)'
+        description: 'New version: a tag, or a branch whose name has no "/"'
         required: true
         default: 'main'
         type: string
@@ -163,8 +163,16 @@ jobs:
           DIFF_OLD_INPUT: ${{ inputs.diff_old }}
         run: |
           set -euo pipefail
+          # This value reaches $GITHUB_ENV, so it is checked here rather than at
+          # the diff step: anything written there takes effect before that step
+          # runs, and a newline in it could set a second variable that the guard
+          # there would then see as clean.
           if [ -n "$DIFF_OLD_INPUT" ]; then
-            echo "DIFF_OLD=$DIFF_OLD_INPUT" >> "$GITHUB_ENV"
+            if ! [[ "$DIFF_OLD_INPUT" =~ ^[A-Za-z0-9._-]+$ ]]; then
+              echo "::error::diff_old '$DIFF_OLD_INPUT' must contain only letters, digits, '.', '_', or '-'."
+              exit 1
+            fi
+            printf 'DIFF_OLD=%s\n' "$DIFF_OLD_INPUT" >> "$GITHUB_ENV"
             echo "Using the baseline given: $DIFF_OLD_INPUT"
             exit 0
           fi
@@ -181,7 +189,7 @@ jobs:
             echo "::error::Could not resolve a baseline release. Pass diff_old explicitly."
             exit 1
           fi
-          echo "DIFF_OLD=$baseline" >> "$GITHUB_ENV"
+          printf 'DIFF_OLD=%s\n' "$baseline" >> "$GITHUB_ENV"
           echo "Resolved the baseline to the most recent full release: $baseline"
 
       - name: Generate schema diff report

--- a/src/docs/SCHEMA_DIFFING.md
+++ b/src/docs/SCHEMA_DIFFING.md
@@ -115,8 +115,8 @@ poetry run diff-releases \
 
 ```bash
 poetry run diff-releases \
-  --old "GenomicsStandardsConsortium/mixs@v6.2.0:src/mixs/schema/mixs.yaml" \
-  --new "GenomicsStandardsConsortium/mixs@v6.3.1:src/mixs/schema/mixs.yaml"
+  --old "GenomicsStandardsConsortium/mixs@v6.3.1:src/mixs/schema/mixs.yaml" \
+  --new "GenomicsStandardsConsortium/mixs@v7.0.0:src/mixs/schema/mixs.yaml"
 ```
 
 **A release from before v6.2.0.** The path differs on the old side, because the
@@ -139,7 +139,10 @@ separate one-time script with an Excel reader.
 
 The **release workflow** is more limited still: it hardcodes
 `src/mixs/schema/mixs.yaml` for both sides, so its oldest usable base is
-v6.2.0.
+v6.2.0. Leaving its `diff_old` input empty compares against the most recent
+full release, skipping pre-releases and anything before v6.2.0. Fill it in only
+to compare against something else, and set `diff_old_path` as well if that is a
+release older than v6.2.0.
 
 | tag | released | `src/mixs/schema/mixs.yaml` | usable in the release workflow |
 | --- | --- | --- | --- |
@@ -152,6 +155,7 @@ v6.2.0.
 | `v6.2.3` | 2026-01-21 | present | yes |
 | `v6.3.0` | 2026-02-06 | present | yes |
 | `v6.3.1` | 2026-07-14 | present | yes |
+| `v7.0.0` | 2026-07-29 | present | yes |
 
 Note the tag naming changes at v6.2.0: earlier releases are `mixs6.x` and `MIxS5`,
 not `v6.x`. There is no `v6.2.1`; the sequence skips from v6.2.0 to v6.2.2.

--- a/src/docs/releasing.md
+++ b/src/docs/releasing.md
@@ -64,6 +64,12 @@ a LinkML schema, but it needs the right path for each side, and releases before
 v6.2.0 keep the schema somewhere else. Check the table in SCHEMA_DIFFING.md
 before choosing a base older than v6.2.0.
 
+Leave the action's `diff_old` input empty and it compares against the most
+recent full release, so there is no default to keep up to date. Fill it in for a
+major release, where the useful baseline is the previous major rather than the
+last patch: v7.0.0 was compared against v6.0.0, not v6.3.1. A base older than
+v6.2.0 needs `diff_old_path` changed too.
+
 The generated release notes cover the span between two tags, which is not
 necessarily the span the schema comparisons cover. When they differ, say so in
 the release body, or a reader will assume the pull requests listed are what

--- a/src/docs/releasing.md
+++ b/src/docs/releasing.md
@@ -67,8 +67,9 @@ before choosing a base older than v6.2.0.
 Leave the action's `diff_old` input empty and it compares against the most
 recent full release, so there is no default to keep up to date. Fill it in for a
 major release, where the useful baseline is the previous major rather than the
-last patch: v7.0.0 was compared against v6.0.0, not v6.3.1. A base older than
-v6.2.0 needs `diff_old_path` changed too.
+last patch: v7.0.0 was compared against MIxS 6.0.0, not v6.3.1. That baseline is
+the tag `mixs6.0.0`, not `v6.0.0`, and being older than v6.2.0 it needs
+`diff_old_path` set to `model/schema/mixs.yaml` as well.
 
 The generated release notes cover the span between two tags, which is not
 necessarily the span the schema comparisons cover. When they differ, say so in


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1326 and https://github.com/GenomicsStandardsConsortium/mixs/issues/1327.

**1326.** The `diff_old` default was `v6.3.1`, which v7.0.0 made stale the next day. Issue 1326 offered two fixes: document a bump step, or resolve the baseline at run time. This takes the second, so there is no default to keep in sync. Leaving the input empty resolves to the most recent full release; pre-releases and the pre-v6.2.0 tag scheme are filtered out, since those also need `diff_old_path` changed. Filling the input in still works, and a major release should, because the useful baseline there is the previous major: v7.0.0 was compared against v6.0.0.

**1327.** The summary skill could only see the schema, so it could report 409 new slots with no way to know that 44 of them are the MInAS ancient DNA extension. It now also reads the pull requests merged between the two refs, the `deprecated:` strings that carry a retirement reason, and the labels showing whether a change went through term review. The skill is told to cite rather than assert and to drop a claim a title does not support, because titles are written by whoever opened the pull request and are sometimes wrong.

Docs updated for both, and SCHEMA_DIFFING.md gains its missing v7.0.0 row.