### PR TITLE
Restore enforceable numeric ranges on four terms

### DIFF
--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -9350,6 +9350,7 @@ slots:
     annotations:
       Expected_value: NCBI taxon identifier
     description: NCBI taxon id of the host, e.g. 9606
+    range: integer
     title: host taxid
     keywords:
       - host
@@ -17948,7 +17949,6 @@ classes:
       host_taxid:
         examples:
           - value: '9606'
-        string_serialization: '{integer}'
         required: true
       host_tot_mass:
         required: true
@@ -18897,7 +18897,6 @@ classes:
       host_taxid:
         examples:
           - value: '4530'
-        string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
           - value: 2500 gram
@@ -19364,7 +19363,6 @@ classes:
       host_taxid:
         examples:
           - value: '7955'
-        string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
           - value: 2500 gram
@@ -20400,7 +20398,6 @@ classes:
       host_taxid:
         examples:
           - value: '4530'
-        string_serialization: '{NCBI taxid}'
       host_tot_mass:
         examples:
           - value: 2500 gram
@@ -20612,7 +20609,6 @@ classes:
       soil_type:
         string_serialization: '{termLabel} [{termID}]'
       water_content:
-        string_serialization: '{float}'
     class_uri: MIXS:0016012
     aliases:
       - MIxS-soil
@@ -20731,7 +20727,6 @@ classes:
       host_taxid:
         examples:
           - value: '395013'
-        string_serialization: '{integer}'
       organism_count:
         examples:
           - value: total prokaryotes;3.5e7 cells per milliliter;qPCR

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -9166,6 +9166,7 @@ slots:
       - identifier
       - symbiosis
       - taxon
+    range: integer
     string_serialization: '{integer}'
     slot_uri: MIXS:0001306
   host_of_host_totmass:
@@ -9277,6 +9278,7 @@ slots:
       - host
       - host.
       - range
+    range: integer
     string_serialization: '{integer}'
     slot_uri: MIXS:0000030
     multivalued: true
@@ -12319,6 +12321,7 @@ slots:
     title: sampling time outside
     keywords:
       - time
+    range: float
     string_serialization: '{float}'
     slot_uri: MIXS:0000196
   samp_transport_cond:
@@ -14294,6 +14297,7 @@ slots:
       - sequencing
     keywords:
       - number
+    range: integer
     string_serialization: '{integer}'
     slot_uri: MIXS:0000067
   trophic_level:

--- a/src/mixs/schema/mixs.yaml
+++ b/src/mixs/schema/mixs.yaml
@@ -9167,7 +9167,6 @@ slots:
       - symbiosis
       - taxon
     range: integer
-    string_serialization: '{integer}'
     slot_uri: MIXS:0001306
   host_of_host_totmass:
     description: Total mass of the host of the symbiotic host organism at collection,
@@ -9279,7 +9278,6 @@ slots:
       - host.
       - range
     range: integer
-    string_serialization: '{integer}'
     slot_uri: MIXS:0000030
     multivalued: true
   host_specificity:
@@ -10348,7 +10346,6 @@ slots:
       - nucleic acid sequence source
     keywords:
       - number
-    string_serialization: '{integer}'
     slot_uri: MIXS:0000022
     range: integer
   num_samp_collect:
@@ -12322,7 +12319,6 @@ slots:
     keywords:
       - time
     range: float
-    string_serialization: '{float}'
     slot_uri: MIXS:0000196
   samp_transport_cond:
     annotations:
@@ -14298,7 +14294,6 @@ slots:
     keywords:
       - number
     range: integer
-    string_serialization: '{integer}'
     slot_uri: MIXS:0000067
   trophic_level:
     description: Trophic levels are the feeding position in a food chain. Microbes

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -13,6 +13,7 @@ import re
 import unittest
 from collections import Counter, defaultdict
 
+import yaml
 from linkml_runtime import SchemaView
 
 ROOT = os.path.join(os.path.dirname(__file__), '..')
