### PR TITLE
Let zizmor fail the check it is required to pass

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,10 +1,13 @@
 name: Workflow security audit (zizmor)
 
 # Audits this repo's GitHub Actions workflows with zizmor (https://docs.zizmor.sh).
-# Non-blocking: findings are reported to GitHub code scanning (the Security tab),
-# not by failing CI. zizmor is pinned to a specific version so a tool upgrade
-# cannot turn this red on unchanged workflows; bump it deliberately.
-# Modeled on microbiomedata/nmdc-schema.
+# A finding fails the check, which is required to merge into main. zizmor is
+# pinned to a specific version so a tool upgrade cannot turn this red on
+# unchanged workflows; bump it deliberately and fix what it reports.
+#
+# Uploading to code scanning stays non-blocking: the findings have already failed
+# the job by then, and an outage in the upload should not fail a build on top of
+# that.
 
 on:
   push:
@@ -31,8 +34,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # Fails the job on a finding. The version is pinned just below, so a tool
+      # upgrade cannot turn this red on unchanged workflows; bump it deliberately
+      # and fix what it reports.
       - name: Run zizmor
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pipx run zizmor==1.25.2 --format sarif .github/workflows/ > zizmor.sarif


### PR DESCRIPTION
`zizmor` is in the required-checks list for `main`, and could not fail. Both of its working steps carried `continue-on-error: true`, so the job reported success whatever the audit found. Twenty of twenty runs have been green.

That was reasonable while it was a reporting workflow feeding the Security tab. It stopped being reasonable when the check became required, because a required check that always passes blocks nothing while reading as protection.

The run step now fails the job. Two things make that safe to do now rather than later:

- it reports **no findings** against the current workflows
- the version is pinned to `zizmor==1.25.2`, so a tool upgrade cannot turn it red on unchanged files. Bumping it stays a deliberate act

Uploading to code scanning stays `continue-on-error`. By that point a finding has already failed the job, and an outage in the upload should not fail a build on top of that.

Part of https://github.com/GenomicsStandardsConsortium/mixs/issues/1242.

**Not changed, and worth knowing why.** Two checks that run on pull requests are still not required, and requiring them would deadlock rather than protect:

- `LinkML Linting` is path-filtered to `src/mixs/schema/mixs.yaml`, so it never reports on a pull request that does not touch the schema. A required check that never reports leaves that pull request permanently unmergeable.
- `Preview documentation build` is skipped on pull requests from forks, with the same effect for external contributors.

Both could become required by making them always run and exit early when they have nothing to do. That is a larger change and is not attempted here.