### PR TITLE
Stop rejecting the token GitHub Actions issues

### DIFF
--- a/src/scripts/diff_two_linkml_mixs_releases.py
+++ b/src/scripts/diff_two_linkml_mixs_releases.py
@@ -1817,16 +1817,16 @@ def validate_github_token(token: str) -> bool:
     Returns:
         True if token format is valid, False otherwise.
     """
-    # GitHub personal access tokens patterns
-    patterns = [
-        r'^ghp_[a-zA-Z0-9]{36}$',  # Personal access token (classic)
-        r'^gho_[a-zA-Z0-9]{36}$',  # OAuth token
-        r'^ghu_[a-zA-Z0-9]{36}$',  # User token
-        r'^ghs_[a-zA-Z0-9]{36}$',  # Server token
-        r'^github_pat_[a-zA-Z0-9_]{22,}$',  # Fine-grained personal access token (variable length)
-    ]
-
-    return any(re.match(pattern, token) for pattern in patterns)
+    # Deliberately not a format check against a list of known prefixes and exact
+    # lengths. A token is opaque, GitHub changes these formats, and the previous
+    # version required ghs_ plus exactly 36 characters, which the token GitHub
+    # Actions issues no longer matches. The result was that CI threw away a valid
+    # token, fell back to the unauthenticated API at 60 requests per hour shared
+    # across runner IP addresses, and the release diff failed on a rate limit.
+    #
+    # Only obvious junk is rejected here. If a token is wrong, the API says so,
+    # and that is a clearer error than being silently unauthenticated.
+    return bool(token) and not re.search(r"\s", token)
 
 
 def get_github_headers() -> Dict[str, str]:
@@ -1863,6 +1863,15 @@ def get_github_headers() -> Dict[str, str]:
         if VERBOSE_AUTH or not AUTH_MESSAGE_PRINTED:
             logger.warning("Using unauthenticated GitHub API (rate limited)")
             AUTH_MESSAGE_PRINTED = True
+
+    # Unauthenticated is 60 requests per hour shared across GitHub's runner IP
+    # addresses, so in CI it is not a degraded mode, it is a run that fails when
+    # someone else has used the budget. Say so where it will be read.
+    if not headers and os.getenv("GITHUB_ACTIONS") == "true":
+        logger.error(
+            "No usable GITHUB_TOKEN in GitHub Actions. The GitHub API calls below "
+            "will be unauthenticated and are likely to fail on a rate limit."
+        )
     return headers
 
 

--- a/src/scripts/diff_two_linkml_mixs_releases.py
+++ b/src/scripts/diff_two_linkml_mixs_releases.py
@@ -1809,13 +1809,13 @@ def diff_top_keys(schema1_view: SchemaView, schema2_view: SchemaView) -> Tuple[S
 
 
 def validate_github_token(token: str) -> bool:
-    """Validate GitHub token format.
-    
+    """Reject a token that is obviously unusable, without judging its format.
+
     Args:
-        token: GitHub token to validate.
-        
+        token: GitHub token to check.
+
     Returns:
-        True if token format is valid, False otherwise.
+        True unless the token is empty or contains whitespace.
     """
     # Deliberately not a format check against a list of known prefixes and exact
     # lengths. A token is opaque, GitHub changes these formats, and the previous
@@ -1848,30 +1848,26 @@ def get_github_headers() -> Dict[str, str]:
             token = os.getenv('GITHUB_TOKEN')
 
     headers = {}
-    if token:
-        if validate_github_token(token):
-            headers['Authorization'] = f'token {token}'
-            if VERBOSE_AUTH or not AUTH_MESSAGE_PRINTED:
-                logger.info("Using authenticated GitHub API")
-                AUTH_MESSAGE_PRINTED = True
-        else:
-            if VERBOSE_AUTH or not AUTH_MESSAGE_PRINTED:
-                logger.warning("Invalid GitHub token format detected, using unauthenticated API")
-                logger.warning("Using unauthenticated GitHub API (rate limited)")
-                AUTH_MESSAGE_PRINTED = True
-    else:
-        if VERBOSE_AUTH or not AUTH_MESSAGE_PRINTED:
-            logger.warning("Using unauthenticated GitHub API (rate limited)")
-            AUTH_MESSAGE_PRINTED = True
+    if token and validate_github_token(token):
+        headers['Authorization'] = f'token {token}'
 