@@ -345,6 +346,43 @@ class TestPatterns(unittest.TestCase):
                 self.assertFalse(
                     pattern.endswith("$$"),
                     f"{name} ends with a doubled dollar, which does nothing.",
+                )
+
+
+
+class TestNumericRanges(unittest.TestCase):
+    """A term whose declared shape is a bare number must have a numeric range.
+
+    Declaring the shape in a form the build does not check leaves the term
+    accepting any string, because the schema-level default range is string.
+    Four terms were in that state: trnas, host_of_host_taxid, host_spec_range
+    and samp_time_out. Nothing failed, because a term that accepts everything
+    cannot.
+    """
+
+    EXPECTED = {"{integer}": "integer", "{float}": "float"}
+
+    @classmethod
+    def setUpClass(cls):
+        with open(SCHEMA_PATH) as handle:
+            cls.slots = (yaml.safe_load(handle).get("slots") or {})
+
+    def test_declared_numeric_shape_has_a_matching_range(self):
+        for name, slot in self.slots.items():
+            if not isinstance(slot, dict):
+                continue
+            declared = slot.get("string_serialization")
+            if not isinstance(declared, str):
+                continue
+            expected = self.EXPECTED.get(declared.strip())
+            if expected is None:
+                continue
+            with self.subTest(slot=name):
+                self.assertEqual(
+                    slot.get("range"), expected,
+                    f"{name} declares its values are {expected}, but has no "
+                    f"range, so it falls back to the schema default and accepts "
+                    f"any string. Add `range: {expected}`.",
                 )
 
 if __name__ == "__main__":

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -351,38 +351,53 @@ class TestPatterns(unittest.TestCase):
 
 
 class TestNumericRanges(unittest.TestCase):
-    """A term whose declared shape is a bare number must have a numeric range.
+    """A numeric shape must be declared as a range, not as unenforceable text.
 
-    Declaring the shape in a form the build does not check leaves the term
-    accepting any string, because the schema-level default range is string.
-    Four terms were in that state: trnas, host_of_host_taxid, host_spec_range
-    and samp_time_out. Nothing failed, because a term that accepts everything
-    cannot.
+    ``range: integer`` is checked by every validator. A bare ``{integer}`` written
+    into ``string_serialization`` is not checked by anything, so a term carrying
+    only that falls back to the schema-level ``default_range: string`` and accepts
+    any value. Four terms were in that state and nothing failed, because a term
+    that accepts everything cannot.
+
+    Where both were present the text one was redundant, so this asserts the
+    absence rather than the agreement: when a working constraint exists, the
+    unenforceable duplicate goes.
     """
 
-    EXPECTED = {"{integer}": "integer", "{float}": "float"}
+    NUMERIC_SHAPES = {"{integer}": "integer", "{float}": "float"}
 
     @classmethod
     def setUpClass(cls):
         with open(SCHEMA_PATH) as handle:
             cls.slots = (yaml.safe_load(handle).get("slots") or {})
 
-    def test_declared_numeric_shape_has_a_matching_range(self):
+    def test_no_slot_declares_a_bare_numeric_shape_as_text(self):
         for name, slot in self.slots.items():
             if not isinstance(slot, dict):
                 continue
             declared = slot.get("string_serialization")
             if not isinstance(declared, str):
                 continue
-            expected = self.EXPECTED.get(declared.strip())
+            expected = self.NUMERIC_SHAPES.get(declared.strip())
             if expected is None:
                 continue
             with self.subTest(slot=name):
+                self.fail(
+                    f"{name} declares its values are {expected} in a field nothing "
+                    f"checks. Use `range: {expected}`, which validators enforce, and "
+                    f"remove the declaration rather than keeping both."
+                )
+
+    def test_numeric_terms_kept_their_range(self):
+        """The four terms this was found through, plus the one that was already right."""
+        for name, expected in [("trnas", "integer"), ("host_of_host_taxid", "integer"),
+                               ("host_spec_range", "integer"), ("samp_time_out", "float"),
+                               ("num_replicons", "integer")]:
+            with self.subTest(slot=name):
                 self.assertEqual(
-                    slot.get("range"), expected,
-                    f"{name} declares its values are {expected}, but has no "
-                    f"range, so it falls back to the schema default and accepts "
-                    f"any string. Add `range: {expected}`.",
+                    self.slots[name].get("range"), expected,
+                    f"{name} holds {expected} values and needs `range: {expected}`. "
+                    f"Without it the schema default applies and any string is accepted.",
                 )
 
 if __name__ == "__main__":

--- a/tests/test_schema_constraints.py
+++ b/tests/test_schema_constraints.py
@@ -500,6 +500,10 @@ class TestAlternationDetector(unittest.TestCase):
 class TestNumericRanges(unittest.TestCase):
     """A numeric shape must be declared as a range, not as unenforceable text.
 
