### PR TITLE
Remove the doubled regex anchors, and test that they cannot come back

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -15540,7 +15540,7 @@ slots:
     slot_uri: MIXS:0001370
     multivalued: true
     range: string
-    pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
+    pattern: "^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
@@ -15790,7 +15790,7 @@ slots:
     slot_uri: MIXS:0001384
     multivalued: true
     range: string
-    pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
+    pattern: "^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
@@ -15833,7 +15833,7 @@ slots:
     slot_uri: MIXS:0001387
     multivalued: true
     range: string
-    pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
+    pattern: "^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true
@@ -15945,7 +15945,7 @@ slots:
     slot_uri: MIXS:0001393
     multivalued: true
     range: string
-    pattern: "^^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$$"
+    pattern: "^PMID:\\d+$|^doi:10.\\d{2,9}/.*$|^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
     structured_pattern:
       syntax: ^{PMID}|{DOI}|{URL}$
       interpolated: true

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -309,3 +309,41 @@ class TestTitles(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPatterns(unittest.TestCase):
+    """Every ``pattern`` must compile, and must not repeat an anchor.
+
+    A doubled anchor is not a syntax error: ``^^`` is two zero-width assertions at
+    the same position, so Python and ECMAScript accept it and behave as if there
+    were one. Nothing in the build looks at pattern values, so it reached four
+    slots and stayed there until CodeQL reported 80 findings against the generated
+    Python.
+    """
+
+    def setUp(self):
+        self.patterns = {name: slot.pattern
+                         for name, slot in reporting_terms().items()
+                         if slot.pattern}
+
+    def test_every_pattern_compiles(self):
+        for name, pattern in self.patterns.items():
+            with self.subTest(slot=name):
+                try:
+                    re.compile(pattern)
+                except re.error as error:
+                    self.fail(f"{name} has a pattern that does not compile: {error}")
+
+    def test_no_repeated_anchors(self):
+        for name, pattern in self.patterns.items():
+            with self.subTest(slot=name):
+                self.assertFalse(
+                    pattern.startswith("^^"),
+                    f"{name} starts with a doubled caret. The second asserts the same "
+                    f"position as the first, so it does nothing, and CodeQL reports it "
+                    f"as an unmatchable caret.",
+                )
+                self.assertFalse(
+                    pattern.endswith("$$"),
+                    f"{name} ends with a doubled dollar, which does nothing.",
+                )

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -307,8 +307,6 @@ class TestTitles(unittest.TestCase):
             f"{len(missing)} classes have no title: {missing}")
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class TestPatterns(unittest.TestCase):
@@ -321,10 +319,11 @@ class TestPatterns(unittest.TestCase):
     Python.
     """
 
-    def setUp(self):
-        self.patterns = {name: slot.pattern
-                         for name, slot in reporting_terms().items()
-                         if slot.pattern}
+    @classmethod
+    def setUpClass(cls):
+        cls.patterns = {name: slot.pattern
+                        for name, slot in reporting_terms().items()
+                        if slot.pattern}
 
     def test_every_pattern_compiles(self):
         for name, pattern in self.patterns.items():
@@ -347,3 +346,6 @@ class TestPatterns(unittest.TestCase):
                     pattern.endswith("$$"),
                     f"{name} ends with a doubled dollar, which does nothing.",
                 )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Four slots carry a pattern that starts `^^` and ends `$$`: `prev_pubs`, `samp_decont_pretreat`, `sop_experimental`, `sop_lib_preparation`. Those four account for **80 of the 81 Reliability findings** on the Security and quality page, because the pattern is repeated 40 times in the generated Python and CodeQL reports the caret and the dollar separately.

**This is behaviour-preserving.** A doubled anchor is two zero-width assertions at the same position, so Python and ECMAScript already treat `^^` as `^`. Each of the four slots was checked against six inputs, three that should match and three that should not:

```
PMID:12345             before=True   after=True
doi:10.1038/nbt.1823   before=True   after=True
https://example.org/a  before=True   after=True
not a reference        before=False  after=False
(empty string)         before=False  after=False
PMID:abc               before=False  after=False
```

**The findings are in generated code, but the cause is not.** The doubled anchors are in `src/mixs/schema/mixs.yaml`, which is hand-edited; LinkML copies them faithfully into every output.

**Why it survived.** Nothing in the build looks at pattern values. `linkml-lint` has eleven rules and none of them examines a `pattern`. Two tests in `tests/test_schema_constraints.py` now check that every pattern compiles and that no anchor is repeated. Confirmed the second one fails if a doubled caret is put back.

**Out of scope, but worth knowing.** These anchors do nothing useful in the OWL either way. The patterns become `xsd:pattern` facets, and XML Schema regex treats `^` and `$` as ordinary characters rather than anchors. Verified with `xmllint`:

```
pattern=^PMID:[0-9]+$   value=PMID:123     matches=False
pattern=^PMID:[0-9]+$   value=^PMID:123$   matches=True
pattern=PMID:[0-9]+     value=PMID:123     matches=True
```

All 7 patterned slots are anchored, and the published OWL carries 78 `xsd:pattern` facets. That is a separate question about whether anyone validates against the OWL, and it is not changed here.

**Sequencing:** this is a schema change, so it should merge before the 7.0.1 release run, and then that release carries both this and the ancient DNA fix.

31 tests pass.