-    # Unauthenticated is 60 requests per hour shared across GitHub's runner IP
-    # addresses, so in CI it is not a degraded mode, it is a run that fails when
-    # someone else has used the budget. Say so where it will be read.
-    if not headers and os.getenv("GITHUB_ACTIONS") == "true":
-        logger.error(
-            "No usable GITHUB_TOKEN in GitHub Actions. The GitHub API calls below "
-            "will be unauthenticated and are likely to fail on a rate limit."
-        )
+    # This function is called from several places, so the message is emitted once
+    # per run unless VERBOSE_AUTH is set.
+    if VERBOSE_AUTH or not AUTH_MESSAGE_PRINTED:
+        if headers:
+            logger.info("Using authenticated GitHub API")
+        elif os.getenv("GITHUB_ACTIONS") == "true":
+            # Unauthenticated means 60 requests per hour shared across GitHub's
+            # runner IP addresses. In CI that is not a degraded mode, it is a run
+            # that fails as soon as someone else has used the budget.
+            logger.error(
+                "No usable GITHUB_TOKEN in GitHub Actions. GitHub API calls will "
+                "be unauthenticated and are likely to fail on a rate limit."
+            )
+        else:
+            logger.warning("Using unauthenticated GitHub API (rate limited)")
+        AUTH_MESSAGE_PRINTED = True
+
     return headers
 
 

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -1,0 +1,115 @@
+"""Authentication for the GitHub API calls the release comparison makes.
+
+The comparison fetches tags and trees from the GitHub API. Unauthenticated, that
+is 60 requests per hour shared across GitHub's runner IP addresses, which is not
+enough to finish, so a release that falls back to it fails on a rate limit.
+
+That is not hypothetical. The v7.0.1 release run failed this way on 2026-07-31
+because the token check demanded ``ghs_`` followed by exactly 36 characters and
+the token GitHub Actions issues no longer matches, so a valid token was discarded
+and the fallback was silent. The v7.0.0 run had the same fallback and survived
+only because the shared budget was not yet used up.
+
+These tests exist so that cannot regress unnoticed.
+"""
+import importlib.util
+import logging
+import os
+import unittest
+from unittest.mock import patch
+
+ROOT = os.path.join(os.path.dirname(__file__), '..')
+SCRIPT = os.path.join(ROOT, "src", "scripts", "diff_two_linkml_mixs_releases.py")
+
+
+def load_module():
+    """A fresh copy, so the once-per-run message flag starts unset."""
+    spec = importlib.util.spec_from_file_location("diff_releases_auth", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # The module falls back to reading local/.env, which would make these tests
+    # depend on whether the person running them happens to have a token there.
+    module.load_dotenv = lambda *args, **kwargs: None
+    return module
+
+
+class TestTokenIsNotFormatChecked(unittest.TestCase):
+    """A token is opaque. Only obviously unusable values are rejected."""
+
+    def setUp(self):
+        self.module = load_module()
+
+    def test_tokens_github_issues_are_accepted(self):
+        for token, description in [
+            ("ghs_" + "a" * 36, "the Actions token as it used to be"),
+            ("ghs_" + "a" * 40, "a longer Actions token, which the old check rejected"),
+            ("ghp_" + "b" * 36, "a classic personal access token"),
+            ("github_pat_" + "c" * 60, "a fine-grained personal access token"),
+            ("some_future_prefix_" + "d" * 20, "a format GitHub has not invented yet"),
+        ]:
+            with self.subTest(description):
+                self.assertTrue(
+                    self.module.validate_github_token(token),
+                    f"{description} must be accepted. Rejecting a usable token sends "
+                    f"the comparison to the unauthenticated API, where it fails on a "
+                    f"rate limit.",
+                )
+
+    def test_obviously_unusable_values_are_rejected(self):
+        for token, description in [
+            ("", "empty"),
+            ("   ", "whitespace only"),
+            ("ghs_abc def", "containing a space"),
+            ("ghs_abc\ndef", "containing a newline"),
+        ]:
+            with self.subTest(description):
+                self.assertFalse(self.module.validate_github_token(token), description)
+
+
+class TestOneMessagePerRun(unittest.TestCase):
+    """get_github_headers is called from several places; it must not repeat itself."""
+
+    def collect(self, env):
+        """Return (headers, log lines) after calling get_github_headers four times."""
+        module = load_module()
+        records = []
+
+        class Capture(logging.Handler):
+            def emit(self, record):
+                records.append((record.levelname, record.getMessage()))
+
+        module.logger.handlers = [Capture()]
+        module.logger.setLevel(logging.DEBUG)
+        module.logger.propagate = False
+
+        with patch.dict(os.environ, env, clear=True):
+            for _ in range(4):
+                headers = module.get_github_headers()
+        return headers, records
+
+    def test_authenticated(self):
+        headers, records = self.collect({"GITHUB_TOKEN": "ghs_" + "a" * 40})
+        self.assertIn("Authorization", headers, "a usable token must be sent")
+        self.assertEqual(len(records), 1, f"expected one message, got {records}")
+        self.assertEqual(records[0][0], "INFO")
+
+    def test_unauthenticated_in_github_actions_is_an_error(self):
+        headers, records = self.collect({"GITHUB_ACTIONS": "true"})
+        self.assertEqual(headers, {})
+        self.assertEqual(len(records), 1, f"expected one message, got {records}")
+        self.assertEqual(
+            records[0][0],
+            "ERROR",
+            "In Actions an unauthenticated run is not degraded, it fails as soon as "
+            "the shared rate limit is used up, so it must not be reported as a warning.",
+        )
+
+    def test_unauthenticated_locally_is_a_warning(self):
+        headers, records = self.collect({})
+        self.assertEqual(headers, {})
+        self.assertEqual(len(records), 1, f"expected one message, got {records}")
+        self.assertEqual(records[0][0], "WARNING")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The v7.0.1 release run failed on a GitHub API rate limit:

```
WARNING - Invalid GitHub token format detected, using unauthenticated API
WARNING - Using unauthenticated GitHub API (rate limited)
ERROR   - Network error while fetching tag MIxS5: 403 Client Error: rate limit exceeded
```

The workflow passed `GITHUB_TOKEN` correctly and the script read it, then discarded it. `validate_github_token` required `^ghs_[a-zA-Z0-9]{36}$`, exactly 36 characters, and the token GitHub Actions issues no longer matches that. So the script fell back to the unauthenticated API, which allows 60 requests per hour shared across GitHub's runner IP addresses, and ran out while enumerating tags.

**This is not new.** The v7.0.0 release run on 2026-07-29 logged the same two warnings. It succeeded only because the shared budget had not been used up at that moment, so whether a release diff works has been luck.

The check no longer pattern-matches known prefixes and lengths. A token is opaque, GitHub changes these formats, and a wrong token produces a clear 401 from the API, which is more useful than being silently unauthenticated. Empty values and anything containing whitespace are still rejected.

Being unauthenticated inside GitHub Actions is now logged at error level rather than warning, since there it is not a degraded mode but a run that fails as soon as someone else has used the shared budget.

Verified that the old-style and longer Actions tokens, classic and fine-grained personal access tokens are all accepted, and that empty values and whitespace are rejected. 24 tests pass.

Nothing was pushed by the failed release run; it stopped before the commit step, so there is no `release/v7.0.1` branch to clean up. The release can be re-run once this merges.