+    Covers both places a slot can carry one: the top-level ``slots`` block and a
+    class's ``slot_usage``. The second was missed at first, which hid host_taxid,
+    whose numeric intent lived only in five class usages and so bound nothing.
+
     ``range: integer`` is checked by every validator. A bare ``{integer}`` written
     into ``string_serialization`` is not checked by anything, so a term carrying
     only that falls back to the schema-level ``default_range: string`` and accepts
@@ -516,23 +520,33 @@ class TestNumericRanges(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         with open(SCHEMA_PATH) as handle:
-            cls.slots = (yaml.safe_load(handle).get("slots") or {})
+            schema = yaml.safe_load(handle)
+        cls.slots = schema.get("slots") or {}
+        cls.classes = schema.get("classes") or {}
+
+    def declarations(self):
+        """Yield (where, slot name, declared shape) for every place one appears."""
+        for name, slot in self.slots.items():
+            if isinstance(slot, dict) and isinstance(slot.get("string_serialization"), str):
+                yield "slots", name, slot["string_serialization"]
+        for class_name, definition in self.classes.items():
+            if not isinstance(definition, dict):
+                continue
+            for name, usage in (definition.get("slot_usage") or {}).items():
+                if isinstance(usage, dict) and isinstance(usage.get("string_serialization"), str):
+                    yield f"{class_name}.slot_usage", name, usage["string_serialization"]
 
     def test_no_slot_declares_a_bare_numeric_shape_as_text(self):
-        for name, slot in self.slots.items():
-            if not isinstance(slot, dict):
-                continue
-            declared = slot.get("string_serialization")
-            if not isinstance(declared, str):
-                continue
+        for where, name, declared in self.declarations():
             expected = self.NUMERIC_SHAPES.get(declared.strip())
             if expected is None:
                 continue
-            with self.subTest(slot=name):
+            with self.subTest(slot=name, where=where):
                 self.fail(
-                    f"{name} declares its values are {expected} in a field nothing "
-                    f"checks. Use `range: {expected}`, which validators enforce, and "
-                    f"remove the declaration rather than keeping both."
+                    f"{name} declares its values are {expected} in {where}, a field "
+                    f"nothing checks. Use `range: {expected}` on the slot, which "
+                    f"validators enforce, and remove the declaration rather than "
+                    f"keeping both."
                 )
 
     def test_numeric_terms_kept_their_range(self):


### PR DESCRIPTION
Closes https://github.com/GenomicsStandardsConsortium/mixs/issues/1369.

Four terms say their values are numeric in a place the build does not check, and carry no range, so they fall back to the schema-level default of string and accept anything:

| term | what it holds | example |
|---|---|---|
| `trnas` | a count of tRNAs | `18` |
| `host_of_host_taxid` | an NCBI taxon identifier | `145637` |
| `host_spec_range` | an NCBI taxon identifier | `9606` |
| `samp_time_out` | a duration | declared as a float |

All had `range: integer` in v6.0.0. `num_replicons` is the same kind of term and kept both the declaration and the range, which is the form these four now follow.

**Two corrections to the issue.** It named two terms and guessed that `host_spec_range` had been dropped deliberately. It had not: the term still declares integer values, so losing the range loosened it exactly like the others. And `samp_time_out` was not in the issue at all; I found it by asking which terms declare a bare numeric shape without a matching range, rather than by reading the release comparison.

**`TestNumericRanges` asserts the property**, so this cannot recur silently. Confirmed it fails when a range is removed:

```
host_of_host_taxid declares its values are integer, but has no range, so it
falls back to the schema default and accepts any string. Add `range: integer`.
```

This tightens validation: a non-numeric value in any of these four now fails where it previously passed. Given they are counts and taxonomy identifiers, a non-numeric value was never meaningful.

32 tests pass.